### PR TITLE
Add arguments-list which is comma seperated

### DIFF
--- a/lib/less/tree/mixin.js
+++ b/lib/less/tree/mixin.js
@@ -107,6 +107,7 @@ tree.mixin.Definition.prototype = {
             _arguments.push((args[i] && args[i].value) || this.params[i].value);
         }
         frame.rules.unshift(new(tree.Rule)('@arguments', new(tree.Expression)(_arguments).eval(env)));
+        frame.rules.unshift(new(tree.Rule)('@arguments-list', new(tree.Value)(_arguments).eval(env)));
 
         rules = important ?
             this.rules.map(function (r) {

--- a/test/css/mixins-args.css
+++ b/test/css/mixins-args.css
@@ -65,6 +65,7 @@ body {
 }
 .arguments4 {
   border: 0 1 2 3 4;
+  commas: 0, 1, 2, 3, 4;
   rest: 1 2 3 4;
   width: 0;
 }

--- a/test/less/mixins-args.less
+++ b/test/less/mixins-args.less
@@ -116,6 +116,7 @@ body {
 
 .mixin-arguments2 (@width, @rest...) {
     border: @arguments;
+	commas: @arguments-list;
     rest: @rest;
     width: @width;
 }


### PR DESCRIPTION
To avoid the popular javascript hacks to convert @arguments into a comma seperated list
