### PR TITLE
Don't try to use variable values that do not exist on the browser. Fixes #190.

### DIFF
--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -5,7 +5,7 @@ tree.URL = function (val, paths) {
         this.attrs = val;
     } else {
         // Add the base path if the URL is relative and we are in the browser
-        if (typeof(window) !== 'undefined' && !/^(?:https?:\/\/|file:\/\/|data:|\/)/.test(val.value) && paths.length > 0) {
+        if (typeof window !== 'undefined' && val.value && !/^(?:https?:\/\/|file:\/\/|data:|\/)/.test(val.value) && paths.length > 0) {
             val.value = paths[0] + (val.value.charAt(0) === '/' ? val.value.slice(1) : val.value);
         }
         this.value = val;


### PR DESCRIPTION
This fixes `url(@foo)` on browsers so it works.
