### PR TITLE
Don't throw object literals.

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -193,7 +193,10 @@ less.Parser = function Parser(env) {
     }
 
     function error(msg, type) {
-        throw new Error(JSON.stringify({ index: i, type: type || 'Syntax', message: msg }));
+		var obj = { index: i, type: type || 'Syntax', message: msg };
+		var json = JSON.stringify(obj);
+		obj.toString = function () { return json; };
+        throw new Error(obj);
     }
 
     // Same as $(), but don't change the state of the parser,


### PR DESCRIPTION
Throwing should only throw a new Error object, which takes a string argument. Throwing an object literal ends up as "[Object object]" in the stack trace.
