### PR TITLE
Edited dist/less-1.1.4.js via GitHub

### DIFF
--- a/dist/less-1.1.4.js
+++ b/dist/less-1.1.4.js
@@ -2292,7 +2292,8 @@ tree.Selector = function (elements) {
     }
 };
 tree.Selector.prototype.match = function (other) {
-    if (this.elements[0].value === other.elements[0].value) {
+    if ((this.elements.length == other.elements.length)
+    		&& (this.elements[0].value === other.elements[0].value)) {
         return true;
     } else {
         return false;


### PR DESCRIPTION
You must compare elements length when comparing two elements.
Indeed, the selector ".class .subClass" doesn't match ".class".
If you only compare first elements, it does.
