### PR TITLE
Optionally use mkdirp to ensure output destination directory exists.

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -2,6 +2,7 @@
 
 var path = require('path'),
     fs = require('fs'),
+    mkdirp = require('mkdirp'),
     sys = require('util'),
     os = require('os');
 
@@ -123,9 +124,10 @@ if (! input) {
 
 var ensureDirectory = function (filepath) {
     var dir = path.dirname(filepath),
+        cmd = mkdirp && mkdirp.sync || fs.mkdirSync,
         existsSync = fs.existsSync || path.existsSync;
     if (!existsSync(dir)) {
-        fs.mkdirSync(dir);
+        cmd(dir);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   "main"          : "./lib/less/index",
   "directories"   : { "test": "./test" },
   "engines"       : { "node": ">=0.4.2" },
-  "optionalDependencies" : { "ycssmin": ">=1.0.1" },
+  "optionalDependencies" : {
+    "mkdirp": "~0.3.4",
+    "ycssmin": ">=1.0.1"
+  },
   "devDependencies" : { "diff": "~1.0" },
   "scripts": {
    "test": "make test"


### PR DESCRIPTION
`mkdirp` is a very widely used module, trivial in size, and I probably should have used it in the first place.

I would write tests, but there are currently none written for the `lessc` utility. I would feel better about doing so if there was a recognizable testing framework already in use (mocha, nodeunit, vows, etc). Rest assured, `mkdirp` performs as advertised.

This fixes issue #1099
