### PR TITLE
#361: Fix for quoted data URIs getting prepended with path

### DIFF
--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -5,7 +5,7 @@ tree.URL = function (val, paths) {
         this.attrs = val;
     } else {
         // Add the base path if the URL is relative and we are in the browser
-        if (!/^(?:https?:\/|file:\/|data:\/)?\//.test(val.value) && paths.length > 0 && typeof(window) !== 'undefined') {
+        if (!/^(?:https?:\/\/|file:\/\/|data:)?/.test(val.value) && paths.length > 0 && typeof(window) !== 'undefined') {
             val.value = paths[0] + (val.value.charAt(0) === '/' ? val.value.slice(1) : val.value);
         }
         this.value = val;

--- a/test/css/css.css
+++ b/test/css/css.css
@@ -80,3 +80,6 @@ p + h1 {
     kg9C9zwz3gVLMDA/A6P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC);
   background-image: url(data:image/x-png,f9difSSFIIGFIFJD1f982FSDKAA9==);
 }
+#svg-data-uri {
+  background: transparent url('data:image/svg+xml, <svg version="1.1"><g></g></svg>');
+}

--- a/test/less/css.less
+++ b/test/less/css.less
@@ -94,3 +94,7 @@ p + h1 {
     kg9C9zwz3gVLMDA/A6P9/AFGGFyjOXZtQAAAAAElFTkSuQmCC);
   background-image: url(data:image/x-png,f9difSSFIIGFIFJD1f982FSDKAA9==);
 }
+
+#svg-data-uri {
+  background: transparent url('data:image/svg+xml, <svg version="1.1"><g></g></svg>');
+}


### PR DESCRIPTION
In the browser environment, quoted data URIs are prepended with the import path. 

The issue superficially appeared to be fixed because the tests pass, but that was because the codepath with the bug is only run in the browser environment. 

This ticket fixes the problem by correctly pattern-matching for valid data URIs, which do not require a slash.
