### PR TITLE
(Issue #669) Extracting alpha value from a colour using alpha()

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -559,7 +559,7 @@ less.Parser = function Parser(env) {
                 // The arguments are parsed with the `entities.arguments` parser.
                 //
                 call: function () {
-                    var name, args, index = i;
+                    var name, args, alpha_ret, index = i;
 
                     if (! (name = /^([\w-]+|%|progid:[\w\.]+)\(/.exec(chunks[j]))) return;
 
@@ -568,7 +568,12 @@ less.Parser = function Parser(env) {
                     if (name === 'url') { return null }
                     else                { i += name.length }
 
-                    if (name === 'alpha') { return $(this.alpha) }
+                    if (name === 'alpha') {
+                        alpha_ret = $(this.alpha);
+                        if(typeof alpha_ret !== 'undefined') {
+                            return alpha_ret;
+                        }
+                    }
 
                     $('('); // Parse the '(' and consume whitespace.
 

--- a/test/css/colors.css
+++ b/test/css/colors.css
@@ -56,3 +56,18 @@
   color: blue2;
   border: 2px solid superred;
 }
+#alpha #fromvar {
+  opacity: 0.7;
+}
+#alpha #short {
+  opacity: 1;
+}
+#alpha #long {
+  opacity: 1;
+}
+#alpha #rgba {
+  opacity: 0.2;
+}
+#alpha #hsl {
+  opacity: 1;
+}

--- a/test/less/colors.less
+++ b/test/less/colors.less
@@ -63,3 +63,22 @@
     color: blue2;
     border: 2px solid superred;
 }
+
+#alpha {
+	@colorvar: rgba(150, 200, 150, 0.7);
+	#fromvar {
+		opacity: alpha(@colorvar);
+	}
+	#short {
+		opacity: alpha(#aaa);
+	}
+	#long {
+		opacity: alpha(#bababa);
+	}
+	#rgba {
+		opacity: alpha(rgba(50, 120, 95, 0.2));
+	}
+	#hsl {
+		opacity: alpha(hsl(120, 100%, 50%));
+	}
+}


### PR DESCRIPTION
The parser code seemed to be set up so that all calls to alpha() where being treated as being the IE style which requires an opacity= argument. I tested alpha() on a few different colour values as well as adapting the test code nathanziarek pasted on the issue, but it appeared to give an error every time. I changed the alpha handler so that when it encounters an alpha call, it first triest to parse it in the IE opacity= style, but then falls back to parsing it as the less.css style alpha function. I included some tests in the commit which should confirm that the change works as expected for each colour notation. 

https://github.com/cloudhead/less.js/issues/669
