### PR TITLE
Remove trailing ANSI escape sequences in no-color mode

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -62,7 +62,7 @@ var less = {
         if (typeof(extract[2]) === 'string') {
             error.push(stylize((ctx.line + 1) + ' ' + extract[2], 'grey'));
         }
-        error = error.join('\n') + '\033[0m\n';
+        error = error.join('\n') + stylize('', 'reset') + '\n';
 
         message += stylize(ctx.type + 'Error: ' + ctx.message, 'red');
         ctx.filename && (message += stylize(' in ', 'red') + ctx.filename +
@@ -133,6 +133,7 @@ for (var k in less) { exports[k] = less[k] }
 // Stylize a string
 function stylize(str, style) {
     var styles = {
+        'reset'     : [0,   0],
         'bold'      : [1,  22],
         'inverse'   : [7,  27],
         'underline' : [4,  24],

--- a/test/less-test.js
+++ b/test/less-test.js
@@ -61,6 +61,7 @@ function toCSS(path, callback) {
 // Stylize a string
 function stylize(str, style) {
     var styles = {
+        'reset'     : [0,   0],
         'bold'      : [1,  22],
         'inverse'   : [7,  27],
         'underline' : [4,  24],


### PR DESCRIPTION
First of all, thank you for this project.

Running lessc with the '-no-color' option appends the ANSI escape sequence '\033[0m' (reset) to error messages. The ANSI code is visible when displayed in a non-terminal environment. It is also written to log files.

This pull request removes trailing '\033[0m' from error messages. The changes will produce two reset sequences at the end of error messages in a terminal.
