### PR TITLE
Updated LESSC

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -7,22 +7,27 @@ var path = require('path'),
 require.paths.unshift(path.join(__dirname, '..', 'lib'));
 
 var less = require('less');
-var args = process.argv.slice(1);
+var args = process.argv.slice(2);
 var options = {
     compress: false,
     optimization: 1,
     silent: false,
     paths: []
 };
+var ioArgs = [];
 
-args = args.filter(function (arg) {
-    var match;
-
-    if (match = arg.match(/^--?([a-z][0-9a-z-]*)(?:=([^\s]+))?$/i)) { arg = match[1] }
-    else { return arg }
-
-    switch (arg) {
-        case 'v':
+var arg;
+while (args.length) 
+{
+	arg = args.shift();
+	
+	var match;
+	if (match = arg.match(/^--?([a-z][0-9a-z-]*)(?:=([^\s]+))?$/i)) { arg = match[1] }
+	else { ioArgs.push(arg) }
+	
+	switch (arg) 
+	{
+		case 'v':
         case 'version':
             sys.puts("lessc " + less.version.join('.') + " (LESS Compiler) [JavaScript]");
             process.exit(0);
@@ -41,30 +46,34 @@ args = args.filter(function (arg) {
         case 'compress':
             options.compress = true;
             break;
+		case 'I':
         case 'include-path':
-            options.paths = match[2].split(':')
-                .map(function(p) {
-                    if (p && p[0] == '/') {
-                        return path.join(path.dirname(input), p);
-                    } else if (p) {
-                        return path.join(process.cwd(), p);
-                    }
-                });
+            var rawPath = args.shift();
+			var cleanPath;
+			if (rawPath && rawPath[0] == '/') {
+				cleanPath = path.normalize(rawPath);
+				options.paths.push(cleanPath);
+			} else if (rawPath) {
+				cleanPath = path.join(process.cwd(), rawPath);
+				options.paths.push(cleanPath);
+			}
             break;
         case 'O0': options.optimization = 0; break;
         case 'O1': options.optimization = 1; break;
-        case 'O2': options.optimization = 2; break;
-    }
-});
+        case 'O2': options.optimization = 2; break;	
+	}
+}
 
-var input = args[1];
+
+var input = ioArgs[0];
 if (input && input[0] != '/') {
     input = path.join(process.cwd(), input);
 }
-var output = args[2];
+var output = ioArgs[1];
 if (output && output[0] != '/') {
     output = path.join(process.cwd(), output);
 }
+
 
 var css, fd, tree;
 


### PR DESCRIPTION
- Rewrote argument parser to support multiple -I or --include-path flags.
- "include paths" may now contain spaces
- The old "colon-separated" syntax is no longer supported.
