### PR TITLE
Fix expansion of units in quoted strings

### DIFF
--- a/lib/less/tree/quoted.js
+++ b/lib/less/tree/quoted.js
@@ -20,7 +20,7 @@ tree.Quoted.prototype = {
             return new(tree.JavaScript)(exp, that.index, true).eval(env).value;
         }).replace(/@\{([\w-]+)\}/g, function (_, name) {
             var v = new(tree.Variable)('@' + name, that.index).eval(env);
-            return ('value' in v) ? v.value : v.toCSS();
+            return ('value' in v) ? ('unit' in v) ? v.value + v.unit : v.value : v.toCSS();
         });
         return new(tree.Quoted)(this.quote + value + this.quote, value, this.escaped, this.index);
     }


### PR DESCRIPTION
Greetings,

Currently this code:

``` css
#foo {
  @angle: -45deg;
  @tmp: ~"@{angle}";
  test: @tmp;
}
```

results in:

``` css
#foo {
  test: -45;
}
```

Besides being surprising, this behavior makes it difficult to write certain kinds of mixins.

The pull request here appends the unit to a value if it has one when the value is being expanded in a quoted string.  With this change, the above code results in:

``` css
#foo {
  test: -45deg;
}
```
