### PR TITLE
Fix for issues #78 and 105 (allowing CSS escapes in selectors)

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -645,7 +645,7 @@ less.Parser = function Parser(env) {
 
                     if (s !== '.' && s !== '#') { return }
 
-                    while (e = $(/^[#.][\w-]+/)) {
+                    while (e = $(/^[#.](?:[\w-]|\\(?:[a-fA-F0-9]{1,6} ?|[^a-fA-F0-9]))+/)) {
                         elements.push(new(tree.Element)(c, e));
                         c = $('>');
                     }
@@ -681,7 +681,7 @@ less.Parser = function Parser(env) {
                     if ((input.charAt(i) !== '.' && input.charAt(i) !== '#') ||
                         peek(/^[^{]*(;|})/)) return;
 
-                    if (match = $(/^([#.][\w-]+)\s*\(/)) {
+                    if (match = $(/^([#.](?:[\w-]|\\(?:[a-fA-F0-9]{1,6} ?|[^a-fA-F0-9]))+)\s*\(/)) {
                         name = match[1];
 
                         while (param = $(this.entities.variable) || $(this.entities.literal)
@@ -762,7 +762,7 @@ less.Parser = function Parser(env) {
                 var e, t;
 
                 c = $(this.combinator);
-                e = $(/^[.#:]?[\w-]+/) || $('*') || $(this.attribute) || $(/^\([^)@]+\)/);
+                e = $(/^[.#:]?(?:[\w-]|\\(?:[a-fA-F0-9]{1,6} ?|[^a-fA-F0-9]))+/) || $('*') || $(this.attribute) || $(/^\([^)@]+\)/);
 
                 if (e) { return new(tree.Element)(c, e) }
             },

--- a/test/css/css-escapes.css
+++ b/test/css/css-escapes.css
@@ -1,0 +1,20 @@
+.escape\|random\|char {
+  color: red;
+}
+.mixin\!tUp {
+  font-weight: bold;
+}
+.\34 04 {
+  background: red;
+}
+.\34 04 strong {
+  color: fuchsia;
+  font-weight: bold;
+}
+.trailingTest\+ {
+  color: red;
+}
+/* This hideous test of hideousness checks for the selector "blockquote" with various permutations of hex escapes */
+\62\6c\6f \63 \6B \0071 \000075o\74 e {
+  color: silver;
+}

--- a/test/less/css-escapes.less
+++ b/test/less/css-escapes.less
@@ -1,0 +1,28 @@
+@ugly: fuchsia;
+
+.escape\|random\|char {
+	color: red;
+}
+
+.mixin\!tUp {
+	font-weight: bold;
+}
+
+// class="404"
+.\34 04 {
+	background: red;
+	
+	strong {
+		color: @ugly;
+		.mixin\!tUp;
+	}
+}
+
+.trailingTest\+ {
+	color: red;
+}
+
+/* This hideous test of hideousness checks for the selector "blockquote" with various permutations of hex escapes */
+\62\6c\6f \63 \6B \0071 \000075o\74 e {
+	color: silver;
+}


### PR DESCRIPTION
Basically just a more complex regex that permits CSS escape characters and hex codes within selector names, along with test files to verify the feature.
