### PR TITLE
Adding "dpi" as a valid dimensions for media queries

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -684,7 +684,7 @@ less.Parser = function Parser(env) {
                     var value, c = input.charCodeAt(i);
                     if ((c > 57 || c < 45) || c === 47) return;
 
-                    if (value = $(/^(-?\d*\.?\d+)(px|%|em|rem|pc|ex|in|deg|s|ms|pt|cm|mm|rad|grad|turn)?/)) {
+                    if (value = $(/^(-?\d*\.?\d+)(px|%|em|rem|pc|ex|in|deg|s|ms|pt|cm|mm|rad|grad|turn|dpi)?/)) {
                         return new(tree.Dimension)(value[1], value[2]);
                     }
                 },


### PR DESCRIPTION
This fixes a problem I ran into with media queries. The example below was throwing a syntax error because "dpi" was not recognized as a valid dimension.

@media only screen and (min-resolution: 240dpi) { }
