### PR TITLE
Fix for Issue #88 and Issue #349

### DIFF
--- a/lib/less/tree/javascript.js
+++ b/lib/less/tree/javascript.js
@@ -42,7 +42,7 @@ tree.JavaScript.prototype = {
             if (match = /^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/.exec(result)) {
                 return new(tree.Color)(match[1]);
             }
-            if (match = /^((-?\d*\.?\d+)\s*(px|%|em|pc|ex|in|deg|s|ms|pt|cm|mm|rad|grad|turn))$/.exec(result)) {
+            if (match = /^((-?\d*\.?\d+)\s*(px|%|em|pc|ex|in|deg|s|ms|pt|cm|mm|rad|grad|turn)?)$/.exec(result)) {
                 return new(tree.Dimension)(match[2], match[3]);
             }
             return new(tree.Quoted)('"' + result + '"', result, this.escaped, this.index);

--- a/test/css/javascript.css
+++ b/test/css/javascript.css
@@ -13,6 +13,7 @@
 .vars {
   width: 8;
   width: 8px;
+  width: 8;
 }
 .escape-interpol {
   width: hello world;

--- a/test/less/javascript.less
+++ b/test/less/javascript.less
@@ -16,6 +16,8 @@
     width: @var;
     @var2: ~`2 + 2 + 'px'`;
     width: @var2 * 2;
+    @var3: ~`"4"`;
+	width: @var3 * 2;
 }
 .escape-interpol {
     @world: "world";


### PR DESCRIPTION
This allows colors pulled in from JavaScript variables to be used with the color modification functions (fadeout, etc.), and turns valid numbers with units into their internal Less representations.
