### PR TITLE
Adding optional compress flag for rhino command line tool

### DIFF
--- a/lib/less/rhino.js
+++ b/lib/less/rhino.js
@@ -27,7 +27,8 @@ function writeFile(filename, content) {
 // Command line integration via Rhino
 (function (args) {
     name = args[0];
-    var output = args[1];
+    var output = args[1],
+        compress = args[2];
 
     if (!name) {
         print('No files present in the fileset; Check your pattern match in build.xml');
@@ -48,7 +49,7 @@ function writeFile(filename, content) {
         if (e) {
             quit(1);
         } else {
-            result = root.toCSS();
+            result = root.toCSS({compress: compress || false});
             if (output) {
                 writeFile(output, result);
                 print("Written to " + output);


### PR DESCRIPTION
There was no way to run the rhino version of less.js and indicate that the output css should be compressed. Now the command is of the format:

```
java -jar js.jar less-rhino.js input.less output.css [compressOutput]
```

Where compressOutput is an optional boolean, and defaults to false.
