### PR TITLE
gentler than process.exit(), path unshift cleanup

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -86,23 +86,15 @@ var less = {
 less.Parser.importer = function (file, paths, callback) {
     var pathname;
     
-    console.log("paths = ")
-    console.dir(paths)
-    
     for (var i = 0; i < paths.length; i++) {
         try {
             pathname = path.join(paths[i], file);
-            console.log("Attempted pathname is:")
-            console.dir(pathname)
             fs.statSync(pathname);
             break;
         } catch (e) {
             pathname = null;
         }
     }
-
-    console.log("Pathname is:")
-    console.dir(pathname)
     
     if (pathname) {
         fs.readFile(pathname, 'utf-8', function(e, data) {
@@ -113,14 +105,12 @@ less.Parser.importer = function (file, paths, callback) {
               filename: pathname
           }).parse(data, function (e, root) {
               if (e) less.writeError(e);
-              console.log("A normal root looks like:")
-              console.dir(root)
               callback(root);
           });
         });
     } else {
         sys.error("file '" + file + "' wasn't found.\n");
-        callback({});
+        callback(null);
     }
 }
 


### PR DESCRIPTION
Hey,

I was having trouble using @import 'anything.css' in nodeJS using the express framework and the connect compiler middleware. Connect.compile wasn't passing in the options.paths that less needs to stat imported .less files - but first, my webserver would crash because of the process.exit() when the file wasn't found.

Also, there was a path.unshift that was called at each render, which ended up giving you a path like ['.','.','.'] etc.
Thanks for the neat compiler!

Cheers,
Hunter
