### PR TITLE
Fix proposal for Issue #409 on browser

### DIFF
--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -5,7 +5,7 @@ tree.URL = function (val, paths) {
         this.attrs = val;
     } else {
         // Add the base path if the URL is relative and we are in the browser
-        if (!/^(?:https?:\/|file:\/|data:\/)?\//.test(val.value) && paths.length > 0 && typeof(window) !== 'undefined') {
+        if (!/^(?:https?:\/|file:\/|data:\/)?\/|^(@\{.*\})/.test(val.value) && paths.length > 0 && typeof(window) !== 'undefined') {
             val.value = paths[0] + (val.value.charAt(0) === '/' ? val.value.slice(1) : val.value);
         }
         this.value = val;


### PR DESCRIPTION
Do NOT include base path if in the browser and url starts with variable. Should fix issue #409 in browser.
