### PR TITLE
Fix for issue #592, which hides the original error message with one generated by the error handling logic.

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -121,6 +121,7 @@ function loadStyleSheets(callback, reload) {
 }
 
 function loadStyleSheet(sheet, callback, reload, remaining) {
+    var contents  = sheet.contents || {};  // Passing a ref to top importing parser content cache trough 'sheet' arg.
     var url       = window.location.href.replace(/[#?].*$/, '');
     var href      = sheet.href.replace(/\?.*$/, '');
     var css       = cache && cache.getItem(href);
@@ -147,11 +148,13 @@ function loadStyleSheet(sheet, callback, reload, remaining) {
         } else {
             // Use remote copy (re-parse)
             try {
+                contents[filename] = data;  // Updating top importing parser content cache
                 new(less.Parser)({
                     optimization: less.optimization,
                     paths: [href.replace(/[\w\.-]+$/, '')],
                     mime: sheet.type,
-                    filename: filename
+                    filename: filename,
+                    'contents': contents    // Passing top importing parser content cache ref down.
                 }).parse(data, function (e, root) {
                     if (e) { return error(e, href) }
                     try {

--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -93,7 +93,8 @@ less.Parser.importer = function (file, paths, callback, env) {
 
     // TODO: Undo this at some point,
     // or use different approach.
-    paths.unshift('.');
+    var paths = [].concat(paths); // Avoid passing paths by reference down the import tree...
+    paths.unshift('.');           // ...which results on a lot of repeated '.' paths.
 
     for (var i = 0; i < paths.length; i++) {
         try {
@@ -109,11 +110,13 @@ less.Parser.importer = function (file, paths, callback, env) {
         fs.readFile(pathname, 'utf-8', function(e, data) {
             if (e) return callback(e);
 
+            env.contents[pathname] = data;      // Updating top importing parser content cache.
             new(less.Parser)({
                 paths: [path.dirname(pathname)].concat(paths),
-                filename: pathname
+                filename: pathname,
+                contents: env.contents
             }).parse(data, function (e, root) {
-                callback(e, root, data);
+                callback(e, root, data);        // TODO: Remove "data" argument? No longer used!
             });
         });
     } else {

--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -65,6 +65,11 @@ less.Parser = function Parser(env) {
 
     var that = this;
 
+    // Top parser on an import tree must be sure there is one "env"
+    // which will then be passed arround by reference.
+    var env = env || { };
+    if (!env.contents) { env.contents={}; }  // env.contents must be passed arround with top env
+
     // This function is called after all files
     // have been imported through `@import`.
     var finish = function () {};
@@ -72,8 +77,8 @@ less.Parser = function Parser(env) {
     var imports = this.imports = {
         paths: env && env.paths || [],  // Search paths, when importing
         queue: [],                      // Files which haven't been imported yet
-        files: {},                      // Holds the imported parse trees
-        contents: {},                   // Holds the imported file contents
+//      files: {},                    // Holds the imported parse trees - TODO: Not used, REMOVE?
+        contents: env.contents,         // Holds the imported file contents
         mime:  env && env.mime,         // MIME type of .less files
         error: null,                    // Error in parsing/evaluating an import
         push: function (path, callback) {
@@ -83,10 +88,10 @@ less.Parser = function Parser(env) {
             //
             // Import a file asynchronously
             //
+            // TODO: Remove "contents" argument?
             less.Parser.importer(path, this.paths, function (e, root, contents) {
                 that.queue.splice(that.queue.indexOf(path), 1); // Remove the path from the queue
-                that.files[path] = root;                        // Store the root
-                that.contents[path] = contents;
+//              that.files[path] = root;            // Store the root - TODO: Not used, REMOVE?
 
                 if (e && !that.error) { that.error = e }
                 callback(e, root);
@@ -191,17 +196,18 @@ less.Parser = function Parser(env) {
         }
     }
 
-    function basename(pathname) {
-        if (less.mode === 'node') {
-            return require('path').basename(pathname);
-        } else {
-            return pathname.match(/[^\/]+$/)[0];
-        }
-    }
+// TODO: Removing this - Using basename() here can mess the cache due to name clashes across the import tree!!!
+//    function basename(pathname) {
+//        if (less.mode === 'node') {
+//            return require('path').basename(pathname);
+//        } else {
+//            return pathname.match(/[^\/]+$/)[0];
+//        }
+//    }
 
     function getInput(e, env) {
         if (e.filename && env.filename && (e.filename !== env.filename)) {
-            return parser.imports.contents[basename(e.filename)];
+            return parser.imports.contents[e.filename];
         } else {
             return input;
         }
@@ -1293,7 +1299,8 @@ if (less.mode === 'browser' || less.mode === 'rhino') {
         // We pass `true` as 3rd argument, to force the reload of the import.
         // This is so we can get the syntax tree as opposed to just the CSS output,
         // as we need this to evaluate the current stylesheet.
-        loadStyleSheet({ href: path, title: path, type: env.mime }, function (e) {
+        // __ Now using the hack of passing a ref to top parser's content cache in the 1st arg. __
+        loadStyleSheet({ href: path, title: path, type: env.mime, contents: env.contents }, function (e) {
             if (e && typeof(env.errback) === "function") {
                 env.errback.call(null, path, paths, callback, env);
             } else {


### PR DESCRIPTION
I Alexis,

This is the pull request to fix issue #592, as explained here:
- https://github.com/cloudhead/less.js/issues/592#issuecomment-4124890

Repeating, since this is actually the best place for it:

I did try with compiling my stuff with 1.2.2 but it still has the same problem.

I finally diagnosed the problem and got to a solution I find acceptable. It is a problem related with scopes and timing.

The callback you pass when you call less.Parser.importer() at the top of "parser.js" is at the top importing files Parser scope. However, I think this callback only gets called and registers the content data (the actual less code text) ater an import is parsed. This might be to late for some parsing errors.

Anyway, when there is a parsing error - because there is actually an error on the Less source code which trigger this problem - the code handling the error does not have access to part of the data it counts on to perform its task.

As parte of the error handling, Less tries to display the offending code. It uses the getInput() function (at parse.js) to get that offending code. When it gets an undefined instead of a string of Less code and tries to cut a bit of it to display it, it cause an exception to be thrown. That is the origin of the weird error message reported at issue #592.

This is also why the error is intermittent. The problem at the error handling code is simply hiding the error message for the real problem. Eventually, the programmer fixes the original problem at his Less code and everything works again.

Therefore I tried to load the cache as soon as the less stylesheet code is loaded. Then, of course, it is necessary to pass the data to the top importing parser cache, which requires some reference passing.

I found a solution simple enough for me to feel confortable. Not beautiful, but I don't feel confortable making a big change on your code. Had to keep it as simple as possible.

I tested everything by:
- Running the tests via "make test";
- Compiling via "lessc" the Less stylesheets for the current (straight rom the master) Twitter Bootstrap and from the app I am working on;
- Running Bootstrap with dynamic loading too.

Everything worked fine except for an unrelated issue, present also on 1.2.2 - resolving variables only on dynamic loading on url()s, like this one:
- https://github.com/twitter/bootstrap/blob/master/less/sprites.less#L24

I also removed the use of basename() since it was vulnerable to name clashes - e.g.:
- when multiple libraries have a "variables.less" file;
- and there is a single "main.less" stylesheet importing from all libraries.

In my use cases I detected no problems about that either and I was careful to ensure all bits and pieces received as filename the name actually used by the loading logic (for both browser and node).

Please review my changes. Do not hesitate to reach me for any doubts, even via Twitter (same id as here).

Cheers
