### PR TITLE
Revert adding "transparent" as a color name

### DIFF
--- a/lib/less/colors.js
+++ b/lib/less/colors.js
@@ -140,7 +140,7 @@
         'teal':'#008080',
         'thistle':'#d8bfd8',
         'tomato':'#ff6347',
-        'transparent':'rgba(0,0,0,0)',
+        // 'transparent':'rgba(0,0,0,0)',
         'turquoise':'#40e0d0',
         'violet':'#ee82ee',
         'wheat':'#f5deb3',


### PR DESCRIPTION
Because a bug was introduced with the addition of adding "transparent" as a color name, specifically when trying to use transparent in the background rule.  I recommend reverting that change until the issue can be fixed.
