### PR TITLE
Fix java.io.FileNotFoundException when @importing from LESS in subdirectory

### DIFF
--- a/lib/less/rhino.js
+++ b/lib/less/rhino.js
@@ -3,7 +3,9 @@ var name;
 function loadStyleSheet(sheet, callback, reload, remaining) {
     var sheetName = name.slice(0, name.lastIndexOf('/') + 1) + sheet.href;
     var input = readFile(sheetName);
-    var parser = new less.Parser();
+    var parser = new less.Parser({
+        paths: [sheet.href.replace(/[\w\.-]+$/, '')]
+    });
     parser.parse(input, function (e, root) {
         if (e) {
             print("Error: " + e);


### PR DESCRIPTION
Imagine the following structure:

```

less
├── lib
│   ├── color.less
├── main.less
├── foo
│   ├── bar.less
└── foo.less
```

Contents of `main.less`:

```
@import "foo.less";
```

Contents of `foo.less`:

```
@import "foo/bar.less"
```

Contents of `bar.less`:

```
@import "../lib/color.less";

...
```

Without this patch, l`ess-rhino-1.1.5.js` fails to process `bar.less`, complaining `File not found: path/to/less/../lib/color.less`.
