### PR TITLE
Move error formatting out of writeError into a seperate function

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -33,7 +33,7 @@ var less = {
             return ee;
         }
     },
-    writeError: function (ctx, options) {
+    formatError: function(ctx, options) {
         options = options || {};
 
         var message = "";
@@ -41,12 +41,10 @@ var less = {
         var error = [];
         var stylize = options.color ? less.stylize : function (str) { return str };
 
-        if (options.silent) { return }
-
-        if (ctx.stack) { return sys.error(stylize(ctx.stack, 'red')) }
+        if (ctx.stack) { return stylize(ctx.stack, 'red') }
 
         if (!ctx.hasOwnProperty('index')) {
-            return sys.error(ctx.stack || ctx.message);
+            return ctx.stack || ctx.message;
         }
 
         if (typeof(extract[0]) === 'string') {
@@ -68,12 +66,19 @@ var less = {
         ctx.filename && (message += stylize(' in ', 'red') + ctx.filename +
                 stylize(':' + ctx.line + ':' + ctx.column, 'grey'));
 
-        sys.error(message, error);
+        message += '\n' + error;
 
         if (ctx.callLine) {
-            sys.error(stylize('from ', 'red')       + (ctx.filename || ''));
-            sys.error(stylize(ctx.callLine, 'grey') + ' ' + ctx.callExtract);
+            message += stylize('from ', 'red') + (ctx.filename || '') + '/n';
+            message += stylize(ctx.callLine, 'grey') + ' ' + ctx.callExtract + '/n';
         }
+
+        return message;
+    },
+    writeError: function (ctx, options) {
+        options = options || {};
+        if (options.silent) { return }
+        sys.error(less.formatError(ctx));
     }
 };
 
@@ -145,4 +150,3 @@ function stylize(str, style) {
            '\033[' + styles[style][1] + 'm';
 }
 less.stylize = stylize;
-


### PR DESCRIPTION
I would like to use the error formatting in some middleware without writing the error message to stderr. I moved the error formatting out of writeError into formatError, which is then used by writeError.
