### PR TITLE
Close @import file handles after reading

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -107,6 +107,7 @@ less.Parser.importer = function (file, paths, callback) {
 
                 fs.read(fd, stats.size, 0, "utf8", function (e, data) {
                     if (e) sys.error(e);
+                    fs.close(fd);
 
                     new(less.Parser)({
                         paths: [path.dirname(pathname)],


### PR DESCRIPTION
Calls to `less.render` on a stylesheet with `@import` statements result in unclosed file handles. Test case:

```
% cat  test.js
fs = require('fs');
less = require('./lib/less');
fs.writeFileSync('test.less', '/* */', 'utf8');
function next() {
  less.render('@import "/test";', function(err, css) {
    if (err) throw err;
    next();
  });
}
next();

% node test.js
Error: EMFILE, Too many open files 'test.less'

fs:177
  binding.read(fd, buffer, offset, length, position, callback || noop);
          ^
TypeError: Bad argument
    at Object.read (fs:177:11)
    at /Users/sam/Dropbox/Projects/less.js/lib/less/index.js:108:20
    at node.js:769:9
```
