### PR TITLE
Report brace count errors symmetrically

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -320,11 +320,11 @@ less.Parser = function Parser(env) {
                         default:                                    chunk.push(c);
                     }
                 }
-                if (level > 0) {
+                if (level != 0) {
                     error = new(LessError)({
                         index: i,
                         type: 'Parse',
-                        message: "missing closing `}`",
+                        message: (level > 0) ? "missing closing `}`" : "missing opening `{`",
                         filename: env.filename
                     }, env);
                 }
@@ -333,7 +333,7 @@ less.Parser = function Parser(env) {
             })([[]]);
 
             if (error) {
-                return callback(error);
+                return callback(error, env);
             }
 
             // Start with the primary rule.


### PR DESCRIPTION
The parser reports an error at the chunking stage if there is one or more missing closing braces (# of `{` > # of `}`). However, it doesn't error if there are too many closing braces (or missing opening braces). It seems to be a simple fix (unless I'm missing a cunning reason to not check for it...)
