### PR TITLE
Fix for including .less files via absolute path with IE7

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -121,7 +121,11 @@ function loadStyleSheet(sheet, callback, reload, remaining) {
 
     // Stylesheets in IE don't always return the full path
     if (! /^(https?|file):/.test(href)) {
-        href = url.slice(0, url.lastIndexOf('/') + 1) + href;
+        if (href.charAt(0) == "/") {
+            href = window.location.protocol + "//" + window.location.host + href;   
+        } else {
+            href = url.slice(0, url.lastIndexOf('/') + 1) + href;
+        }
     }
 
     xhr(sheet.href, sheet.type, function (data, lastModified) {


### PR DESCRIPTION
The commit message hopefully explains the issue and the fix.
