### PR TITLE
fixed bug in less.js where relative `url()`s were being resvolved based ...

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -96,6 +96,7 @@ less.refreshStyles = loadStyles;
 
 less.refresh(less.env === 'development');
 
+
 function loadStyles() {
     var styles = document.getElementsByTagName('style');
     for (var i = 0; i < styles.length; i++) {
@@ -126,6 +127,7 @@ function loadStyleSheet(sheet, callback, reload, remaining) {
     var css       = cache && cache.getItem(href);
     var timestamp = cache && cache.getItem(href + ':timestamp');
     var styles    = { css: css, timestamp: timestamp };
+    var _originalPath = sheet._originalPath  ||  href.replace(/[\w\.-]+$/, '');
 
     // Stylesheets in IE don't always return the full path
     if (! /^(https?|file):/.test(href)) {
@@ -146,9 +148,11 @@ function loadStyleSheet(sheet, callback, reload, remaining) {
         } else {
             // Use remote copy (re-parse)
             try {
+                var paths = [href.replace(/[\w\.-]+$/, '')];
+                paths._originalPath = _originalPath;
                 new(less.Parser)({
                     optimization: less.optimization,
-                    paths: [href.replace(/[\w\.-]+$/, '')],
+                    paths: paths,
                     mime: sheet.type
                 }).parse(data, function (e, root) {
                     if (e) { return error(e, href) }

--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1110,7 +1110,7 @@ if (less.mode === 'browser' || less.mode === 'rhino') {
         // We pass `true` as 3rd argument, to force the reload of the import.
         // This is so we can get the syntax tree as opposed to just the CSS output,
         // as we need this to evaluate the current stylesheet.
-        loadStyleSheet({ href: path, title: path, type: env.mime }, callback, true);
+        loadStyleSheet({ href: path, title: path, type: env.mime, _originalPath: paths._originalPath }, callback, true);
     };
 }
 

--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -5,8 +5,8 @@ tree.URL = function (val, paths) {
         this.attrs = val;
     } else {
         // Add the base path if the URL is relative and we are in the browser
-        if (!/^(?:https?:\/\/|file:\/\/|data:)?/.test(val.value) && paths.length > 0 && typeof(window) !== 'undefined') {
-            val.value = paths[0] + (val.value.charAt(0) === '/' ? val.value.slice(1) : val.value);
+        if (!/^(?:\/|https?:\/\/|file:\/\/|data:)?/.test(val.value) && paths.length > 0 && typeof(window) !== 'undefined') {
+            val.value = (paths._originalPath || paths[0]) + val.value;
         }
         this.value = val;
         this.paths = paths;


### PR DESCRIPTION
...on the path of the containing .less file, instead of the original (topmost) .less file.

This brings the behavior of less.js in line with lessc.

Fixes #471 & #465 and probably a few others.
