### PR TITLE
fix comments in operations (ex: *height: 2px * 4 /* ie hack */)

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1052,7 +1052,7 @@ less.Parser = function Parser(env) {
             multiplication: function () {
                 var m, a, op, operation;
                 if (m = $(this.operand)) {
-                    while ((op = ($('/') || $('*'))) && (a = $(this.operand))) {
+                    while (!peek(/^\/\*/) && (op = ($('/') || $('*'))) && (a = $(this.operand))) {
                         operation = new(tree.Operation)(op, [operation || m, a]);
                     }
                     return operation || m;

--- a/test/css/comments.css
+++ b/test/css/comments.css
@@ -8,9 +8,9 @@
     Comment
 
 */
-/*  
+/*
  * Comment Test
- * 
+ *
  * - cloudhead (http://cloudhead.net)
  *
  */
@@ -46,6 +46,8 @@
 */
 .selector, .lots, .comments {
   color: grey, /* blue */ orange;
+  -webkit-border-radius: 2px /* webkit only */;
+  -moz-border-radius: 8px /* moz only with operation */;
 }
 #last {
   color: blue;

--- a/test/less/comments.less
+++ b/test/less/comments.less
@@ -10,9 +10,9 @@
 
 */
 
-/*  
+/*
  * Comment Test
- * 
+ *
  * - cloudhead (http://cloudhead.net)
  *
  */
@@ -35,15 +35,15 @@
 /* @group Variables
 ------------------- */
 #comments /* boo */ {
-  /**/ // An empty comment 
+  /**/ // An empty comment
   color: red; /* A C-style comment */
   background-color: orange; // A little comment
   font-size: 12px;
-  
+
   /* lost comment */ content: @var;
-  
+
   border: 1px solid black;
-  
+
   // padding & margin //
   padding: 0; // }{ '"
   margin: 2em;
@@ -57,6 +57,8 @@
 
 .selector /* .with */, .lots, /* of */ .comments {
   color: grey, /* blue */ orange;
+  -webkit-border-radius: 2px /* webkit only */;
+  -moz-border-radius: 2px * 4 /* moz only with operation */;
 }
 
 #last { color: blue }


### PR DESCRIPTION
This patch allows you to specify comments for entities which are operations.

Prior to this patch - the following cases would throw an exception:

``` CSS
*height: 12px /* oh noes */; 
width: 10px * 4 + 3 /* oh noes also */;
```

With this patch, these cases are fine now.
