### PR TITLE
Fix resolution of URLs using chrome-extension protocol

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -128,7 +128,7 @@ function loadStyleSheet(sheet, callback, reload, remaining) {
     var styles    = { css: css, timestamp: timestamp };
 
     // Stylesheets in IE don't always return the full path
-    if (! /^(https?|file):/.test(href)) {
+    if (! /^(https?|file|chrome-extension):/.test(href)) {
         if (href.charAt(0) == "/") {
             href = window.location.protocol + "//" + window.location.host + href;
         } else {

--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1292,7 +1292,7 @@ if (less.mode === 'browser' || less.mode === 'rhino') {
     // Used by `@import` directives
     //
     less.Parser.importer = function (path, paths, callback, env) {
-        if (!/^([a-z]+:)?\//.test(path) && paths.length > 0) {
+        if (!/^([a-z-]+:)?\//.test(path) && paths.length > 0) {
             path = paths[0] + path;
         }
         // We pass `true` as 3rd argument, to force the reload of the import.

--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -5,7 +5,7 @@ tree.URL = function (val, paths) {
         this.attrs = val;
     } else {
         // Add the base path if the URL is relative and we are in the browser
-        if (typeof(window) !== 'undefined' && !/^(?:https?:\/\/|file:\/\/|data:|\/)/.test(val.value) && paths.length > 0) {
+        if (typeof(window) !== 'undefined' && !/^(?:https?:\/\/|file:\/\/|data:|\/|chrome-extension:\/\/)/.test(val.value) && paths.length > 0) {
             val.value = paths[0] + (val.value.charAt(0) === '/' ? val.value.slice(1) : val.value);
         }
         this.value = val;


### PR DESCRIPTION
Without these changes chrome-extension:// urls are not detected properly and less.js will try to resolve files by appending the full URL to the protocol and hostname, eg "chrome-extension://<id>/chrome-extension://<id>/some/path/to/file"

See #685
