### PR TITLE
Fix #423 by preserving order of link/style elements

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -194,7 +194,8 @@ function createCSS(styles, sheet, lastModified) {
         css.type = 'text/css';
         css.media = sheet.media || 'screen';
         css.id = id;
-        document.getElementsByTagName('head')[0].appendChild(css);
+        var nextEl = sheet && sheet.nextSibling || null;
+        document.getElementsByTagName('head')[0].insertBefore(css, nextEl);
     }
 
     if (css.styleSheet) { // IE


### PR DESCRIPTION
Appending generated css to the head element is confusing because it
changes the order of style declarations. If there are regular css link
or style elements after the less link element, less declarations with
equal specificity will override css declarations that come later in the
document.

This change preserves the original order by inserting the generated css
immediately after the less link element.

See #423 for details.
