### PR TITLE
Adding support for absolute paths on Windows.

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -65,11 +65,11 @@ args = args.filter(function (arg) {
 });
 
 var input = args[1];
-if (input && input[0] != '/' && input != '-') {
+if (input && input[0] != '/' && input != '-' && input[1] != ':') {
     input = path.join(process.cwd(), input);
 }
 var output = args[2];
-if (output && output[0] != '/') {
+if (output && output[0] != '/' && input[1] != ':') {
     output = path.join(process.cwd(), output);
 }
 


### PR DESCRIPTION
While lessc is developed for *nix platforms, node has expanded to provide support to Windows environments, which means lessc can now be used without much hassle. The existing version does not support absolute paths, however, as the check for absolute vs relative relies on the first path character being '/' or not.

This isn't a huge deal in most cases, but for a developer such as myself using tools such as django_assets to compile assets on the fly during development, absolute path support is vital.
