### PR TITLE
Issue 234.   preserve-3d property value rendered incorrectly

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -465,7 +465,7 @@ less.Parser = function Parser(env) {
                 //
                 keyword: function () {
                     var k;
-                    if (k = $(/^[A-Za-z-]+/)) { return new(tree.Keyword)(k) }
+                    if (k = $(/^[A-Za-z-][A-Za-z0-9-]*/)) { return new(tree.Keyword)(k) }
                 },
 
                 //


### PR DESCRIPTION
Fixing the issue with arbitary property value keywords that contain a number not being parsed properly (for example -webkit-transform-style: preserve-3d;)
