### PR TITLE
New round(n) function

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -130,6 +130,18 @@ tree.functions = {
         }
         str = str.replace(/%%/g, '%');
         return new(tree.Quoted)('"' + str + '"', str);
+    },
+    round: function (n) {
+        if (n instanceof tree.Dimension) {
+            return new(tree.Dimension)(Math.round(number(n)), n.unit);
+        } else if (typeof(n) === 'number') {
+            return Math.round(n);
+        } else {
+	    throw {
+                error: "RuntimeError",
+                message: "math functions take numbers as parameters"
+            };
+        }
     }
 };
 

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -20,6 +20,8 @@
   hue: 98;
   saturation: 12%;
   lightness: 95%;
+  rounded: 11;
+  roundedpx: 3px;
 }
 #alpha {
   alpha: rgba(153, 94, 51, 0.6);

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -24,6 +24,8 @@
   hue: hue(hsl(98, 12%, 95%));
   saturation: saturation(hsl(98, 12%, 95%));
   lightness: lightness(hsl(98, 12%, 95%));
+  rounded: round(@r/3);
+  roundedpx: round(10px / 3);
 }
 
 #alpha {


### PR DESCRIPTION
I've made Math.round() available as a function. The same could be done for some other Math functions, but this was the one I needed.

Use case: I was computing grid layout widths and noticed that depending on how I divided my grid into two, I would lose a pixel due to the browser always truncating the fractional widths.

Example:

```
rounded: round(32/3);
roundedpx: round(10px / 3);
```

turns into

```
rounded: 11;
roundedpx: 3px;
```

Alternatives considered:
1. backtick escapes
   
   ```
   .grid(@columns) {
     @mw: @columns;
     blah: `this.mw.toJS()`;
   }
   .grid1 { .grid(1); }
   .grid2 { .grid(2); }
   .grid12 { .grid(12); }
   ```
   
   results in
   
   ```
   .grid1 {
     blah: 12;
   }
   .grid2 {
     blah: 12;
   }
   .grid12 {
     blah: 12;
   }
   ```
   
   so as you can see I have trouble getting the basics to work (nothing in `this` seems to vary with the `@columns` parameter).
2. defining the function just for me
   This would be easy in the browser, but I'm using `lessc` installed with `npm` and I have no idea how to easily make a customized command.

Because I think having this function generally available is useful, I ended up implementing it as a built-in. I hope it won't be seen as code bloat.

Regards,

Bart.
