### PR TITLE
Google Chrome(Chromium) support for extensions

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -4,6 +4,7 @@
 
 var isFileProtocol = (location.protocol === 'file:'    ||
                       location.protocol === 'chrome:'  ||
+                      location.protocol === 'chrome-extension:'  ||
                       location.protocol === 'resource:');
 
 less.env = less.env || (location.hostname == '127.0.0.1' ||


### PR DESCRIPTION
Fix for Google Chrome(Chromium), so you can use less in extensions, apps. Adds protocol support but you have to use .json or .css as file extension for less file, otherwise you get "Uncaught Error: NETWORK_ERR: XMLHttpRequest Exception 101".

This should be noted somewhere in doc's perhaps?
