### PR TITLE
Accept 2xx statuses even for file requests

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -233,7 +233,7 @@ function xhr(url, type, callback, errback) {
     xhr.send(null);
 
     if (isFileProtocol) {
-        if (xhr.status === 0) {
+        if (xhr.status === 0 || (xhr.status >= 200 && xhr.status < 300)) {
             callback(xhr.responseText);
         } else {
             errback(xhr.status, url);


### PR DESCRIPTION
XHR requests to the chrome-extension:// protocol seem to return a 200 status on request (not 0). Looking at the history of this project I'm guessing that this wasn't always the case. This commit simply treats 2xx statuses (in addition to 0) as success even for file requests.
