### PR TITLE
Added a -depends switch which outputs a dependency line suitable for

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -7,6 +7,7 @@ var path = require('path'),
 var less = require('../lib/less');
 var args = process.argv.slice(1);
 var options = {
+    depends: false,
     compress: false,
     yuicompress: false,
     optimization: 1,
@@ -46,6 +47,10 @@ args = args.filter(function (arg) {
         case 'compress':
             options.compress = true;
             break;
+        case 'M':
+        case 'depends':
+            options.depends = true;
+            break;
         case 'yui-compress':
             options.yuicompress = true;
             break;
@@ -69,10 +74,12 @@ args = args.filter(function (arg) {
 });
 
 var input = args[1];
+var inputbase = args[1];
 if (input && input[0] != '/' && input != '-' && input[1] != ':') {
     input = path.join(process.cwd(), input);
 }
 var output = args[2];
+var outputbase = args[2];
 if (output && output[0] != '/' && input[1] != ':') {
     output = path.join(process.cwd(), output);
 }
@@ -82,6 +89,10 @@ var css, fd, tree;
 if (! input) {
     sys.puts("lessc: no input files");
     process.exit(1);
+}
+if (options.depends) {
+    // output the target filename, needs to be specified on the command line (no stdout)
+    sys.print(outputbase + ": ");
 }
 
 var parseLessFile = function (e, data) {
@@ -93,26 +104,33 @@ var parseLessFile = function (e, data) {
     new(less.Parser)({
         paths: [path.dirname(input)].concat(options.paths),
         optimization: options.optimization,
+        parentPath: path.resolve(inputbase),
+        import: options.depends ? function(importname,env) { sys.print(path.resolve(path.dirname(env.parentPath),importname) + " "); } : null,
         filename: input
     }).parse(data, function (err, tree) {
         if (err) {
             less.writeError(err, options);
             process.exit(1);
         } else {
-            try {
-                css = tree.toCSS({
-                    compress: options.compress,
-                    yuicompress: options.yuicompress
-                });
-                if (output) {
-                    fd = fs.openSync(output, "w");
-                    fs.writeSync(fd, css, 0, "utf8");
-                } else {
-                    sys.print(css);
+            if (options.depends) {
+                // finish the dependency line
+                sys.print("\n");
+            } else {
+                try {
+                    css = tree.toCSS({
+                        compress: options.compress,
+                        yuicompress: options.yuicompress
+                    });
+                    if (output) {
+                        fd = fs.openSync(output, "w");
+                        fs.writeSync(fd, css, 0, "utf8");
+                    } else {
+                        sys.print(css);
+                    }
+                } catch (e) {
+                    less.writeError(e, options);
+                    process.exit(2);
                 }
-            } catch (e) {
-                less.writeError(e, options);
-                process.exit(2);
             }
         }
     });

--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -87,7 +87,7 @@ var less = {
     require('./tree/' + n);
 });
 
-less.Parser.importer = function (file, paths, callback) {
+less.Parser.importer = function (file, paths, callback, env) {
     var pathname;
 
     paths.unshift('.');
@@ -108,7 +108,9 @@ less.Parser.importer = function (file, paths, callback) {
 
           new(less.Parser)({
               paths: [path.dirname(pathname)].concat(paths),
-              filename: pathname
+              filename: pathname,
+              parentPath: pathname,
+              import: env.import
           }).parse(data, function (e, root) {
               if (e) less.writeError(e);
               callback(root);

--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -81,6 +81,7 @@ less.Parser = function Parser(env) {
             // Import a file asynchronously
             //
             less.Parser.importer(path, this.paths, function (root) {
+                if ( env.import ) env.import( path, env );      // If depends, output the path
                 that.queue.splice(that.queue.indexOf(path), 1); // Remove the path from the queue
                 that.files[path] = root;                        // Store the root
 


### PR DESCRIPTION
- Added a -depends switch which outputs a dependency line suitable for a makefile" (by @adamgundy: 10696d9c11afccd7fb4dadd92985b5166c66f6f2)
- Added a synonym flag "-M" to "-depends" to match syntax of other compilers.
- Added support for recursive dependencies.
- Fixed some issues with path calculation when dependencies and recursive dependencies.
