### PR TITLE
Add an option to read imported files synchronously for packaging

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -89,6 +89,7 @@ var less = {
 
 less.Parser.importer = function (file, paths, callback, env) {
     var pathname;
+    var data = '';
 
     // TODO: Undo this at some point,
     // or use different approach.
@@ -104,23 +105,36 @@ less.Parser.importer = function (file, paths, callback, env) {
         }
     }
 
-    if (pathname) {
-        fs.readFile(pathname, 'utf-8', function(e, data) {
-            if (e) return callback(e);
-
-            new(less.Parser)({
-                paths: [path.dirname(pathname)].concat(paths),
-                filename: pathname
-            }).parse(data, function (e, root) {
-                callback(e, root, data);
-            });
-        });
-    } else {
+    if (!pathname) {
         if (typeof(env.errback) === "function") {
             env.errback(file, paths, callback);
         } else {
             callback({ type: 'File', message: "'" + file + "' wasn't found.\n" });
         }
+        return;
+    }
+
+    function parseFile(e, data) {
+        if (e) return callback(e);
+
+        new(less.Parser)({
+            paths: [path.dirname(pathname)].concat(paths),
+            filename: pathname,
+            syncImport: env.syncImport
+        }).parse(data, function (e, root) {
+            callback(e, root, data);
+        });
+    };
+
+    if (env.syncImport) {
+        try {
+            data = fs.readFileSync(pathname, 'utf-8');
+            parseFile(null, data);
+        } catch (e) {
+            parseFile(e);
+        }
+    } else {
+        fs.readFile(pathname, 'utf-8', parseFile);
     }
 }
 


### PR DESCRIPTION
I added an option flag 'syncImport' that makes LESS import files synchronously. It allows LESS to be used with packagers like [Hem](https://github.com/maccman/hem) that use require to resolve files (in a same fashion as [Stitch](https://github.com/sstephenson/stitch)), which requires LESS to return synchronously.
