### PR TITLE
require 'util' instead of 'sys' in lessc and less-benchmark.js

### DIFF
--- a/benchmark/less-benchmark.js
+++ b/benchmark/less-benchmark.js
@@ -1,6 +1,6 @@
 var path = require('path'),
     fs = require('fs'),
-    sys = require('sys');
+    sys = require('util');
 
 var less = require('../lib/less');
 var file = path.join(__dirname, 'benchmark.less');

--- a/bin/lessc
+++ b/bin/lessc
@@ -2,7 +2,7 @@
 
 var path = require('path'),
     fs = require('fs'),
-    sys = require('sys');
+    sys = require('util');
 
 var less = require('../lib/less');
 var args = process.argv.slice(1);


### PR DESCRIPTION
Just a small patch to fix the files that were missed in commit 85a681de2f11f291083b0ce4aaefa5b6085cd8da.
