### PR TITLE
Fix loading stylesheet from cache


### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -143,7 +143,7 @@ function loadStyleSheet(sheet, callback, reload, remaining) {
             new(Date)(styles.timestamp).valueOf())) {
             // Use local copy
             createCSS(styles.css, sheet);
-            callback(null, sheet, { local: true, remaining: remaining });
+            callback(null, null, data, sheet, { local: true, remaining: remaining });
         } else {
             // Use remote copy (re-parse)
             try {


### PR DESCRIPTION
When callback signatures were updated in b9dbfc0 & b5dd30f, the call when loading a stylesheet from the cache was overlooked.  This results in the following error:

env is undefined
less-1.2.1.js (Line 3019)
