### PR TITLE
Fix for issue 117

### DIFF
--- a/benchmark/less-benchmark.js
+++ b/benchmark/less-benchmark.js
@@ -10,7 +10,7 @@ var file = path.join(__dirname, 'benchmark.less');
 if (process.argv[2]) { file = path.join(process.cwd(), process.argv[2]) }
 
 fs.stat(file, function (e, stats) {
-    fs.open(file, process.O_RDONLY, stats.mode, function (e, fd) {
+    fs.open(file, "r", stats.mode, function (e, fd) {
         fs.read(fd, stats.size, 0, "utf8", function (e, data) {
             var tree, css, start, end, total;
 

--- a/bin/lessc
+++ b/bin/lessc
@@ -67,7 +67,7 @@ fs.stat(input, function (e, stats) {
         sys.puts("lessc: " + e.message);
         process.exit(1);
     }
-    fs.open(input, process.O_RDONLY, stats.mode, function (e, fd) {
+    fs.open(input, "r", stats.mode, function (e, fd) {
         fs.read(fd, stats.size, 0, "utf8", function (e, data) {
             new(less.Parser)({
                 paths: [path.dirname(input)],

--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -102,7 +102,7 @@ less.Parser.importer = function (file, paths, callback) {
         fs.stat(pathname, function (e, stats) {
             if (e) sys.error(e);
 
-            fs.open(pathname, process.O_RDONLY, stats.mode, function (e, fd) {
+            fs.open(pathname, "r", stats.mode, function (e, fd) {
                 if (e) sys.error(e);
 
                 fs.read(fd, stats.size, 0, "utf8", function (e, data) {

--- a/test/less-test.js
+++ b/test/less-test.js
@@ -63,7 +63,7 @@ function toCSS(path, callback) {
 function read(path, callback) {
     fs.stat(path, function (e, stats) {
         if (e) return callback(e);
-        fs.open(path, process.O_RDONLY, stats.mode, function (e, fd) {
+        fs.open(path, "r", stats.mode, function (e, fd) {
             if (e) return callback(e);
             fs.read(fd, stats.size, 0, "utf8", function (e, data) {
                 if (e) return callback(e);


### PR DESCRIPTION
Hi Alexis,

After running into some issues with less.js, I realized they were caused by some semi-recent node.js changes. Specifically, the process.\* constants seem to have been removed, and they were replaced with string flags. See http://nodejs.org/changelog.html , changes from 2010.02.17, Version 0.1.29 and http://nodejs.org/api.html#fs-open-135 .

I've done the 'dumb' thing and just replaced the constants. Depending on what version of node.js you support, you may want to be smarter than this...

Cheers,
Gijs
