### PR TITLE
lessc: Defend against missing output directories

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -136,6 +136,9 @@ var parseLessFile = function (e, data) {
                 if (output) {
                     ensureDirectory(output);
                     fs.writeFileSync(output, css, 'utf8');
+                    if (options.verbose) {
+                        console.log('lessc: wrote ' + output);
+                    }
                 } else {
                     sys.print(css);
                 }


### PR DESCRIPTION
If an output specifies a destination inside a directory that doesn't exist, it blows up unceremoniously. Let's avoid that.

Also, uses modern fs.writeFileSync instead of manual open/write/closeSync.
