### PR TITLE
Fix: Syntax error due to missing semicolon

### DIFF
--- a/lib/less/tree/condition.js
+++ b/lib/less/tree/condition.js
@@ -11,7 +11,7 @@ tree.Condition.prototype.eval = function (env) {
     var a = this.lvalue.eval(env),
         b = this.rvalue.eval(env);
 
-    var i = this.index, result
+    var i = this.index, result;
 
     var result = (function (op) {
         switch (op) {


### PR DESCRIPTION
There is a missing ";" that is causing syntax error while compiling in twostroke 
( https://github.com/charliesome/twostroke ).
Can you kindly pull to get it fixed?
As I do now have a full javascript runtime on my PC I just corrected error manually in original file however I assume that you also update the files in dist directory.
Thanks, Thomas
