### PR TITLE
Allow version numbering of @imported less files so as to enabled browser cache busting when versions change.

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -162,6 +162,7 @@ function loadStyleSheet(sheet, callback, reload, remaining) {
             try {
                 contents[href] = data;  // Updating top importing parser content cache
                 new(less.Parser)({
+                    suffix: sheet.suffix | false,
                     optimization: less.optimization,
                     paths: [href.replace(/[\w\.-]+$/, '')],
                     mime: sheet.type,

--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -76,6 +76,7 @@ less.Parser = function Parser(env) {
 
     var imports = this.imports = {
         paths: env && env.paths || [],  // Search paths, when importing
+        suffix: env && env.suffix || false, //Suffix to append to imported files when loading to bust browser caches
         queue: [],                      // Files which haven't been imported yet
         files: {},                      // Holds the imported parse trees
         contents: env.contents,         // Holds the imported file contents
@@ -88,7 +89,7 @@ less.Parser = function Parser(env) {
             //
             // Import a file asynchronously
             //
-            less.Parser.importer(path, this.paths, function (e, root) {
+            less.Parser.importer(path, this.paths, this.suffix, function (e, root) {
                 that.queue.splice(that.queue.indexOf(path), 1); // Remove the path from the queue
 
                 var imported = path in that.files;
@@ -1481,15 +1482,18 @@ if (less.mode === 'browser' || less.mode === 'rhino') {
     //
     // Used by `@import` directives
     //
-    less.Parser.importer = function (path, paths, callback, env) {
+    less.Parser.importer = function (path, paths, suffix, callback, env) {
         if (!/^([a-z-]+:)?\//.test(path) && paths.length > 0) {
             path = paths[0] + path;
+        }
+        if (suffix) {
+            path = path + suffix;
         }
         // We pass `true` as 3rd argument, to force the reload of the import.
         // This is so we can get the syntax tree as opposed to just the CSS output,
         // as we need this to evaluate the current stylesheet.
         // __ Now using the hack of passing a ref to top parser's content cache in the 1st arg. __
-        loadStyleSheet({ href: path, title: path, type: env.mime, contents: env.contents }, function (e) {
+        loadStyleSheet({ href: path, title: path, suffix: suffix, type: env.mime, contents: env.contents }, function (e) {
             if (e && typeof(env.errback) === "function") {
                 env.errback.call(null, path, paths, callback, env);
             } else {


### PR DESCRIPTION
...oaded by the browser so that you can bust the browser cache with a version number. Use like so: new(less.Parser)({suffix: '?version=12345'});

We're using less.js at Ning to recompile individual social networks' css when network owners change style paramerters.  This makes it so they can see a live update of what the changes to their color scheme, etc. will look like.  For this purpose, we _want_ a browser to cache the less files so that it's speedy to compile something with a lot of imports.  But we also want to be able to _bust_ that cache when we change the less styles so they don't get an old version of the less to customize.  So we added in this suffix parameter to less.js to let us do that.  Now we can still cache @import files on the users' browser, but bust the cache by updating the suffix when we make changes. 
