### PR TITLE
Add a watch option to the node.js compiler

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -14,7 +14,8 @@ var options = {
     silent: false,
     paths: [],
     color: true,
-    strictImports: false
+    strictImports: false,
+    watch: false
 };
 
 args = args.filter(function (arg) {
@@ -56,6 +57,10 @@ args = args.filter(function (arg) {
             break;
         case 'no-color':
             options.color = false;
+            break;
+        case 'w':
+        case 'watch':
+            options.watch = true;
             break;
         case 'include-path':
             options.paths = match[2].split(os.type().match(/Windows/) ? ';' : ':')
@@ -124,6 +129,13 @@ var parseLessFile = function (e, data) {
 
 if (input != '-') {
     fs.readFile(input, 'utf-8', parseLessFile);
+    if (options.watch) {
+        fs.watchFile(path.dirname(input), function(cur, prev) {
+            if (cur.mtime != prev.mtime) {
+                fs.readFile(input, "utf8", parseLessFile);
+            }
+        });
+    }
 } else {
     process.stdin.resume();
     process.stdin.setEncoding('utf8');


### PR DESCRIPTION
By adding the argument '-w' or '--watch', lessc will use the fs.watchFile
method to watch for changes inside the directory the given less file
resides and recompile it on each change. Not the given file, but the
directory is used so changes to files which are included with a @import
statement trigger a recompile as well.
Only works properly if the source and destination arguments are given
and pointing to writeable / readable files
