### PR TITLE
Add failing test for importing a css file inside a mixin

### DIFF
--- a/test/less/import.less
+++ b/test/less/import.less
@@ -9,3 +9,13 @@
   height: @a + 10%;
 }
 @import "import/import-test-e" screen and (max-width: 600px);
+
+.doNotCall() {
+  @import "import/import-test-e.less";
+}
+.doImport() {
+  @import "import/import-test-c.less";
+}
+.testStrictImport {
+  .doImport();
+}


### PR DESCRIPTION
Created to cover the issue raised in #546.. for which that pull request does not fix.

Would need to bubble the import back up to root somehow.. but seems like a low priority corner case.