### PR TITLE
fix #31 and #406

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -823,21 +823,21 @@ less.Parser = function Parser(env) {
 
                 if (c === '>' || c === '+' || c === '~') {
                     i++;
-                    while (input.charAt(i) === ' ') { i++ }
+                    while (input.charAt(i).match(/\s/)) { i++ }
                     return new(tree.Combinator)(c);
                 } else if (c === '&') {
                     match = '&';
                     i++;
-                    if(input.charAt(i) === ' ') {
+                    if(input.charAt(i).match(/\s/)) {
                         match = '& ';
                     }
-                    while (input.charAt(i) === ' ') { i++ }
+                    while (input.charAt(i).match(/\s/)) { i++ }
                     return new(tree.Combinator)(match);
                 } else if (c === ':' && input.charAt(i + 1) === ':') {
                     i += 2;
-                    while (input.charAt(i) === ' ') { i++ }
+                    while (input.charAt(i).match(/\s/)) { i++ }
                     return new(tree.Combinator)('::');
-                } else if (input.charAt(i - 1) === ' ') {
+                } else if (input.charAt(i - 1).match(/\s/)) {
                     return new(tree.Combinator)(" ");
                 } else {
                     return new(tree.Combinator)(null);


### PR DESCRIPTION
this patch makes any whitespace char allowed inside the selectors : spaces, tabs, linebreaks... (\s)

http://www.w3.org/TR/CSS2/selector.html#descendant-selectors
