### PR TITLE
Synchronous XHR requests disallowed in Chrome Packaged Apps

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -239,7 +239,7 @@ function xhr(url, type, callback, errback) {
     xhr.setRequestHeader('Accept', type || 'text/x-less, text/css; q=0.9, */*; q=0.5');
     xhr.send(null);
 
-    if (isFileProtocol) {
+    if (isFileProtocol && !less.fileAsync) {
         if (xhr.status === 0 || (xhr.status >= 200 && xhr.status < 300)) {
             callback(xhr.responseText);
         } else {


### PR DESCRIPTION
Chrome apps (which load as chrome-extension://) will not currently work with less because synchronous xhr requests are disabled.

https://developer.chrome.com/apps/app_deprecated.html

isFileProtocol in browser.js matches these resources, hence less.async is ignored.

Synchronous loading is clearly preferred, since it will prevent flickering, but there should be some way to force the use of asynchronous XHR.

Are there reasons not to modify browser.js line 20 to:
less.async = less.async || false;
