### PR TITLE
Implemented a luma() function call

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -44,6 +44,11 @@ tree.functions = {
     alpha: function (color) {
         return new(tree.Dimension)(color.toHSL().a);
     },
+    luma: function (color) {
+        return new(tree.Dimension)(Math.round(color.rgb[0]*30/255 + 
+                                              color.rgb[1]*59/255 +
+                                              color.rgb[2]*11/255), '%');
+    },
     saturate: function (color, amount) {
         var hsl = color.toHSL();
 

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -22,6 +22,7 @@
   hue: 98;
   saturation: 12%;
   lightness: 95%;
+  luma: 23%;
   rounded: 11;
   roundedpx: 3px;
   percentage: 20%;

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -26,6 +26,7 @@
   hue: hue(hsl(98, 12%, 95%));
   saturation: saturation(hsl(98, 12%, 95%));
   lightness: lightness(hsl(98, 12%, 95%));
+  luma: luma(rgb(180, 0, 50));
   rounded: round(@r/3);
   roundedpx: round(10px / 3);
   percentage: percentage(10px / 50);


### PR DESCRIPTION
Deciding whether to use white/black text on top of a given background color is much better decided using the backgrounds "luma" rather than "lightness". Luma is a better measure of the intensity of the light, since it differentiates between colors that we do not see as well (30% red, 59% green, 11% blue).
