### PR TITLE
Fix issue (#160) where STYLE elements would not be updated properly in IE < 9

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -102,7 +102,11 @@ function loadStyles() {
         if (styles[i].type.match(typePattern)) {
             new(less.Parser)().parse(styles[i].innerHTML || '', function (e, tree) {
                 styles[i].type      = 'text/css';
-                styles[i].innerHTML = tree.toCSS();
+                if (styles[i].styleSheet) {
+                    styles[i].styleSheet.cssText = tree.toCSS();
+                } else {
+                    styles[i].innerHTML = tree.toCSS();
+                }
             });
         }
     }


### PR DESCRIPTION
Looks like IE doesn't allow updating of a STYLE tag's innerHTML before version 9. Updating the tag's stylesheet property instead, if it exists, falling back to innerHTML if it does not.
