### PR TITLE
Change the default behavior of "@import" to only import once.

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1178,7 +1178,7 @@ less.Parser = function Parser(env) {
                 if (dir && (path = $(this.entities.quoted) || $(this.entities.url))) {
                     features = $(this.mediaFeatures);
                     if ($(';')) {
-						var importOnce = dir[1] !== 'multiple';
+                        var importOnce = dir[1] !== 'multiple';
                         return new(tree.Import)(path, imports, features, importOnce, index);
                     }
                 }


### PR DESCRIPTION
- Change the default behavior of "@import" to only import once.
- Add @import-multiple if for some insane reason you want multiple imports.
- Continue to support @import-once for backwards compatibility.
- Fixes #212.
