### PR TITLE
Added colors.js to the Mozilla Rhino build rules.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ rhino:
 	      build/ecma-5.js\
 	      ${SRC}/parser.js\
 	      ${SRC}/functions.js\
+              ${SRC}/colors.js\
 	      ${SRC}/tree/*.js\
 	      ${SRC}/tree.js\
 	      ${SRC}/rhino.js > ${RHINO}


### PR DESCRIPTION
I've updated the Makefile rules for the Mozilla Rhino build to include the colors.js script. This removes errors like:

```
Line 657:     if (tree.colors.hasOwnProperty(k)) {
Cannot call method "hasOwnProperty" of undefined
```

That are present in the latest build of the less.js compiler (version 1.2.1). This closes #555.
