### PR TITLE
Change 'sys' includes to 'util' to remove annoying warning

### DIFF
--- a/benchmark/less-benchmark.js
+++ b/benchmark/less-benchmark.js
@@ -1,6 +1,6 @@
 var path = require('path'),
     fs = require('fs'),
-    sys = require('sys');
+    util = require( process.binding('natives').util ? 'util' : 'sys' );
 
 require.paths.unshift(__dirname, path.join(__dirname, '..'));
 
@@ -12,7 +12,7 @@ if (process.argv[2]) { file = path.join(process.cwd(), process.argv[2]) }
 fs.readFile(file, 'utf8', function (e, data) {
     var tree, css, start, end, total;
 
-    sys.puts("Bechmarking...\n", path.basename(file) + " (" +
+    util.puts("Bechmarking...\n", path.basename(file) + " (" +
              parseInt(data.length / 1024) + " KB)", "");
 
     start = new(Date);
@@ -22,7 +22,7 @@ fs.readFile(file, 'utf8', function (e, data) {
 
         total = end - start;
 
-        sys.puts("Parsing: " +
+        util.puts("Parsing: " +
                  total + " ms (" +
                  parseInt(1000 / total *
                  data.length / 1024) + " KB\/s)");
@@ -31,13 +31,13 @@ fs.readFile(file, 'utf8', function (e, data) {
         css = tree.toCSS();
         end = new(Date);
 
-        sys.puts("Generation: " + (end - start) + " ms (" +
+        util.puts("Generation: " + (end - start) + " ms (" +
                  parseInt(1000 / (end - start) *
                  data.length / 1024) + " KB\/s)");
 
         total += end - start;
 
-        sys.puts("Total: " + total + "ms (" +
+        util.puts("Total: " + total + "ms (" +
                  parseInt(1000 / total * data.length / 1024) + " KB/s)");
 
         if (err) {

--- a/bin/lessc
+++ b/bin/lessc
@@ -2,7 +2,7 @@
 
 var path = require('path'),
     fs = require('fs'),
-    sys = require('sys');
+    util = require( process.binding('natives').util ? 'util' : 'sys' );
 
 require.paths.unshift(path.join(__dirname, '..', 'lib'));
 
@@ -30,7 +30,7 @@ args = args.filter(function (arg) {
     switch (arg) {
         case 'v':
         case 'version':
-            sys.puts("lessc " + less.version.join('.') + " (LESS Compiler) [JavaScript]");
+            util.puts("lessc " + less.version.join('.') + " (LESS Compiler) [JavaScript]");
             process.exit(0);
         case 'verbose':
             options.verbose = true;
@@ -41,7 +41,7 @@ args = args.filter(function (arg) {
             break;
         case 'h':
         case 'help':
-            sys.puts("usage: lessc source [destination]");
+            util.puts("usage: lessc source [destination]");
             process.exit(0);
         case 'x':
         case 'compress':
@@ -78,13 +78,13 @@ if (output && output[0] != '/') {
 var css, fd, tree;
 
 if (! input) {
-    sys.puts("lessc: no input files");
+    util.puts("lessc: no input files");
     process.exit(1);
 }
 
 var parseLessFile = function (e, data) {
     if (e) {
-        sys.puts("lessc: " + e.message);
+        util.puts("lessc: " + e.message);
         process.exit(1);
     }
 
@@ -103,7 +103,7 @@ var parseLessFile = function (e, data) {
                     fd = fs.openSync(output, "w");
                     fs.writeSync(fd, css, 0, "utf8");
                 } else {
-                    sys.print(css);
+                    util.print(css);
                 }
             } catch (e) {
                 less.writeError(e, options);

--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -1,5 +1,5 @@
 var path = require('path'),
-    sys = require('sys'),
+    util = require( process.binding('natives').util ? 'util' : 'sys' ),
     fs = require('fs');
 
 require.paths.unshift(path.join(__dirname, '..'));
@@ -46,7 +46,7 @@ var less = {
         if (options.silent) { return }
 
         if (!ctx.index) {
-            return sys.error(ctx.stack || ctx.message);
+            return util.error(ctx.stack || ctx.message);
         }
 
         if (typeof(extract[0]) === 'string') {
@@ -65,13 +65,13 @@ var less = {
         message += stylize(ctx.message, 'red');
         ctx.filename && (message += stylize(' in ', 'red') + ctx.filename);
 
-        sys.error(message, error);
+        util.error(message, error);
 
         if (ctx.callLine) {
-            sys.error(stylize('from ', 'red')       + (ctx.filename || ''));
-            sys.error(stylize(ctx.callLine, 'grey') + ' ' + ctx.callExtract);
+            util.error(stylize('from ', 'red')       + (ctx.filename || ''));
+            util.error(stylize(ctx.callLine, 'grey') + ' ' + ctx.callExtract);
         }
-        if (ctx.stack) { sys.error(stylize(ctx.stack, 'red')) }
+        if (ctx.stack) { util.error(stylize(ctx.stack, 'red')) }
     }
 };
 
@@ -101,7 +101,7 @@ less.Parser.importer = function (file, paths, callback) {
 
     if (pathname) {
         fs.readFile(pathname, 'utf-8', function(e, data) {
-          if (e) sys.error(e);
+          if (e) util.error(e);
 
           new(less.Parser)({
               paths: [path.dirname(pathname)],
@@ -112,7 +112,7 @@ less.Parser.importer = function (file, paths, callback) {
           });
         });
     } else {
-        sys.error("file '" + file + "' wasn't found.\n");
+        util.error("file '" + file + "' wasn't found.\n");
         process.exit(1);
     }
 }

--- a/test/less-test.js
+++ b/test/less-test.js
@@ -1,6 +1,6 @@
 var path = require('path'),
     fs = require('fs'),
-    sys = require('sys');
+    util = require( process.binding('natives').util ? 'util' : 'sys' );
 
 require.paths.unshift(__dirname, path.join(__dirname, '..'));
 
@@ -16,7 +16,7 @@ less.tree.functions.color = function (str) {
     if (str.value === "evil red") { return new(less.tree.Color)("600") }
 }
 
-sys.puts("\n" + stylize("LESS", 'underline') + "\n");
+util.puts("\n" + stylize("LESS", 'underline') + "\n");
 
 fs.readdirSync('test/less').forEach(function (file) {
     if (! /\.less/.test(file)) { return }
@@ -25,14 +25,14 @@ fs.readdirSync('test/less').forEach(function (file) {
         var name = path.basename(file, '.less');
 
         fs.readFile(path.join('test/css', name) + '.css', 'utf-8', function (e, css) {
-            sys.print("- " + name + ": ")
-            if (less === css) { sys.print(stylize('OK', 'green')) }
+            util.print("- " + name + ": ")
+            if (less === css) { util.print(stylize('OK', 'green')) }
             else if (err) {
-                sys.print(stylize("ERROR: " + (err && err.message), 'red'));
+                util.print(stylize("ERROR: " + (err && err.message), 'red'));
             } else {
-                sys.print(stylize("FAIL", 'yellow'));
+                util.print(stylize("FAIL", 'yellow'));
             }
-            sys.puts("");
+            util.puts("");
         });
     });
 });


### PR DESCRIPTION
This commit changes all instances of `require('sys')` to use the Node.js 0.3+ compatible `util` module, with a fallback to `sys` for those still using Node.js 0.2.x. This change fixes the warning `The "sys" module is now called "util". It should have a similar interface.`
