### PR TITLE
Ensure .css files are imported using the correct path in browsers. Fixes #465.

### DIFF
--- a/lib/less/tree/import.js
+++ b/lib/less/tree/import.js
@@ -31,6 +31,11 @@ tree.Import = function (path, imports, features) {
         imports.push(this.path, function (e, root) {
             that.root = root;
         });
+
+    // Ensure CSS files are imported relative to the LESS file, not the HTML
+    // file, in browsers
+    } else if (typeof window !== 'undefined' && !/^[a-z][a-z0-9+.-]*:/i.test(this.path)) {
+        this.path = imports.paths[0] + this.path;
     }
 };
 


### PR DESCRIPTION
This is for `@import "foo.css"`; `@import url("foo.css");` works fine already.
