### PR TITLE
Add contrast function

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -124,12 +124,20 @@ tree.functions = {
     greyscale: function (color) {
         return this.desaturate(color, new(tree.Dimension)(100));
     },
-    contrast: function (color) {
+    contrast: function (color, light, dark) {
         var hsl = color.toHSL();
-        if (hsl.l > 0.5) {
-            return this.rgba(0, 0, 0, 1.0);
-        } else {
-            return this.rgba(255, 255, 255, 1.0);
+        if (arguments.length == 1) {
+            if (hsl.l > 0.5) {
+                return this.rgba(0, 0, 0, 1.0);
+            } else {
+                return this.rgba(255, 255, 255, 1.0);
+            }
+        } else if (arguments.length == 3) {
+            if (hsl.l > 0.5) {
+                return dark;
+            } else {
+                return light;
+            }
         }
     },
     e: function (str) {

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -16,6 +16,8 @@
   spin-n: #bf4055;
   contrast-white: #000000;
   contrast-black: #ffffff;
+  contrast-light: #111111;
+  contrast-dark: #eeeeee;
   format: "rgb(32, 128, 64)";
   format-string: "hello world";
   format-multiple: "hello earth 2";

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -19,6 +19,8 @@
   spin-n: spin(hsl(30, 50%, 50%), -40);
   contrast-white: contrast(#fff);
   contrast-black: contrast(#000);
+  contrast-light: contrast(#fff, #eeeeee, #111111);
+  contrast-dark: contrast(#000, #eeeeee, #111111);
   format: %("rgb(%d, %d, %d)", @r, 128, 64);
   format-string: %("hello %s", "world");
   format-multiple: %("hello %s %d", "earth", 2);


### PR DESCRIPTION
I've added a contrast colour function. Given a colour, it returns black for colours > 50% lightness, white for < 50%. This ensures you don't end up with white on white or black on black. It's used like this:

.someblock {
    background-color: @background;
    color: contrast(@background);
}

There are probably more subtle ways of doing this, but it should always work, unlike say, inverting the lightness value.
