### PR TITLE
less.watch() called in production mode FIX && clearInterval @ unwatch

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -41,8 +41,7 @@ less.unwatch = function () {clearInterval(less.watchTimer); return this.watchMod
 function initRunningMode(){
 	if (less.env === 'development') {		
 		less.optimization = 0;		
-		less.watchTimer = setInterval(function () {
-			console.log('in interval')
+		less.watchTimer = setInterval(function () {			
 			if (less.watchMode) {
 				loadStyleSheets(function (e, root, _, sheet, env) {
 					if (root) {


### PR DESCRIPTION
When you call less.watch() in production environment or with the hash mark -> it just does not work. Feature or bug dunno. But:

Many people trying to do this:

``` javascript
<script type="text/javascript" src="less-1.2.2.js"></script>  
<script>
   less.env = "development";
   less.watch();
</script>
```

but they do not realize that the `less.env` line is ignored (because less.js loaded itself right before that line), and that variable is auto set up based on your URL (`localhost`/`127.0.0.1`,`file:///`,etc). Which is not always useful.

For example I work on localhost with a `http://projects.local/...` host name so there the  less.watch() wont work.

I added a bit code to the `browser.js`. 

EFFECT: `less.watch()` can be called from hash or from `script` tag even in production env.

Now this will function as follows:

``` javascript
<script type="text/javascript" src="less-1.2.2.js"></script>  
<script>
   //less.env = "development"; NO NEED FOR THAT LINE
   less.watch();
</script>
```

Also fixed: missing `clearInterval` @ `less.unwatch()`. Its weird that less.js doesnt kill the timer, but check the `less.watchMode` true/false in the loop :D
Hope you guys like it.
