### PR TITLE
add namespaced element selector test case from angular.js

### DIFF
--- a/test/css/css.css
+++ b/test/css/css.css
@@ -98,3 +98,15 @@ p + h1 {
 .æøå {
   margin: 0;
 }
+[ng\:cloak],
+[ng-cloak],
+[data-ng-cloak],
+[x-ng-cloak],
+.ng-cloak,
+.x-ng-cloak{
+  display:none;
+}
+ng\:form,
+ng-form{
+  display:block;
+}

--- a/test/less/css.less
+++ b/test/less/css.less
@@ -113,3 +113,11 @@ p + h1 {
 .æøå {
   margin: 0;
 }
+
+[ng\:cloak],[ng-cloak],[data-ng-cloak],[x-ng-cloak],.ng-cloak,.x-ng-cloak{
+  display:none;
+}
+
+ng\:form, ng-form{
+  display:block;
+}


### PR DESCRIPTION
It seems 

``` css
ng\:form{display:block;}
```

causes a parse error, despite being valid css
