### PR TITLE
Fixes #409. Need to test for absolute URLs after evaluating variables

### DIFF
--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -4,10 +4,6 @@ tree.URL = function (val, paths) {
     if (val.data) {
         this.attrs = val;
     } else {
-        // Add the base path if the URL is relative and we are in the browser
-        if (!/^(?:https?:\/\/|file:\/\/|data:)?/.test(val.value) && paths.length > 0 && typeof(window) !== 'undefined') {
-            val.value = paths[0] + (val.value.charAt(0) === '/' ? val.value.slice(1) : val.value);
-        }
         this.value = val;
         this.paths = paths;
     }
@@ -18,7 +14,17 @@ tree.URL.prototype = {
                                     : this.value.toCSS()) + ")";
     },
     eval: function (ctx) {
-        return this.attrs ? this : new(tree.URL)(this.value.eval(ctx), this.paths);
+        if(this.attrs) {
+            return this;
+        } else {
+            var val = this.value.eval(ctx);
+            // Add the base path if the URL is relative and we are in the browser
+            if (!/^(?:https?:\/\/|file:\/\/|data:)?/.test(val.value) && this.paths.length > 0 && typeof(window) !== 'undefined') {
+                val = paths[0] + val;
+            }
+
+            return new(tree.URL)(val, this.paths);
+        }
     }
 };
 


### PR DESCRIPTION
Fixes #409

This was a problem when specifying paths (in the browser) _and_ using something like `url("@{my_url}/test.png")`. It used to just convert it to something like: `url(/my_path/http://my/url/test.png)`.

Now it works!
