### PR TITLE
url concatenation bug fix

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -121,7 +121,7 @@ function loadStyleSheet(sheet, callback, reload, remaining) {
 
     // Stylesheets in IE don't always return the full path
     if (! /^(https?|file):/.test(href)) {
-        href = url.slice(0, url.lastIndexOf('/') + 1) + href;
+        href = url.charAt(url.length-1) === '/' ? url.slice(0, url.length-1) + href : url + href;
     }
 
     xhr(sheet.href, sheet.type, function (data, lastModified) {


### PR DESCRIPTION
this fixes an issue where the trailing slash is not removed

i have added a check for  a trailing slash before trimming the end of the string

Hope this helps

cheers
