### PR TITLE
Fixing the tests in Windows

### DIFF
--- a/test/less-test.js
+++ b/test/less-test.js
@@ -24,6 +24,7 @@ fs.readdirSync('test/less').forEach(function (file) {
 
         fs.readFile(path.join('test/css', name) + '.css', 'utf-8', function (e, css) {
             sys.print("- " + name + ": ")
+            css = css && css.replace(/\r\n/g, '\n');
             if (less === css) { sys.print(stylize('OK', 'green')) }
             else if (err) {
                 sys.print(stylize("ERROR: " + (err && err.message), 'red'));


### PR DESCRIPTION
The tests fail in Windows because readFile uses the \r\n format for line feeds on Windows. This just mimics what parser.js does by adjusting the line feeds.
