### PR TITLE
Fix for bug I introduced with data URLs in browser

### DIFF
--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -5,7 +5,7 @@ tree.URL = function (val, paths) {
         this.attrs = val;
     } else {
         // Add the base path if the URL is relative and we are in the browser
-        if (!/^(?:https?:\/\/|file:\/\/|data:)/.test(val.value) && paths.length > 0 && typeof(window) !== 'undefined') {
+        if (!/^(?:https?:\/\/|file:\/\/|data:|\/)/.test(val.value) && paths.length > 0 && typeof(window) !== 'undefined') {
             val.value = paths[0] + (val.value.charAt(0) === '/' ? val.value.slice(1) : val.value);
         }
         this.value = val;


### PR DESCRIPTION
The current master is broken in the browser environment: it does not respect absolute urls. Even if not via this change, it needs to be fixed.

I discussed the problem and solution in a common to the previous pull request: https://github.com/cloudhead/less.js/pull/432#issuecomment-2507984
