### PR TITLE
Fix rhino command line tool.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ rhino:
 	      build/ecma-5.js\
 	      ${SRC}/parser.js\
 	      ${SRC}/functions.js\
+	      ${SRC}/colors.js\
 	      ${SRC}/tree/*.js\
 	      ${SRC}/tree.js\
 	      ${SRC}/rhino.js > ${RHINO}

--- a/lib/less/rhino.js
+++ b/lib/less/rhino.js
@@ -11,7 +11,7 @@ function loadStyleSheet(sheet, callback, reload, remaining) {
             print("Error: " + e);
             quit(1);
         }
-        callback(root, sheet, { local: false, lastModified: 0, remaining: remaining });
+        callback(e, root, input, sheet, { local: false, lastModified: 0, remaining: remaining });
     });
 
     // callback({}, sheet, { local: true, remaining: remaining });


### PR DESCRIPTION
The rhino command line tool has been broken by changes in the loadStyleSheet() API. Also, colors.js was missing from the generated JS file.

This commit makes it possible to build bootstrap2 using rhino.
