### PR TITLE
Added http serving less files on the fly

### DIFF
--- a/bin/lessserv
+++ b/bin/lessserv
@@ -144,6 +144,7 @@ function _writeResponse(res, code, text) {
 
 var http = require('http');
 options.path = path.normalize(options.path);
+options.paths.push(options.path);
 console.log('path' + options.path)
 http.createServer(
     function (req, res) {


### PR DESCRIPTION
I wrote it for myself, because it is very comfortable not to run processor by yourself and processing LESS in the browser while using twitter bootstrap can make a huge delay in page loading.

I used your lessc as a base for this simple server, so it supports all parameters lessc supports. Just added -p argument to specify from which folder to serve .less files. All errors are logged via console.log.

Of course, it is good idea not to use copy-paste, but while this script is not in your repository it is just simpler to copy instead of full refactoring.

// Anyway, thanx for cool tool :)
