### PR TITLE
Better fix for issue #198, where %s and %d weren't replaced properly in %().

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -125,8 +125,10 @@ tree.functions = {
             str = quoted.value;
 
         for (var i = 0; i < args.length; i++) {
-            str = str.replace(/%s/,    args[i].value)
-                     .replace(/%[da]/, args[i].toCSS());
+            str = str.replace(/%[sda]/i, function(token) {
+                var value = token.match(/s/i) ? args[i].value : args[i].toCSS();
+                return token.match(/[A-Z]$/) ? encodeURIComponent(value) : value;
+            });
         }
         str = str.replace(/%%/g, '%');
         return new(tree.Quoted)('"' + str + '"', str);

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -16,6 +16,8 @@
   spin-n: #bf4055;
   format: "rgb(32, 128, 64)";
   format-string: "hello world";
+  format-multiple: "hello earth 2";
+  format-url-encode: "red is %23ff0000";
   eformat: rgb(32, 128, 64);
   hue: 98;
   saturation: 12%;

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -19,6 +19,8 @@
   spin-n: spin(hsl(30, 50%, 50%), -40);
   format: %("rgb(%d, %d, %d)", @r, 128, 64);
   format-string: %("hello %s", "world");
+  format-multiple: %("hello %s %d", "earth", 2);
+  format-url-encode: %('red is %A', #ff0000);
   eformat: e(%("rgb(%d, %d, %d)", @r, 128, 64));
 
   hue: hue(hsl(98, 12%, 95%));


### PR DESCRIPTION
Deals better with multiple %s, %a, %d in a %() function; before, the first %s and %d would BOTH be replaced with the same value, since the replaces were chained together. Also adds the ability to use %S, %A, %D for urlencoding a value (such as passing a hex color into a background-image's url).

Tests included.
