### PR TITLE
Fix issue with import paths in parser.js

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1098,7 +1098,11 @@ if (typeof(window) !== 'undefined') {
     // Used by `@import` directives
     //
     less.Parser.importer = function (path, paths, callback, env) {
-        if (path.charAt(0) !== '/' && paths.length > 0) {
+        if (
+                path.charAt(0) !== '/' && 
+                path.indexOf('://') == -1 &&
+                paths.length > 0
+            ) {
             path = paths[0] + path;
         }
         // We pass `true` as 3rd argument, to force the reload of the import.


### PR DESCRIPTION
When using less.js in the browser, I was seeing 404s like: http://localhost/dijit/themes/claro/http://localhost/dijit/themes/claro/Common.less

I tracked this down to the less.Parser.importer function, which looks for root-relative paths, but not fully-qualified/absolute urls. In chrome at least (surely not unique), when you ask for the href of an @import rule it is already absolute. So maybe this fix needs to be further upstream in the parser? 
