### PR TITLE
added support for `@import` linking to .less files over HTTP

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -1,6 +1,8 @@
 var path = require('path'),
     sys = require('sys'),
-    fs = require('fs');
+    fs = require('fs'),
+    url = require('url'),
+    http = require('http');
 
 require.paths.unshift(path.join(__dirname, '..'));
 
@@ -87,11 +89,10 @@ var less = {
 var isUrlRe = /^(?:https?:)?\/\//i;
 
 less.Parser.importer = function (file, paths, callback) {
-    var isUrl = isUrlRe.test( file );
+    var isUrl = isUrlRe.test( file ),
+        pathname,
+        i;
     if (isUrl || isUrlRe.test(paths[0])) {
-
-        var url = require('url'),
-            http = require('http'),
 
             urlStr = isUrl ? file : url.resolve(paths[0], file),
             urlObj = url.parse(urlStr),
@@ -126,11 +127,9 @@ less.Parser.importer = function (file, paths, callback) {
 
     } else {
 
-        var pathname;
-
         paths.unshift('.');
 
-        for (var i = 0; i < paths.length; i++) {
+        for (i = 0; i < paths.length; i++) {
             try {
                 pathname = path.join(paths[i], file);
                 fs.statSync(pathname);


### PR DESCRIPTION
This allows a team of developers to host a generic .less mixin-library on a central web server.

Adding HTTPS support would of course be a trivial addition (on my task-list).
