### PR TITLE
Make parse error handler more robust

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -19,7 +19,7 @@ var less = {
 
         if (callback) {
             parser.parse(input, function (e, root) {
-                callback(e, root.toCSS(options));
+                callback(e, root && root.toCSS && root.toCSS(options));
             });
         } else {
             ee = new(require('events').EventEmitter);


### PR DESCRIPTION
This is necessary to get useful error messages in cases where root has not been constructed successfully. I actually ran into this problem when specifying a string for `paths` instead of an array.
