### PR TITLE
Modified to allow precompiling of *.less.css files as well as *.less file

### DIFF
--- a/lib/less/tree/import.js
+++ b/lib/less/tree/import.js
@@ -23,7 +23,7 @@ tree.Import = function (path, imports) {
         this.path = path.value.value || path.value;
     }
 
-    this.css = /css$/.test(this.path);
+    this.css = /css$/.test(this.path)&&/less\.css$/.test(this.path);//precompile less.css and .less files!
 
     // Only pre-compile .less files
     if (! this.css) {


### PR DESCRIPTION
My web server isn't set up to serve .less files. To be compatable with situations where the files must be served with .css extention, allow parsing of *.less.css files as well as *.less files
