### PR TITLE
deep error reporting

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -95,7 +95,7 @@ less.Parser = function Parser(env) {
 
                 callback(e, root, imported);
 
-                if (that.queue.length === 0) { finish() }       // Call `finish` if we're done importing
+                if (that.queue.length === 0) { finish(e) }       // Call `finish` if we're done importing
             }, env);
         }
     };
@@ -435,7 +435,10 @@ less.Parser = function Parser(env) {
             }
 
             if (this.imports.queue.length > 0) {
-                finish = function () { callback(error, root) };
+                finish = function (e) {
+                    if (e) callback(e);
+                    else callback(null, root);
+                };
             } else {
                 callback(error, root);
             }


### PR DESCRIPTION
Made a small change in the way an error is bound to Parser.importer.error

Any time an error is passed back from `less.Parser.importer()` it is bound to `this` -> `Parser.importer.error`. Previously only the first error encountered was bound and reported, ignoring any following errors.

The change makes it much easier to see where syntax errors are encountered in imported child files when debugging CSS.

All tests are passing.
