### PR TITLE
Easier Environment Override

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -7,12 +7,12 @@ var isFileProtocol = (location.protocol === 'file:'    ||
                       location.protocol === 'chrome-extension:'  ||
                       location.protocol === 'resource:');
 
-less.env = less.env || (location.hostname == '127.0.0.1' ||
-                        location.hostname == '0.0.0.0'   ||
-                        location.hostname == 'localhost' ||
-                        location.port.length > 0         ||
-                        isFileProtocol                   ? 'development'
-                                                         : 'production');
+less.env = less.env || LESS_ENV || (location.hostname == '127.0.0.1' ||
+                                    location.hostname == '0.0.0.0'   ||
+                                    location.hostname == 'localhost' ||
+                                    location.port.length > 0         ||
+                                    isFileProtocol                   ? 'development'
+                                                                     : 'production');
 
 // Load styles asynchronously (default: false)
 //
@@ -377,4 +377,3 @@ function error(e, href) {
         }, 10);
     }
 }
-


### PR DESCRIPTION
In response to #75, I've allowed the browser `env` to be set by a global var `LESS_ENV`.

I know the use of a global is not ideal, but this is pretty much only for development since production is the default. The reason I need this is because Less won't automatically pick up that I'm in development mode simply because I use a hostname other than localhost for local development at work.

My only other option is to run this script before including less.js:

```
var less = { env: "development" };
```

This works, but this is much simpler:

```
var LESS_ENV = "development";
```
