### PR TITLE
Rewrite url paths based on rewrite rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist
 node_modules
 .emacs*
 *.flymake

--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -124,7 +124,7 @@ less.Parser.importer = function (file, paths, callback, env) {
 
             env.contents[pathname] = data;      // Updating top importing parser content cache.
             new(less.Parser)({
-                paths: [path.dirname(pathname)].concat(paths),
+                paths: [path.dirname(pathname) + '/'].concat(paths),
                 filename: pathname,
                 contents: env.contents,
                 dumpLineNumbers: env.dumpLineNumbers

--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -95,6 +95,7 @@ var less = {
 });
 
 less.Parser.importer = function (file, paths, callback, env) {
+    console.log("importer", file);
     var pathname;
 
     // TODO: Undo this at some point,
@@ -102,14 +103,20 @@ less.Parser.importer = function (file, paths, callback, env) {
     var paths = [].concat(paths); // Avoid passing paths by reference down the import tree...
     paths.unshift('.');           // ...which results on a lot of repeated '.' paths.
 
-    for (var i = 0; i < paths.length; i++) {
-        try {
-            pathname = path.join(paths[i], file);
-            fs.statSync(pathname);
-            break;
-        } catch (e) {
-            pathname = null;
+    // If filepath is relative...
+    if (! file.match(/^\/|\\/)){
+        for (var i = 0; i < paths.length; i++) {
+            try {
+                pathname = path.join(paths[i], file);
+                fs.statSync(pathname);
+                break;
+            } catch (e) {
+                pathname = null;
+            }
         }
+    }
+    else{
+        pathname = file;
     }
 
     if (pathname) {

--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -95,7 +95,6 @@ var less = {
 });
 
 less.Parser.importer = function (file, paths, callback, env) {
-    console.log("importer", file);
     var pathname;
 
     // TODO: Undo this at some point,

--- a/lib/less/tree/import.js
+++ b/lib/less/tree/import.js
@@ -23,6 +23,7 @@ tree.Import = function (path, imports, features, once, index) {
     if (path instanceof tree.Quoted) {
         this.path = /\.(le?|c)ss(\?.*)?$/.test(path.value) ? path.value : path.value + '.less';
     } else {
+        path = path.eval();
         this.path = path.value.value || path.value;
     }
 

--- a/lib/less/tree/import.js
+++ b/lib/less/tree/import.js
@@ -27,9 +27,11 @@ tree.Import = function (path, imports, features, once, index) {
         this.path = path.value.value || path.value;
     }
 
-    this.css = /css(\?.*)?$/.test(this.path);
+    // Don't compile .css files, unless specified in config.
+    if (! less.compileCss){
+        this.css = /css(\?.*)?$/.test(this.path);
+    }
 
-    // Only pre-compile .less files
     if (! this.css) {
         imports.push(this.path, function (e, root, imported) {
             if (e) { e.index = index }

--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -11,6 +11,14 @@ tree.URL.prototype = {
     eval: function (ctx) {
         var val = this.value.eval(ctx);
 
+        // Rewrite the path per less.pathRewrites.
+        if (less.pathRewrites){
+            for (var i in less.pathRewrites){
+                var rewrite = less.pathRewrites[i];
+                val.value = val.value.replace(rewrite[0], rewrite[1]);
+            }
+        }
+
         // Add the base path if the URL is relative and we are in the browser
         if (typeof window !== 'undefined' && typeof val.value === "string" && !/^(?:[a-z-]+:|\/)/.test(val.value) && this.paths.length > 0) {
             val.value = this.paths[0] + (val.value.charAt(0) === '/' ? val.value.slice(1) : val.value);

--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -6,7 +6,7 @@ tree.URL = function (val, paths) {
 };
 tree.URL.prototype = {
     toCSS: function () {
-        return "url(" + this.eval().value + ")";
+        return "url(" + this.eval().value.value + ")";
     },
     eval: function (ctx) {
         var val = this.value.eval(ctx);

--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -11,12 +11,9 @@ tree.URL.prototype = {
     eval: function (ctx) {
         var val = this.value.eval(ctx);
 
-        // Rewrite the path per less.pathRewrites.
-        if (less.pathRewrites){
-            for (var i in less.pathRewrites){
-                var rewrite = less.pathRewrites[i];
-                val.value = val.value.replace(rewrite[0], rewrite[1]);
-            }
+        // Rewrite the path per less.rewritePath
+        if (less.rewritePath && typeof less.rewritePath === 'function'){
+            val.value = less.rewritePath(val.value);
         }
 
         // Add the base path if the URL is relative and we are in the browser

--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -6,7 +6,7 @@ tree.URL = function (val, paths) {
 };
 tree.URL.prototype = {
     toCSS: function () {
-        return "url(" + this.value.toCSS() + ")";
+        return "url(" + this.eval().value + ")";
     },
     eval: function (ctx) {
         var val = this.value.eval(ctx);

--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -6,7 +6,7 @@ tree.URL = function (val, paths) {
 };
 tree.URL.prototype = {
     toCSS: function () {
-        return "url(" + this.eval().value.value + ")";
+        return "url('" + this.eval().value.value + "')";
     },
     eval: function (ctx) {
         var val = this.value.eval(ctx);
@@ -16,8 +16,9 @@ tree.URL.prototype = {
             val.value = less.rewritePath(val.value);
         }
 
-        // Add the base path if the URL is relative and we are in the browser
-        if (typeof window !== 'undefined' && typeof val.value === "string" && !/^(?:[a-z-]+:|\/)/.test(val.value) && this.paths.length > 0) {
+        // Add the base path if the URL is relative,
+        // and we are in the browse or addBasePath is true.
+        if ( (typeof window !== 'undefined' || less.addBasePath) && typeof val.value === "string" && !/^(?:[a-z-]+:|\/)/.test(val.value) && this.paths.length > 0) {
             val.value = this.paths[0] + (val.value.charAt(0) === '/' ? val.value.slice(1) : val.value);
         }
 


### PR DESCRIPTION
I would like to add the ability to rewrite paths based on a set of rewrite rules.

For example, I would like to do the following:

```
lessText = 'body {background-image: url("path1");}';

less.rewriteRules = [
[/path1/, 'newPath1']
]

parser = new less.Parser();
parser.parse(lessText, function(err, tree){
  console.log(tree.toCSS());
})
```

This would yield:

```
body {
  background-image: url("newPath1")
}
```

### Use Case for This Feature
The ability to rewrite paths would make it possible to write modular CSS with less, by making it possible to annotate modules through the use of unique URIs.

For example, say I have a module 'common' that includes these files:
```
common/
  buttons.less
  tooltips.less
  images/
    cancel.png
    ...
  ...
```

I want to write another module, 'moduleA', that can access these files.  However, I don't know yet where the 'common' module will be located yet in relation to 'moduleA'.  So what I do is I use a path identifier for 'common', like this:

```
moduleA/style.less:

@import url('module:common:buttons.less');
```

Then, in my less.rewritePaths function, I can map the identifier path to the actual path when I know it:
```
less.rewritePaths = function(path){
   return path.replace(/module:common:/, '/the/real/path/to/common');
}
```