### PR TITLE
Removed call to put header into minified build, because it's already there.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ rhino:
 
 min: less
 	@@echo minifying...
-	@@cat ${HEADER} | sed s/@VERSION/${VERSION}/ > ${DIST_MIN}
 	@@uglifyjs ${DIST} >> ${DIST_MIN}
 
 clean:


### PR DESCRIPTION
Maybe uglifyjs has changed its behavior regarding comments at the beginning of a file, but it seems like space is of the essence in a minified file, so you may as well not have an extra set of copywrite/license information. Simple enough to do yourself in the Makefile, if you don't want to do it through git.
