### PR TITLE
Remove potential UTF Byte Order Mark

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -265,6 +265,9 @@ less.Parser = function Parser(env) {
             i = j = current = furthest = 0;
             input = str.replace(/\r\n/g, '\n');
 
+            // Remove potential UTF Byte Order Mark
+            input = str.replace(/^\uFEFF/, '');
+
             // Split the input into chunks.
             chunks = (function (chunks) {
                 var j = 0,


### PR DESCRIPTION
Visual Studio tends to save text files as "UTF-8 with with signature" which includes a 0xFEFF Byte Order Mark sequence at the start which is (arguably erroneously) included in the string returned by node's fs.readFile(). This results in  "ParseError: Syntax Error on line 1" in less.
