### PR TITLE
data-uri: adds `inline-image()` to embed data-URIs

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -201,6 +201,21 @@ tree.functions = {
     },
     _isa: function (n, Type) {
         return (n instanceof Type) ? tree.True : tree.False;
+    },
+    "inline-image": function(ctx) {
+        return {
+            toCSS: function() {
+                var fs = require('fs');
+                var sys = require('util');
+
+                var chunks = ctx.value.split('.');
+                var ext = chunks[chunks.length - 1];
+
+                var mimetype = 'image/' + ext.replace(/jpg/, 'jpeg');
+
+                return 'url("data:' + mimetype + ';base64,' + new Buffer(fs.readFileSync(ctx.value)).toString('base64') + '")';
+            }
+        }
     }
 };
 


### PR DESCRIPTION
The "inline-image" function reads images, encodes them
using base64 encoding, and embeds them into the generated
CSS files as data-URIs.

More about data-URIs:
http://en.wikipedia.org/wiki/Data_URI_scheme

This causes a significant reduction in the number of
HTTP requests sent although it increases the size of the
resulting CSS code. Multiple occurrences of the same data-URI
are easily handled by server-side GZIP compression and hence
redundancy should not be a drawback for the majority of the
client audience.

The original author of this patch is:
Marc Boeker marc.boeker@onchestra.com
