### PR TITLE
Better & combinator

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -898,7 +898,7 @@ less.Parser = function Parser(env) {
 
                 if (e) { return new(tree.Element)(c, e, i) }
 
-                if ((c.value && c.value.charAt(0) === '&') || input.charAt(i) === '&') {
+                if (c.value && c.value.charAt(0) === '&' || input.charAt(i) === '&') {
                     return new(tree.Element)(c, null, i);
                 }
             },


### PR DESCRIPTION
Basic fix for #639 and #704.

It has problems with (double) spacing: `a { div > &` becomes `div__a`, `a { & > div` becomes `a__> div` and `a { div > & + b` becomes `div >__a__+ b` (where `__` represents two spaces). Doesn't handle more than one & in the same rule (ignores all &'s other than the first one).

``` less
a {
    div > & {
        background-color: red;
    }
    & div { color: red; }
    & > div { color: red; }
    & > div + div { color: blue; }
    input & output { color: silver; }
    div > & + b {
        color: white;
    }
}
```

compiles to:

``` css
div >  a {
  background-color: red;
}
a div {
  color: red;
}
a  > div {
  color: red;
}
a  > div + div {
  color: blue;
}
input a output {
  color: silver;
}
div >  a  + b {
  color: white;
}
```
