### PR TITLE
Fix `parser.parse` and `less.render` error handling

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -19,7 +19,8 @@ var less = {
 
         if (callback) {
             parser.parse(input, function (e, root) {
-                callback(e, root.toCSS(options));
+                if (e) { callback(e) }
+                else   { callback(null, root.toCSS(options)) }
             });
         } else {
             ee = new(require('events').EventEmitter);

--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -316,7 +316,7 @@ less.Parser = function Parser(env) {
                     }
                 }
                 if (level > 0) {
-                    throw {
+                    error = {
                         type: 'Syntax',
                         message: "Missing closing `}`",
                         filename: env.filename
@@ -326,6 +326,14 @@ less.Parser = function Parser(env) {
                 return chunks.map(function (c) { return c.join('') });;
             })([[]]);
 
+            if (error) {
+                if (callback) {
+                    return callback(error);
+                } else {
+                    throw error;
+                }
+            }
+
             // Start with the primary rule.
             // The whole syntax tree is held under a Ruleset node,
             // with the `root` property set to true, so no `{}` are
@@ -334,7 +342,11 @@ less.Parser = function Parser(env) {
                 root = new(tree.Ruleset)([], $(this.parsers.primary));
                 root.root = true;
             } catch (e) {
-                return callback(new(LessError)(e, env));
+                if (callback) {
+                    return callback(new(LessError)(e, env));
+                } else {
+                    throw new(LessError)(e, env);
+                }
             }
 
             root.toCSS = (function (evaluate) {
@@ -426,8 +438,14 @@ less.Parser = function Parser(env) {
 
             if (this.imports.queue.length > 0) {
                 finish = function () { callback(error, root) };
+            } else if (callback) {
+                return callback(error, root);
             } else {
-                callback(error, root);
+                if (error) {
+                    throw error;
+                } else {
+                    return root;
+                }
             }
         },
 

--- a/test/js/parse.js
+++ b/test/js/parse.js
@@ -1,0 +1,120 @@
+var less = require('../../lib/less');
+var assert = require('assert');
+var parser = new less.Parser;
+
+var valid = '.class { width: 1 + 1 }';
+var result = '.class {\n  width: 2;\n}\n';
+var invalidSyntax = '.class { width: 1 + 1';
+var invalidParse = '.class width: 1 + 1';
+
+
+/*
+ * parser.parse callback
+ */
+exports['callback suucess'] = function() {
+    parser.parse(valid, function (err, tree) {
+        assert.ok(!err);
+        assert.ok(tree instanceof less.tree.Ruleset);
+        assert.equal(tree.toCSS(), result);
+    });
+};
+
+exports['callback syntax error'] = function() {
+    parser.parse(invalidSyntax, function (err, tree) {
+        assert.ok(err);
+        assert.equal(err.type, 'Syntax');
+    });
+};
+
+exports['callback parse error'] = function() {
+    parser.parse(invalidParse, function (err, tree) {
+        assert.ok(err);
+        assert.equal(err.type, 'Parse');
+    });
+};
+
+/*
+ * parser.parse return value
+ */
+exports['return value success'] = function() {
+    var tree = parser.parse(valid);
+    assert.ok(tree instanceof less.tree.Ruleset);
+};
+
+exports['return value syntax error'] = function() {
+    try {
+        var tree = parser.parse(invalidSyntax);
+        assert.ok(false);
+    } catch (err) {
+        assert.ok(err);
+        assert.equal(err.type, 'Syntax');
+        assert.ok(!tree);
+    }
+};
+
+exports['return value parse error'] = function() {
+    try {
+        var tree = parser.parse(invalidParse);
+        assert.ok(false);
+    } catch (err) {
+        assert.ok(err);
+        assert.equal(err.type, 'Parse');
+        assert.ok(!tree);
+    }
+};
+
+/*
+ * less.render callback
+ */
+exports['less.render success'] = function() {
+    less.render(valid, function(err, css) {
+        assert.ok(!err);
+        assert.equal(css, result);
+    });
+};
+
+exports['less.render syntax error'] = function() {
+    less.render(invalidSyntax, function(err, css) {
+        assert.equal(err.type, 'Syntax');
+    });
+};
+
+exports['less.render parse error'] = function() {
+    less.render(invalidParse, function(err, css) {
+        assert.equal(err.type, 'Parse');
+    });
+};
+
+
+/*
+ * less.render EventEmitter
+ */
+exports['less.render success ee'] = function() {
+    var ee = less.render(valid);
+    ee.on('success', function(css) {
+        assert.equal(css, result);
+    });
+    ee.on('error', function() {
+        assert.ok(false);
+    });
+};
+
+exports['less.render syntax error ee'] = function() {
+    var ee = less.render(invalidSyntax);
+    ee.on('success', function() {
+        assert.ok(false);
+    });
+    ee.on('error', function(err) {
+        assert.equal(err.type, 'Syntax');
+    });
+};
+
+exports['less.render parse error ee'] = function() {
+    var ee = less.render(invalidParse);
+    ee.on('success', function() {
+        assert.ok(false);
+    });
+    ee.on('error', function(err) {
+        assert.equal(err.type, 'Parse');
+    });
+};

--- a/test/less-test.js
+++ b/test/less-test.js
@@ -35,6 +35,29 @@ fs.readdirSync('test/less').forEach(function (file) {
     });
 });
 
+fs.readdirSync('test/js').forEach(function(file) {
+    if (! /\.js$/.test(file)) { return }
+
+    var name = path.basename(file, '.js');
+    var tests = require(__dirname + '/js/' + file);
+    var testName;
+    var error;
+    sys.print("- " + name + ": ")
+    for (testName in tests) {
+        try {
+            tests[testName]();
+        } catch (err) {
+            error = err;
+            sys.print(stylize("ERROR: [" + testName + "] " + (err.message || err.toString()), 'red'));
+            break;
+        }
+    }
+    if (!error) {
+        sys.print(stylize('OK', 'green'));
+    }
+    sys.puts("");
+});
+
 function toCSS(path, callback) {
     var tree, css;
     fs.readFile(path, 'utf-8', function (e, str) {


### PR DESCRIPTION
`less.render` or `parser.parse` error handling differs by 'parse error' and 'synatax error'. Because 'parse error' is set callback, 'syntax error' throw exception.

```
var parser = new less.Parser;
try {
    parser.parse('.class width: { 1 + 1 ', function(err, css) {
        console.log('parse error:' + err);
    });
} catch (e) {
    console.log('syntax error:' + e);
}
```

Error handling is duplicated.

`parser.parse` is not asynchronized function. It should return value, not use callback.

```
var parser = new less.Parser;
var tree, css;
try {
    tree = parser.parse(str);
    css = tree.toCSS();
} catch (e) {
    console.log(e);
}
```

And for backward compatibility, It also use the callback style.

```
var parser = new less.Parser;
parser.parse(str, function(err, tree) {
    console.log(err);
});
```

See also test case.
