### PR TITLE
Allow dimensions starting with +

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -682,9 +682,10 @@ less.Parser = function Parser(env) {
                 //
                 dimension: function () {
                     var value, c = input.charCodeAt(i);
-                    if ((c > 57 || c < 45) || c === 47) return;
+                    //Is the first char of the dimension 0-9, '.', '+' or '-'
+                    if ((c > 57 || c < 43) || c === 47 || c == 44) return;
 
-                    if (value = $(/^(-?\d*\.?\d+)(px|%|em|rem|pc|ex|in|deg|s|ms|pt|cm|mm|rad|grad|turn)?/)) {
+                    if (value = $(/^([+-]?\d*\.?\d+)(px|%|em|rem|pc|ex|in|deg|s|ms|pt|cm|mm|rad|grad|turn)?/)) {
                         return new(tree.Dimension)(value[1], value[2]);
                     }
                 },

--- a/test/less/css.less
+++ b/test/less/css.less
@@ -52,7 +52,7 @@ q:lang(no) {
 }
 
 p + h1 {
-  font-size: 2.2em;
+  font-size: +2.2em;
 }
 
 #shorthands {


### PR DESCRIPTION
According to http://www.w3.org/TR/CSS2/syndata.html#numbers,
numbers may start with a '+'.
Also updates the test suite to include at least one dimension
starting with '+'
