### PR TITLE
alternative to throwing an object literal.

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -193,7 +193,10 @@ less.Parser = function Parser(env) {
     }
 
     function error(msg, type) {
-        throw { index: i, type: type || 'Syntax', message: msg };
+        var e = new Error(msg)
+        e.index = i
+        e.type = type || 'Syntax'
+        throw e
     }
 
     // Same as $(), but don't change the state of the parser,


### PR DESCRIPTION
create a real exception and extend it with the
custom properties that less needs to satisfy its
error generator while retaining the stack
info. An alternative to the solution
proposed in cloudhead/less.js#963
