### PR TITLE
Running lessc in node.js 0.6.2 causes an ReferenceError in less.js/lib/less/tree/url.js:8

### DIFF
--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -5,7 +5,7 @@ tree.URL = function (val, paths) {
         this.attrs = val;
     } else {
         // Add the base path if the URL is relative and we are in the browser
-        if (less.mode === 'browser' && !/^(?:https?:\/\/|file:\/\/|data:|\/)/.test(val.value) && paths.length > 0) {
+        if (typeof less !== 'undefined' && less.mode === 'browser' && !/^(?:https?:\/\/|file:\/\/|data:|\/)/.test(val.value) && paths.length > 0) {
             val.value = paths[0] + (val.value.charAt(0) === '/' ? val.value.slice(1) : val.value);
         }
         this.value = val;


### PR DESCRIPTION
Running lessc in node.js 0.6.2 causes an ReferenceError in less.js/lib/less/tree/url.js:8 ("ReferenceError: less is not defined")

sorry for my wrong pull request recently ;)
