### PR TITLE
Improved Windows path support in lessc

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -2,7 +2,8 @@
 
 var path = require('path'),
     fs = require('fs'),
-    sys = require('util');
+    sys = require('util'),
+    os = require('os');
 
 var less = require('../lib/less');
 var args = process.argv.slice(1);
@@ -53,12 +54,10 @@ args = args.filter(function (arg) {
             options.color = false;
             break;
         case 'include-path':
-            options.paths = match[2].split(':')
+            options.paths = match[2].split(os.type().match(/Windows/) ? ';' : ':')
                 .map(function(p) {
-                    if (p && p[0] == '/') {
-                        return path.join(path.dirname(input), p);
-                    } else if (p) {
-                        return path.join(process.cwd(), p);
+                    if (p) {
+                      return path.resolve(process.cwd(), p);
                     }
                 });
             break;
@@ -69,12 +68,12 @@ args = args.filter(function (arg) {
 });
 
 var input = args[1];
-if (input && input[0] != '/' && input != '-' && input[1] != ':') {
-    input = path.join(process.cwd(), input);
+if (input && input != '-') {
+    input = path.resolve(process.cwd(), input);
 }
 var output = args[2];
-if (output && output[0] != '/' && input[1] != ':') {
-    output = path.join(process.cwd(), output);
+if (output) {
+    output = path.resolve(process.cwd(), output);
 }
 
 var css, fd, tree;


### PR DESCRIPTION
The include-path implementation in the current lessc version doesn't work very well with Windows, because it doesn't recognize absolute Windows paths and uses ":" as path separator which won't work on Windows because ":" is part of an absolute path there.

This commit improves the lessc windows compatibility in the following ways:
- If the os type is Windows, it uses ";" as include-path separator instead of ":"
- The code uses path.resolve instead of recognizing and joining absolute paths itself
