### PR TITLE
Fix callback called two times

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -309,16 +309,20 @@ less.Parser = function Parser(env) {
                     }
                 }
                 if (level > 0) {
-                    return callback(new(LessError)({
+                    error = new(LessError)({
                         index: i,
                         type: 'Parse',
                         message: "missing closing `}`",
                         filename: env.filename
-                    }, env));
+                    }, env);
                 }
 
                 return chunks.map(function (c) { return c.join('') });;
             })([[]]);
+
+            if (error) {
+                return callback(error);
+            }
 
             // Start with the primary rule.
             // The whole syntax tree is held under a Ruleset node,


### PR DESCRIPTION
Simple case is this.

```
var less = require('less');
var parser = new less.Parser;
parser.parse('foo { width: 10px', function(err, tree) {
  // called two times
});
```

This `return` can not end parse function.

```
chunks = (function (chunks) {
    ...
    return callback(...)
})([[]]);
```

Fix it.
