### PR TITLE
Flexible AMD naming

### DIFF
--- a/build/amd.js
+++ b/build/amd.js
@@ -2,5 +2,5 @@
 //
 // Define Less as an AMD module.
 if (typeof define === "function" && define.amd) {
-    define("less", [], function () { return less; } );
+    define(function () { return less; } );
 }


### PR DESCRIPTION
Previously (in #933), it was discussed to include improved amd support.

The current amd support will work perfectly for most amd needs by just adding the included change here.

The point is that modules are designed to be portable. That is, I can load `less` as any name I choose, allowing multiple version support, alternative naming, path variations etc.

There are no consequences of removing this naming - a file called `less.js` in the base amd folder will naturally correspond to the named amd module, `less`.

This change would be much appreciated so that I no longer need to use a fork in [require-less](https://github.com/guybedford/require-less).
