### PR TITLE
test for relative urls in import (node less does not adjust relative paths)

### DIFF
--- a/test/css/import.css
+++ b/test/css/import.css
@@ -1,6 +1,7 @@
 @import "import-test-d.css";
 #import {
   color: red;
+  background-image: url("import/relative.png");
 }
 .mixin {
   height: 10px;

--- a/test/less/import/import-test-c.less
+++ b/test/less/import/import-test-c.less
@@ -4,4 +4,5 @@
 
 #import {
   color: @c;
+  background-image: url("relative.png");
 }


### PR DESCRIPTION
when using lessc on the command line, urls are not adjusted from imported style sheets.  this adds a test case to show the failure.  looking at previous issues it seems that this keeps popping its head up from time to time but there doesn't seem to be a test for it.
