### PR TITLE
Fix expansion of URLs when loading via ajax

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -128,7 +128,7 @@ function loadStyleSheet(sheet, callback, reload, remaining) {
     var styles    = { css: css, timestamp: timestamp };
 
     // Stylesheets in IE don't always return the full path
-    if (! /^(https?|file):/.test(href)) {
+    if (! /^[a-z-]+:/.test(href)) {
         if (href.charAt(0) == "/") {
             href = window.location.protocol + "//" + window.location.host + href;
         } else {


### PR DESCRIPTION
URLs starting with chrome-extension:// were being treated as incomplete making @import statements fail. This should allow a URL with any scheme to be treated as complete.
