### PR TITLE
mixin exact match css's selector.

### DIFF
--- a/lib/less/tree/element.js
+++ b/lib/less/tree/element.js
@@ -10,7 +10,7 @@ tree.Element.prototype.toCSS = function (env) {
 };
 
 tree.Combinator = function (value) {
-    if (value === ' ') {
+    if (value && /^\s+$/.test(value)) { // match space string
         this.value = ' ';
     } else if (value === '& ') {
         this.value = '& ';

--- a/lib/less/tree/selector.js
+++ b/lib/less/tree/selector.js
@@ -7,25 +7,28 @@ tree.Selector = function (elements) {
     }
 };
 tree.Selector.prototype.match = function (other) {
-    var value = this.elements[0].value,
-        len   = this.elements.length,
+    var len   = this.elements.length,
         olen  = other.elements.length;
 
     if (len > olen) {
-        return value === other.elements[0].value;
+        for (var i = 0; i < olen; i++) {
+            if (this.elements[i].value !== other.elements[i].value) {
+                return false;
+            }
+        }
+        return true;
     }
 
-    for (var i = 0; i < olen; i ++) {
-        if (value === other.elements[i].value) {
-            for (var j = 1; j < len; j ++) {
-                if (this.elements[j].value !== other.elements[i + j].value) {
-                    return false;
-                }
-            }
-            return true;
+    if (len != olen) {
+        return false;
+    }
+
+    for (var i = 0; i < len; i++) {
+        if (this.elements[i].value !== other.elements[i].value) {
+            return false;
         }
     }
-    return false;
+    return true;
 };
 tree.Selector.prototype.toCSS = function (env) {
     if (this._css) { return this._css }

--- a/test/css/mixins.css
+++ b/test/css/mixins.css
@@ -59,6 +59,14 @@
 }
 .extended {
   border: 1px;
-  color: black;
   background: none;
+}
+.topbar {
+  color: red;
+}
+.topbar .fill {
+  background-color: #222;
+}
+body > header {
+  color: red;
 }

--- a/test/less/mixins.less
+++ b/test/less/mixins.less
@@ -47,15 +47,25 @@
 }
 
 .bo {
-    border: 1px;
+  border: 1px;
 }
 .ar.bo.ca {
-    color: black;
+  color: black;
 }
 .jo.ki {
-    background: none;
+  background: none;
 }
 .extended {
-    .bo;
-    .jo.ki;
+  .bo;
+  .jo.ki;
+}
+
+.topbar {
+  color: red;
+}
+.topbar .fill {
+  background-color: #222;
+}
+body > header {
+  .topbar;
 }


### PR DESCRIPTION
I use some less framework, such as twitter's bootstrap.

That frameworks provide some useful class. for example:

twitter's bootstrap provide .topbar class, use to layout site's topbar.

``` less
// bootstrap/patterns.less

.topbar {
  height: 40px;
  // ...
}

.topbar-inner,
.topbar .fill {
  background-color: #222;
  //...
}
```

```
// my_app.less

@import "bootstrap/patterns.less"

body > header {
  .topbar;
  > div {
    .topbar-inner;
  }
}
```

But the current mixin, will mixin ".topbar .fill" css to "body> header". this is clearly not what we want.

Other, I see the mixin's test file.

```
.bo {
  border: 1px;
}
.ar.bo.ca {
  color: black;
}
.extended {
  .bo;
}
```

The .extended will be mixin ".bo", ".ar.bo.ca". mixin ".bo" obviously, 
but mixin ".ar.bo.ca" is not right. the mixin should skip this.

Back to my example, I modify the code, return the result is:

```
body > header {
  height: 40px;
}
```

The original is:

```
body > header {
  height: 40px;
  background-color: #222;
}
```

but the best I hope return is:  

```
body > header {
  height: 40px;
}

body > header .fill {
  background-color: #222;
}
```

However, I did not do this modification, because this is a huge project, and now fully meet my needs.
