### PR TITLE
Added Invert color function

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -124,6 +124,11 @@ tree.functions = {
     greyscale: function (color) {
         return this.desaturate(color, new(tree.Dimension)(100));
     },
+    invert: function (color) {
+        return new(tree.Color)([255 - color.rgb[0],
+                                255 - color.rgb[1],
+                                255 - color.rgb[2]]);
+    },
     e: function (str) {
         return new(tree.Anonymous)(str instanceof tree.JavaScript ? str.evaluated : str);
     },


### PR DESCRIPTION
Simple invert function that is similar to invert function is Sass.
I have used this modification in my own projects for a while but I finally had some time to make this fork.

This fixes my original feature request https://github.com/cloudhead/less.js/issues/589
