### PR TITLE
Fixed lessc require('sys') for nodejs 0.6.*

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -2,7 +2,7 @@
 
 var path = require('path'),
     fs = require('fs'),
-    sys = require('sys');
+    sys = require('util');
 
 var less = require('../lib/less');
 var args = process.argv.slice(1);


### PR DESCRIPTION
renamed 'sys' to 'util'
