### PR TITLE
Random colour generator / random item selector

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -122,11 +122,10 @@ tree.functions = {
         return new(tree.Color)(rgb, alpha);
     },
     randomcolor: function() {
-        if (arguments.length > 0) {
-            return arguments[Math.floor(Math.random() * arguments.length)];
-        } else {
-            return this.rgba(Math.random() * 255, Math.random() * 255, Math.random() * 255, 1.0);
-        }
+        return this.rgba(Math.random() * 255, Math.random() * 255, Math.random() * 255, 1.0);
+    },
+    pickrandom: function() {
+        return arguments[Math.floor(Math.random() * arguments.length)];
     },
     greyscale: function (color) {
         return this.desaturate(color, new(tree.Dimension)(100));


### PR DESCRIPTION
Adds two very simple functions, `randomcolor` and `pickrandom`.

`randomcolor` generates a completely random opaque colour.
`pickrandom` selects a random item (of any kind) from a list.

Usage is like this:

``` css
color: randomcolor();
background-color: pickrandom(pink, orange, blue, green, #176dea);
background-image: pickrandom(url(images/snow.png), url(images/water.png));

```

output from this might be:

``` css
color: #6b265c;
background-color: #0000ff;
background-image: url(images/snow.png);
```

There are no test cases for these functions because, by definition, the output is not predictable! I foresee `randomcolor` function being useful in generating random colour palettes, where an initial random colour can be used to derive others via LESS's existing colour manipulation functions and my contrast function in #730.
`pickrandom` has all kinds of uses since it can randomise anything you put into it.
