### PR TITLE
Name of CSS attribute selector with underscore breaks parser

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -995,7 +995,7 @@ less.Parser = function Parser(env) {
 
                 if (! $('[')) return;
 
-                if (key = $(/^[a-zA-Z-]+/) || $(this.entities.quoted)) {
+                if (key = $(/^[a-zA-Z-_]+/) || $(this.entities.quoted)) {
                     if ((op = $(/^[|~*$^]?=/)) &&
                         (val = $(this.entities.quoted) || $(/^[\w-]+/))) {
                         attr = [key, op, val.toCSS ? val.toCSS() : val].join('');


### PR DESCRIPTION
If an css attribute has an underscore (i.e. SHADOW_IN) it should be allowed.

This request makes the pull request #838 obsolete
