### PR TITLE
rhino integration not only for the command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ VERSION = `cat package.json | grep version \
 														| grep -o '[0-9]\.[0-9]\.[0-9]\+'`
 DIST = dist/less-${VERSION}.js
 RHINO = dist/less-rhino-${VERSION}.js
+RHINO_EMBED = dist/less-rhino-embed-${VERSION}.js
 DIST_MIN = dist/less-${VERSION}.min.js
 
 less:
@@ -45,8 +46,22 @@ rhino:
 	      ${SRC}/functions.js\
 	      ${SRC}/tree/*.js\
 	      ${SRC}/tree.js\
+	      ${SRC}/rhino-common.js\
 	      ${SRC}/rhino.js > ${RHINO}
 	@@echo ${RHINO} built.
+
+rhino-embed:
+	@@mkdir -p dist
+	@@touch ${RHINO_EMBED}
+	@@cat build/require-rhino.js\
+	      build/ecma-5.js\
+	      ${SRC}/parser.js\
+	      ${SRC}/functions.js\
+	      ${SRC}/tree/*.js\
+	      ${SRC}/tree.js\
+	      ${SRC}/rhino-common.js\
+	      ${SRC}/rhino-embed.js > ${RHINO_EMBED}
+	@@echo ${RHINO_EMBED} built.
 
 min: less
 	@@echo minifying...

--- a/lib/less/rhino-common.js
+++ b/lib/less/rhino-common.js
@@ -1,0 +1,23 @@
+var name;
+
+function loadStyleSheet(sheet, callback, reload, remaining) {
+    var sheetName = name.slice(0, name.lastIndexOf('/') + 1) + sheet.href;
+    var input = readFile(sheetName);
+    var parser = new less.Parser();
+    parser.parse(input, function (e, root) {
+        if (e) {
+            print("Error: " + e);
+            quit(1);
+        }
+        callback(root, sheet, { local: false, lastModified: 0, remaining: remaining });
+    });
+
+    // callback({}, sheet, { local: true, remaining: remaining });
+}
+
+function writeFile(filename, content) {
+    var fstream = new java.io.FileWriter(filename);
+    var out = new java.io.BufferedWriter(fstream);
+    out.write(content);
+    out.close();
+}

--- a/lib/less/rhino-embed.js
+++ b/lib/less/rhino-embed.js
@@ -1,0 +1,17 @@
+// Define a function as entry for rhinos javascript compiler
+function compileLess(inputFile) {
+    name = inputFile; 
+    path = name.split("/");path.pop();path=path.join("/")
+    var input = readFile(name);
+    var result;
+    var parser = new less.Parser();
+    parser.parse(input, function (e, root) {
+        if (!e) {
+            result = root.toCSS();
+        }
+        else {
+            throw e;
+        } 
+    });
+    return result;
+}

--- a/lib/less/rhino.js
+++ b/lib/less/rhino.js
@@ -1,27 +1,3 @@
-var name;
-
-function loadStyleSheet(sheet, callback, reload, remaining) {
-    var sheetName = name.slice(0, name.lastIndexOf('/') + 1) + sheet.href;
-    var input = readFile(sheetName);
-    var parser = new less.Parser();
-    parser.parse(input, function (e, root) {
-        if (e) {
-            print("Error: " + e);
-            quit(1);
-        }
-        callback(root, sheet, { local: false, lastModified: 0, remaining: remaining });
-    });
-
-    // callback({}, sheet, { local: true, remaining: remaining });
-}
-
-function writeFile(filename, content) {
-    var fstream = new java.io.FileWriter(filename);
-    var out = new java.io.BufferedWriter(fstream);
-    out.write(content);
-    out.close();
-}
-
 // Command line integration via Rhino
 (function (args) {
     name = args[0];


### PR DESCRIPTION
implement a simple function that allows to use less from rhino other than the command line (e.g. compile it with rhinos compiler to a Java class and use it in your Java web application).

split the rhino file in two to avoid code duplication.

adjusted Makefile as well.

Comments welcome!

Cheers 
Uwe
