### PR TITLE
Add support for Titanium Desktop (app:// as a file protocol)

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -3,6 +3,7 @@
 //
 
 var isFileProtocol = (location.protocol === 'file:'    ||
+                      location.protocol === 'app:'     ||
                       location.protocol === 'chrome:'  ||
                       location.protocol === 'chrome-extension:'  ||
                       location.protocol === 'resource:');


### PR DESCRIPTION
Titanium Desktop currently doesn't work with Less because it uses the app:// protocol for local files; this simple fix makes it work correctliy.
