### PR TITLE
Add flag to treat @import URLs as opaque

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1084,7 +1084,7 @@ less.Parser = function Parser(env) {
                 if (dir && (path = $(this.entities.quoted) || $(this.entities.url))) {
                     features = $(this.mediaFeatures);
                     if ($(';')) {
-                        return new(tree.Import)(path, imports, features, (dir[1] === 'once'), index);
+                        return new(tree.Import)(path, imports, features, (dir[1] === 'once'), index, env);
                     }
                 }
             },

--- a/lib/less/tree/import.js
+++ b/lib/less/tree/import.js
@@ -11,7 +11,7 @@
 // `import,push`, we also pass it a callback, which it'll call once
 // the file has been fetched, and parsed.
 //
-tree.Import = function (path, imports, features, once, index) {
+tree.Import = function (path, imports, features, once, index, env) {
     var that = this;
 
     this.once = once;
@@ -20,13 +20,13 @@ tree.Import = function (path, imports, features, once, index) {
     this.features = features && new(tree.Value)(features);
 
     // The '.less' extension is optional
-    if (path instanceof tree.Quoted) {
+    if (path instanceof tree.Quoted && (!env || !env.opaque)) {
         this.path = /\.(le?|c)ss(\?.*)?$/.test(path.value) ? path.value : path.value + '.less';
     } else {
         this.path = path.value.value || path.value;
     }
 
-    this.css = /css(\?.*)?$/.test(this.path);
+    this.css = /css(\?.*)?$/.test(this.path) && (!env || !env.opaque);
 
     // Only pre-compile .less files
     if (! this.css) {


### PR DESCRIPTION
Not every @import URL will end in .css or .less, some may include a query string to generate the CSS or LESS dynamically. This patch adds an "opaque" boolean flag to the less.Parser parameter and if true will cause all import URLs to be the same: never append ".less" and always inline the style rules.

Some example @import would be:
@import url("style.cgi?lang=en");
@import url("style.cgi?format=lesscss");
