### PR TITLE
no caching when in development mode

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -50,12 +50,12 @@ if (less.env === 'development') {
     less.optimization = 3;
 }
 
-var cache;
+var cache = null;
 
-try {
-    cache = (typeof(window.localStorage) === 'undefined') ? null : window.localStorage;
-} catch (_) {
-    cache = null;
+if less.optimization > 0 {
+    try {
+        cache = (typeof(window.localStorage) === 'undefined') ? null : window.localStorage;
+    } catch (_) {}
 }
 
 //


### PR DESCRIPTION
Hi, when using watch with a file which has @import statements, the cache prevented reloading of those imported files. I think you can assume that when in development env and using watch that you really want to reload the file.
