### PR TITLE
I found a easier way to make rhino version of less 1.3.1

### DIFF
--- a/dist/less-rhino-1.3.1.js
+++ b/dist/less-rhino-1.3.1.js
@@ -1,8 +1,26 @@
 //
-// Stub out `require` in rhino
+// LESS - Leaner CSS v1.3.1
+// 
+// Copyright (c) 2009-2011, Alexis Sellier
+// modified for using on rhino by acecode <acecode.tk@gmail.com>
+//
+
+if(typeof(window) === 'undefined'){
+    //fake window to append less on
+    var WIN={
+        location:{
+            port:""
+        }
+    };
+
+}
+
+(function (window, document, undefined) {
+//
+// Stub out `require` in the browser
 //
 function require(arg) {
-    return less[arg.split('/')[1]];
+    return window.less[arg.split('/')[1]];
 };
 
 
@@ -21,6 +39,7 @@ if (!Array.isArray) {
                (obj instanceof Array);
     };
 }
+
 if (!Array.prototype.forEach) {
     Array.prototype.forEach =  function(block, thisObject) {
         var len = this.length >>> 0;
@@ -57,6 +76,7 @@ if (!Array.prototype.filter) {
         return values;
     };
 }
+
 if (!Array.prototype.reduce) {
     Array.prototype.reduce = function(fun /*, initial*/) {
         var len = this.length >>> 0;
@@ -146,6 +166,7 @@ if (typeof environment === "object" && ({}).toString.call(environment) === "[obj
     tree = window.less.tree = {};
     less.mode = 'browser';
 }
+
 //
 // less.js - parser
 //
@@ -179,6 +200,7 @@ if (typeof environment === "object" && ({}).toString.call(environment) === "[obj
 //    It also takes care of moving all the indices forwards.
 //
 //
+
 less.Parser = function Parser(env) {
     var input,       // LeSS input string
         i,           // current index in `input`
@@ -230,7 +252,7 @@ less.Parser = function Parser(env) {
             }, env);
         }
     };
-
+    
     function save()    { temp = chunks[j], memo = i, current = i }
     function restore() { chunks[j] = temp, i = memo, current = i }
 
@@ -400,7 +422,7 @@ less.Parser = function Parser(env) {
     this.optimization = ('optimization' in this.env) ? this.env.optimization : 1;
 
     this.env.filename = this.env.filename || null;
-
+    
     //
     // The Parser
     //
@@ -2445,12 +2467,12 @@ tree.Element.prototype.eval = function (env) {
                              this.index);
 };
 tree.Element.prototype.toCSS = function (env) {
-	var value = (this.value.toCSS ? this.value.toCSS(env) : this.value);
-	if (value == '' && this.combinator.value.charAt(0) == '&') {
-		return '';
-	} else {
-		return this.combinator.toCSS(env || {}) + value;
-	}
+    var value = (this.value.toCSS ? this.value.toCSS(env) : this.value);
+    if (value == '' && this.combinator.value.charAt(0) == '&') {
+        return '';
+    } else {
+        return this.combinator.toCSS(env || {}) + value;
+    }
 };
 
 tree.Combinator = function (value) {
@@ -2855,7 +2877,7 @@ tree.mixin.Definition.prototype = {
                 i--;
                 continue;
             }
-			
+            
             if (name = this.params[i].name) {
                 if (this.params[i].variadic && args) {
                     varargs = [];
@@ -3086,7 +3108,7 @@ tree.Ruleset.prototype = {
 
         // push the current ruleset to the frames stack
         env.frames.unshift(ruleset);
-
+        
         // Evaluate imports
         if (ruleset.root || ruleset.allowImports || !ruleset.strictImports) {
             for (var i = 0; i < ruleset.rules.length; i++) {
@@ -3600,61 +3622,422 @@ tree.jsify = function (obj) {
 };
 
 })(require('./tree'));
-var name;
+//
+// browser.js - client-side engine
+//
+
+var isFileProtocol = /^(file|chrome(-extension)?|resource|qrc|app):/.test(window.location.protocol);
+
+less.env = less.env || (window.location.hostname == '127.0.0.1' ||
+                        window.location.hostname == '0.0.0.0'   ||
+                        window.location.hostname == 'localhost' ||
+                        window.location.port.length > 0         ||
+                        isFileProtocol                   ? 'development'
+                                                         : 'production');
+
+// Load styles asynchronously (default: false)
+//
+// This is set to `false` by default, so that the body
+// doesn't start loading before the stylesheets are parsed.
+// Setting this to `true` can result in flickering.
+//
+less.async = less.async || false;
+less.fileAsync = less.fileAsync || false;
+
+// Interval between watch polls
+less.poll = less.poll || (isFileProtocol ? 1000 : 1500);
+
+//
+// Watch mode
+//
+less.watch   = function () { return this.watchMode = true };
+less.unwatch = function () { return this.watchMode = false };
+
+if (less.env === 'development') {
+    less.optimization = 0;
+
+    if (/!watch/.test(location.hash)) {
+        less.watch();
+    }
+    var dumpLineNumbers = /!dumpLineNumbers:(comments|mediaquery|all)/.exec(location.hash);
+    if (dumpLineNumbers) {
+        less.dumpLineNumbers = dumpLineNumbers[1];
+    }
+    less.watchTimer = setInterval(function () {
+        if (less.watchMode) {
+            loadStyleSheets(function (e, root, _, sheet, env) {
+                if (root) {
+                    createCSS(root.toCSS(), sheet, env.lastModified);
+                }
+            });
+        }
+    }, less.poll);
+} else {
+    less.optimization = 3;
+}
+
+var cache;
+
+try {
+    cache = (typeof(window.localStorage) === 'undefined') ? null : window.localStorage;
+} catch (_) {
+    cache = null;
+}
+
+//
+// Get all <link> tags with the 'rel' attribute set to "stylesheet/less"
+//
+var links = document.getElementsByTagName('link');
+var typePattern = /^text\/(x-)?less$/;
+
+less.sheets = [];
+
+for (var i = 0; i < links.length; i++) {
+    if (links[i].rel === 'stylesheet/less' || (links[i].rel.match(/stylesheet/) &&
+       (links[i].type.match(typePattern)))) {
+        less.sheets.push(links[i]);
+    }
+}
+
+
+less.refresh = function (reload) {
+    var startTime, endTime;
+    startTime = endTime = new(Date);
+
+    loadStyleSheets(function (e, root, _, sheet, env) {
+        if (env.local) {
+            log("loading " + sheet.href + " from cache.");
+        } else {
+            log("parsed " + sheet.href + " successfully.");
+            createCSS(root.toCSS(), sheet, env.lastModified);
+        }
+        log("css for " + sheet.href + " generated in " + (new(Date) - endTime) + 'ms');
+        (env.remaining === 0) && log("css generated in " + (new(Date) - startTime) + 'ms');
+        endTime = new(Date);
+    }, reload);
+
+    loadStyles();
+};
+less.refreshStyles = loadStyles;
+
+less.refresh(less.env === 'development');
+
+function loadStyles() {
+    var styles = document.getElementsByTagName('style');
+    for (var i = 0; i < styles.length; i++) {
+        if (styles[i].type.match(typePattern)) {
+            new(less.Parser)({
+                filename: document.location.href.replace(/#.*$/, ''),
+                dumpLineNumbers: less.dumpLineNumbers
+            }).parse(styles[i].innerHTML || '', function (e, tree) {
+                var css = tree.toCSS();
+                var style = styles[i];
+                style.type = 'text/css';
+                if (style.styleSheet) {
+                    style.styleSheet.cssText = css;
+                } else {
+                    style.innerHTML = css;
+                }
+            });
+        }
+    }
+}
+
+function loadStyleSheets(callback, reload) {
+    for (var i = 0; i < less.sheets.length; i++) {
+        loadStyleSheet(less.sheets[i], callback, reload, less.sheets.length - (i + 1));
+    }
+}
 
 function loadStyleSheet(sheet, callback, reload, remaining) {
-    var endOfPath = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\')),
-        sheetName = name.slice(0, endOfPath + 1) + sheet.href,
-        contents = sheet.contents || {},
-        input = readFile(sheetName);
-        
-    contents[sheetName] = input;
-        
-    var parser = new less.Parser({
-        paths: [sheet.href.replace(/[\w\.-]+$/, '')],
-        contents: contents
-    });
-    parser.parse(input, function (e, root) {
-        if (e) {
-            return error(e, sheetName);
+    var contents  = sheet.contents || {};  // Passing a ref to top importing parser content cache trough 'sheet' arg.
+    var url       = window.location.href.replace(/[#?].*$/, '');
+    var href      = sheet.href.replace(/\?.*$/, '');
+    var css       = cache && cache.getItem(href);
+    var timestamp = cache && cache.getItem(href + ':timestamp');
+    var styles    = { css: css, timestamp: timestamp };
+
+    // Stylesheets in IE don't always return the full path
+    if (! /^[a-z-]+:/.test(href)) {
+        if (href.charAt(0) == "/") {
+            href = window.location.protocol + "//" + window.location.host + href;
+        } else {
+            href = url.slice(0, url.lastIndexOf('/') + 1) + href;
         }
-        try {
-            callback(e, root, sheet, { local: false, lastModified: 0, remaining: remaining });
-        } catch(e) {
-            error(e, sheetName);
+    }
+    xhr(sheet.href, sheet.type, function (data, lastModified) {
+        if (!reload && styles && lastModified &&
+           (new(Date)(lastModified).valueOf() ===
+            new(Date)(styles.timestamp).valueOf())) {
+            // Use local copy
+            createCSS(styles.css, sheet);
+            callback(null, null, data, sheet, { local: true, remaining: remaining });
+        } else {
+            // Use remote copy (re-parse)
+            try {
+                contents[href] = data;  // Updating top importing parser content cache
+                new(less.Parser)({
+                    optimization: less.optimization,
+                    paths: [href.replace(/[\w\.-]+$/, '')],
+                    mime: sheet.type,
+                    filename: href,
+                    'contents': contents,    // Passing top importing parser content cache ref down.
+                    dumpLineNumbers: less.dumpLineNumbers
+                }).parse(data, function (e, root) {
+                    if (e) { return error(e, href) }
+                    try {
+                        callback(e, root, data, sheet, { local: false, lastModified: lastModified, remaining: remaining });
+                        removeNode(document.getElementById('less-error-message:' + extractId(href)));
+                    } catch (e) {
+                        error(e, href);
+                    }
+                });
+            } catch (e) {
+                error(e, href);
+            }
         }
+    }, function (status, url) {
+        throw new(Error)("Couldn't load " + url + " (" + status + ")");
     });
 }
 
-function writeFile(filename, content) {
-    var fstream = new java.io.FileWriter(filename);
-    var out = new java.io.BufferedWriter(fstream);
-    out.write(content);
-    out.close();
+function extractId(href) {
+    return href.replace(/^[a-z]+:\/\/?[^\/]+/, '' )  // Remove protocol & domain
+               .replace(/^\//,                 '' )  // Remove root /
+               .replace(/\?.*$/,               '' )  // Remove query
+               .replace(/\.[^\.\/]+$/,         '' )  // Remove file extension
+               .replace(/[^\.\w-]+/g,          '-')  // Replace illegal characters
+               .replace(/\./g,                 ':'); // Replace dots with colons(for valid id)
 }
+
+function createCSS(styles, sheet, lastModified) {
+    var css;
+
+    // Strip the query-string
+    var href = sheet.href ? sheet.href.replace(/\?.*$/, '') : '';
+
+    // If there is no title set, use the filename, minus the extension
+    var id = 'less:' + (sheet.title || extractId(href));
+
+    // If the stylesheet doesn't exist, create a new node
+    if ((css = document.getElementById(id)) === null) {
+        css = document.createElement('style');
+        css.type = 'text/css';
+        if( sheet.media ){ css.media = sheet.media; }
+        css.id = id;
+        var nextEl = sheet && sheet.nextSibling || null;
+        document.getElementsByTagName('head')[0].insertBefore(css, nextEl);
+    }
+
+    if (css.styleSheet) { // IE
+        try {
+            css.styleSheet.cssText = styles;
+        } catch (e) {
+            throw new(Error)("Couldn't reassign styleSheet.cssText.");
+        }
+    } else {
+        (function (node) {
+            if (css.childNodes.length > 0) {
+                if (css.firstChild.nodeValue !== node.nodeValue) {
+                    css.replaceChild(node, css.firstChild);
+                }
+            } else {
+                css.appendChild(node);
+            }
+        })(document.createTextNode(styles));
+    }
+
+    // Don't update the local store if the file wasn't modified
+    if (lastModified && cache) {
+        log('saving ' + href + ' to cache.');
+        try {
+            cache.setItem(href, styles);
+            cache.setItem(href + ':timestamp', lastModified);
+        } catch(e) {
+            //TODO - could do with adding more robust error handling
+            log('failed to save');
+        }
+    }
+}
+
+function xhr(url, type, callback, errback) {
+    var xhr = getXMLHttpRequest();
+    var async = isFileProtocol ? less.fileAsync : less.async;
+
+    if (typeof(xhr.overrideMimeType) === 'function') {
+        xhr.overrideMimeType('text/css');
+    }
+    xhr.open('GET', url, async);
+    xhr.setRequestHeader('Accept', type || 'text/x-less, text/css; q=0.9, */*; q=0.5');
+    xhr.send(null);
+
+    if (isFileProtocol && !less.fileAsync) {
+        if (xhr.status === 0 || (xhr.status >= 200 && xhr.status < 300)) {
+            callback(xhr.responseText);
+        } else {
+            errback(xhr.status, url);
+        }
+    } else if (async) {
+        xhr.onreadystatechange = function () {
+            if (xhr.readyState == 4) {
+                handleResponse(xhr, callback, errback);
+            }
+        };
+    } else {
+        handleResponse(xhr, callback, errback);
+    }
+
+    function handleResponse(xhr, callback, errback) {
+        if (xhr.status >= 200 && xhr.status < 300) {
+            callback(xhr.responseText,
+                     xhr.getResponseHeader("Last-Modified"));
+        } else if (typeof(errback) === 'function') {
+            errback(xhr.status, url);
+        }
+    }
+}
+
+function getXMLHttpRequest() {
+    if (window.XMLHttpRequest) {
+        return new(XMLHttpRequest);
+    } else {
+        try {
+            return new(ActiveXObject)("MSXML2.XMLHTTP.3.0");
+        } catch (e) {
+            log("browser doesn't support AJAX.");
+            return null;
+        }
+    }
+}
+
+function removeNode(node) {
+    return node && node.parentNode.removeChild(node);
+}
+
+function log(str) {
+    if (less.env == 'development' && typeof(console) !== "undefined") { console.log('less: ' + str) }
+}
+
+function error(e, href) {
+    var id = 'less-error-message:' + extractId(href);
+    var template = '<li><label>{line}</label><pre class="{class}">{content}</pre></li>';
+    var elem = document.createElement('div'), timer, content, error = [];
+    var filename = e.filename || href;
+    var filenameNoPath = filename.match(/([^\/]+)$/)[1];
+
+    elem.id        = id;
+    elem.className = "less-error-message";
+
+    content = '<h3>'  + (e.message || 'There is an error in your .less file') +
+              '</h3>' + '<p>in <a href="' + filename   + '">' + filenameNoPath + "</a> ";
+
+    var errorline = function (e, i, classname) {
+        if (e.extract[i]) {
+            error.push(template.replace(/\{line\}/, parseInt(e.line) + (i - 1))
+                               .replace(/\{class\}/, classname)
+                               .replace(/\{content\}/, e.extract[i]));
+        }
+    };
+
+    if (e.stack) {
+        content += '<br/>' + e.stack.split('\n').slice(1).join('<br/>');
+    } else if (e.extract) {
+        errorline(e, 0, '');
+        errorline(e, 1, 'line');
+        errorline(e, 2, '');
+        content += 'on line ' + e.line + ', column ' + (e.column + 1) + ':</p>' +
+                    '<ul>' + error.join('') + '</ul>';
+    }
+    elem.innerHTML = content;
+
+    // CSS for error messages
+    createCSS([
+        '.less-error-message ul, .less-error-message li {',
+            'list-style-type: none;',
+            'margin-right: 15px;',
+            'padding: 4px 0;',
+            'margin: 0;',
+        '}',
+        '.less-error-message label {',
+            'font-size: 12px;',
+            'margin-right: 15px;',
+            'padding: 4px 0;',
+            'color: #cc7777;',
+        '}',
+        '.less-error-message pre {',
+            'color: #dd6666;',
+            'padding: 4px 0;',
+            'margin: 0;',
+            'display: inline-block;',
+        '}',
+        '.less-error-message pre.line {',
+            'color: #ff0000;',
+        '}',
+        '.less-error-message h3 {',
+            'font-size: 20px;',
+            'font-weight: bold;',
+            'padding: 15px 0 5px 0;',
+            'margin: 0;',
+        '}',
+        '.less-error-message a {',
+            'color: #10a',
+        '}',
+        '.less-error-message .error {',
+            'color: red;',
+            'font-weight: bold;',
+            'padding-bottom: 2px;',
+            'border-bottom: 1px dashed red;',
+        '}'
+    ].join('\n'), { title: 'error-message' });
+
+    elem.style.cssText = [
+        "font-family: Arial, sans-serif",
+        "border: 1px solid #e00",
+        "background-color: #eee",
+        "border-radius: 5px",
+        "-webkit-border-radius: 5px",
+        "-moz-border-radius: 5px",
+        "color: #e00",
+        "padding: 15px",
+        "margin-bottom: 15px"
+    ].join(';');
+
+    if (less.env == 'development') {
+        timer = setInterval(function () {
+            if (document.body) {
+                if (document.getElementById(id)) {
+                    document.body.replaceChild(elem, document.getElementById(id));
+                } else {
+                    document.body.insertBefore(elem, document.body.firstChild);
+                }
+                clearInterval(timer);
+            }
+        }, 10);
+    }
+}
+
+// amd.js
+//
+// Define Less as an AMD module.
+if (typeof define === "function" && define.amd) {
+    define("less", [], function () { return less; } );
+}
+
+})(
+    //fake window, defined on the top line
+    WIN,
+    //fake document
+    {
+        //empty links won't trigger other affair
+        getElementsByTagName:function(){return [];}
+    }
+    //undefined is just undefined
+);
 
 // Command line integration via Rhino
 (function (args) {
-    var output,
-        compress = false,
-        i;
-        
-    for(i = 0; i < args.length; i++) {
-        switch(args[i]) {
-            case "-x":
-                compress = true;
-                break;
-            default:
-                if (!name) {
-                    name = args[i];
-                } else if (!output) {
-                    output = args[i];
-                } else {
-                    print("unrecognised parameters");
-                    print("input_file [output_file] [-x]");
-                }
-        }
-    }
+    name = args[0];
+    var output = args[1];
 
     if (!name) {
         print('No files present in the fileset; Check your pattern match in build.xml');
@@ -3670,56 +4053,23 @@ function writeFile(filename, content) {
     }
 
     var result;
-    try {
-        var parser = new less.Parser();
-        parser.parse(input, function (e, root) {
-            if (e) {
-                error(e, name);
-                quit(1);
+    //change from less to WIN.less,
+    //cause less is add in to WIN at The MIAN function just Before
+    var parser = new WIN.less.Parser();
+    parser.parse(input, function (e, root) {
+        if (e) {
+            writeError(e);
+            quit(1);
+        } else {
+            result = root.toCSS();
+            if (output) {
+                writeFile(output, result);
+                print("Written to " + output);
             } else {
-                result = root.toCSS({compress: compress || false});
-                if (output) {
-                    writeFile(output, result);
-                    print("Written to " + output);
-                } else {
-                    print(result);
-                }
-                quit(0);
+                print(result);
             }
-        });
-    }
-    catch(e) {
-        error(e, name);
-        quit(1);
-    }
+            quit(0);
+        }
+    });
     print("done");
 }(arguments));
-
-function error(e, filename) {
-
-    var content = "Error : " + filename + "\n";
-    
-    filename = e.filename || filename;
-    
-    if (e.message) {
-        content += e.message + "\n";
-    }
-
-    var errorline = function (e, i, classname) {
-        if (e.extract[i]) {
-            content += 
-                String(parseInt(e.line) + (i - 1)) + 
-                ":" + e.extract[i] + "\n";
-        }
-    };
-
-    if (e.stack) {
-        content += e.stack;
-    } else if (e.extract) {
-        content += 'on line ' + e.line + ', column ' + (e.column + 1) + ':\n';
-        errorline(e, 0);
-        errorline(e, 1);
-        errorline(e, 2);
-    }
-   print(content);
-}


### PR DESCRIPTION
just change the arguments of the MAIN function of less 1.3.1;
by giving fake window, document;

1.define location.port is enough, cause only location.\* and location.port.length were used;
2.when document.getElementsByName return empty Array to links,
it won't trigger other document functions;

always use window.location instead of location
(replacing 4 location to window.location in MAIN function);

Use WIN.less instead of less in rhino function

Using this way, you need not to delete window, location or document used in less.js, just add some code around it to make a version running on rhiro 
