### PR TITLE
add "unitless" function to strip units

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -147,6 +147,10 @@ tree.functions = {
                 message: "math functions take numbers as parameters"
             };
         }
+    },
+    unitless: function (n) {
+        n.unit = '';
+        return n;
     }
 };
 


### PR DESCRIPTION
It's very annoying not to be able to strip units sometimes. If I've done some calculations like so:

@var 10px
@foo (@var - 5px) \* 20

But then I want to do this:

div {
    -moz-transform: scale(25 / @foo, 25 / @foo)
}

That doesn't work because the scale values need to be unitless. The above code would transform the element to be 25px wide and tall, regardless of the elements true size. This is very useful for effects that scale elements under certain circumstances.

I'm sure there are other use cases of this, too. I'm not sure if I implemented it correctly, but it seems to work.
