### PR TITLE
Make 3rd parameter for `mix` function optional

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -106,7 +106,7 @@ tree.functions = {
     // http://sass-lang.com
     //
     mix: function (color1, color2, weight) {
-        var p = weight.value / 100.0;
+        var p = (weight ? weight.value : 50) / 100.0;
         var w = p * 2 - 1;
         var a = color1.toHSL().a - color2.toHSL().a;
 


### PR DESCRIPTION
Since 186f898a8e4e4d6124c86189faca59c74f62ff0f all parameters for `mix` function was mandatory.
This fixes it, 3rd becomes 50% by default as in
http://sass-lang.com/docs/yardoc/Sass/Script/Functions.html#mix-instance_method
