### PR TITLE
Don't cache during development, for watch() and refresh() to work with imports

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -52,12 +52,12 @@ if (less.env === 'development') {
     less.optimization = 3;
 }
 
-var cache;
+var cache = null;
 
-try {
-    cache = (typeof(window.localStorage) === 'undefined') ? null : window.localStorage;
-} catch (_) {
-    cache = null;
+if (less.env != 'development') {
+    try {
+        cache = (typeof(window.localStorage) === 'undefined') ? null : window.localStorage;
+    } catch (_) {}
 }
 
 //


### PR DESCRIPTION
When using watch with a file which has @import statements, the cache prevents automatic reloading of those imported files. I think you can assume that when in development env, and using watch, you really want to reload the file, and just skip the cache.

This should resolve both #346 and #47.

Thanks.
