### PR TITLE
Automatic output (.css) file creation near .less file

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -86,10 +86,11 @@ if (input && input != '-') {
     input = path.resolve(process.cwd(), input);
 }
 var output = args[2];
+var separator = path.sep || '/';
 if (output) {
     output = path.resolve(process.cwd(), output);
 } else if (input && input != '-' && path.extname(input) == '.less' && output != '-'){
-    output = path.dirname(input) + '/' + path.basename(input, '.less') + '.css'
+    output = path.dirname(input) + separator + path.basename(input, '.less') + '.css'
 }
 
 if (! input) {


### PR DESCRIPTION
lessc used to output the generated css to standard out when output file name is not provided. However, in most of the cases, developer need to write it to a .css file. Typically people choose same file name and path for .less and .css files.

After this enhancement, if only less file path is provided to lessc, it will generate .css file in the same directory. One can use '-' as second argument if the output is needed on standard out. 
