### PR TITLE
Pass the filename and paths on to the Less functions

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -616,7 +616,7 @@ less.Parser = function Parser(env) {
 
                     if (! $(')')) return;
 
-                    if (name) { return new(tree.Call)(name, args, index, env.filename, env.paths) }
+                    if (name) { return new(tree.Call)(name, args, index, env) }
                 },
                 arguments: function () {
                     var args = [], arg;

--- a/lib/less/tree/call.js
+++ b/lib/less/tree/call.js
@@ -3,12 +3,11 @@
 //
 // A function call node.
 //
-tree.Call = function (name, args, index, filename, paths) {
+tree.Call = function (name, args, index, parserEnv) {
     this.name = name;
     this.args = args;
     this.index = index;
-    this.filename = filename;
-    this.paths = paths;
+    this.parserEnv = parserEnv;
 };
 tree.Call.prototype = {
     //
@@ -25,10 +24,10 @@ tree.Call.prototype = {
     //
     eval: function (env) {
         var args = this.args.map(function (a) { return a.eval(env) });
-        args.push(this.filename);
-        args.push(this.paths);
 
         if (this.name in tree.functions) { // 1.
+            args.push(this.parserEnv);
+            
             try {
                 return tree.functions[this.name].apply(tree.functions, args);
             } catch (e) {


### PR DESCRIPTION
I think it would be useful if functions (less.tree.functions) had some additional arguments passed on:
- filename - the name of the LESS file
- paths - search paths (reuse the @import paths)

It could be used to create functions which will be able to resolve relative paths - data-url() function for example.
