### PR TITLE
Fixes #602

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -143,7 +143,7 @@ function loadStyleSheet(sheet, callback, reload, remaining) {
             new(Date)(styles.timestamp).valueOf())) {
             // Use local copy
             createCSS(styles.css, sheet);
-            callback(null, sheet, { local: true, remaining: remaining });
+            callback(null, null, data, sheet, { local: true, remaining: remaining });
         } else {
             // Use remote copy (re-parse)
             try {


### PR DESCRIPTION
This patch is to fix an issue in Internet Explorer where `env` would be undefined in the `loadStyleSheet` callback due to `callback()` being called with invalid arguments on line 3083 which should have been called like on line 3095. Line numbers reference a complete build file not libraries.
