### PR TITLE
If weight is not passed to mix() asume it's 50

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -106,6 +106,9 @@ tree.functions = {
     // http://sass-lang.com
     //
     mix: function (color1, color2, weight) {
+        if (!weight) {
+            weight = new(tree.Dimension)(50);
+        }
         var p = weight.value / 100.0;
         var w = p * 2 - 1;
         var a = color1.toHSL().a - color2.toHSL().a;

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -26,6 +26,10 @@
   roundedpx: 3px;
   percentage: 20%;
   color: #ff0011;
+  mix: #ff3300;
+  mix-0: #ffff00;
+  mix-100: #ff0000;
+  mix-weightless: #ff8000;
 }
 #built-in .is-a {
   color: true;

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -31,6 +31,11 @@
   percentage: percentage(10px / 50);
   color: color("#ff0011");
 
+  mix: mix(#ff0000, #ffff00, 80);
+  mix-0: mix(#ff0000, #ffff00, 0);
+  mix-100: mix(#ff0000, #ffff00, 100);
+  mix-weightless: mix(#ff0000, #ffff00);
+
   .is-a {
     color: iscolor(#ddd);
     color1: iscolor(red);


### PR DESCRIPTION
Currently http://lesscss.org/ doesn't mention required `weight` argument that has to be passed to **mix()**. If one doesn't pass it, the

```
var p = weight.value / 100.0;
```

line, obviously, raises the `Cannot read property 'value' of undefined` error.

I would propose to leave `weight` (that should be mentioned on the site no matter what) as an optional argument. The pull request contains tests and fix for the case when `weight` is not provided.
