### PR TITLE
fix undefined reference

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -36,12 +36,12 @@ var less = {
         }
     },
     writeError: function (ctx, options) {
+        options = options || {};
+
         var message = "";
         var extract = ctx.extract;
         var error = [];
         var stylize = options.color ? less.stylize : function (str) { return str };
-
-        options = options || {};
 
         if (options.silent) { return }
 


### PR DESCRIPTION
At line 110 in the same file, `writeError` is called without a second argument which makes `options` undefined and `options.color` an error.

If moving the line before all `var`s is against your coding standards, an alternative is using `options && options.color` or doing the initialization of `stylize` later.
