### PR TITLE
(bugfix) Add explicit 'var' for implicitly declared variables

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -74,7 +74,8 @@ for (var i = 0; i < links.length; i++) {
 
 
 less.refresh = function (reload) {
-    var startTime = endTime = new(Date);
+    var endTime, startTime;
+    startTime = endTime = new(Date);
 
     loadStyleSheets(function (root, sheet, env) {
         if (env.local) {

--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -127,7 +127,7 @@ less.Parser = function Parser(env) {
         // grammar is mostly white-space insensitive.
         //
         if (match) {
-            mem = i += length;
+            var mem = i += length;
             endIndex = i + chunks[j].length - length;
 
             while (i < endIndex) {
@@ -768,7 +768,7 @@ less.Parser = function Parser(env) {
             element: function () {
                 var e, t;
 
-                c = $(this.combinator);
+                var c = $(this.combinator);
                 e = $(/^(?:[.#]?|:*)(?:[\w-]|\\(?:[a-fA-F0-9]{1,6} ?|[^a-fA-F0-9]))+/) || $('*') || $(this.attribute) || $(/^\([^)@]+\)/);
 
                 if (e) { return new(tree.Element)(c, e) }
@@ -885,6 +885,7 @@ less.Parser = function Parser(env) {
                 if (c === '.' || c === '#' || c === '&') { return }
 
                 if (name = $(this.variable) || $(this.property)) {
+                    var match;
                     if ((name.charAt(0) != '@') && (match = /^([^@+\/'"*`(;{}-]*);/.exec(chunks[j]))) {
                         i += match[0].length - 1;
                         value = new(tree.Anonymous)(match[1]);


### PR DESCRIPTION
These implicitly declared variables cause havoc when trying to run less.js in a multi-threaded Rhino, but even outside of multi-threading they represent bugs.
