### PR TITLE
Fix inline styles for Safari/Chrome/WebKit

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -107,7 +107,7 @@ function loadStyles() {
                 if (style.styleSheet) {
                     style.styleSheet.cssText = css;
                 } else {
-                    style.innerHTML = css;
+                    style.innerHTML = "\n" + css;
                 }
             });
         }


### PR DESCRIPTION
Without a newline character in the beginning, WebKit doesn't seem to honor the newly injected text/css code.
