### PR TITLE
passing Parser import errors

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -99,7 +99,7 @@ less.Parser = function Parser(env) {
 
                 callback(e, root, imported);
 
-                if (that.queue.length === 0) { finish(e) }       // Call `finish` if we're done importing
+                if (that.queue.length === 0) { finish(that.error) }       // Call `finish` if we're done importing
             }, env);
         }
     };


### PR DESCRIPTION
parser.imports stored any errors in .error, but only returned an error to the callback on that last import in the queue.

This commit makes it return the stored error (that.error).

issue #463

Will write a failing test if needed. - Import 2 files, error in the first.
