### PR TITLE
Read less-content from stdin

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -58,7 +58,7 @@ args = args.filter(function (arg) {
 });
 
 var input = args[1];
-if (input && input[0] != '/') {
+if (input && input[0] != '/' && input != '-') {
     input = path.join(process.cwd(), input);
 }
 var output = args[2];
@@ -73,7 +73,7 @@ if (! input) {
     process.exit(1);
 }
 
-fs.readFile(input, 'utf-8', function (e, data) {
+var parseLessFile = function (e, data) {
     if (e) {
         sys.puts("lessc: " + e.message);
         process.exit(1);
@@ -102,4 +102,20 @@ fs.readFile(input, 'utf-8', function (e, data) {
             }
         }
     });
-});
+};
+
+if (input != '-') {
+    fs.readFile(input, 'utf-8', parseLessFile);
+} else {
+    process.stdin.resume();
+    process.stdin.setEncoding('utf8');
+
+    var buffer = '';
+    process.stdin.on('data', function(data) {
+        buffer += data;
+    });
+
+    process.stdin.on('end', function() {
+        parseLessFile(false, buffer);
+    });
+}


### PR DESCRIPTION
Support for passing less-content through stdin using - as source target instead of a filename.
