### PR TITLE
Only assign a media type in browser when one is specified

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -192,7 +192,7 @@ function createCSS(styles, sheet, lastModified) {
     if ((css = document.getElementById(id)) === null) {
         css = document.createElement('style');
         css.type = 'text/css';
-        css.media = sheet.media || 'screen';
+        if( sheet.media ){ css.media = sheet.media; }
         css.id = id;
         document.getElementsByTagName('head')[0].appendChild(css);
     }


### PR DESCRIPTION
Defaulting to media="screen" causes the
browser to ignore inline @media print
and other queries.

Fixes #612
