### PR TITLE
Avoid error when optionalDependency 'request' is not present.

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -1,7 +1,6 @@
 var path = require('path'),
     sys = require('util'),
     url = require('url'),
-    request = require('request'),
     fs = require('fs');
 
 var less = {
@@ -137,8 +136,9 @@ less.Parser.importer = function (file, paths, callback, env) {
     
     var isUrl = isUrlRe.test( file );
     if (isUrl || isUrlRe.test(paths[0])) {
-    
-        if (!request) {
+        try {
+            var request = require('request');
+        } catch (ex) {
             callback({ type: 'File', message: "optional dependency 'request' required to import over http(s)\n" });
             return;
         }


### PR DESCRIPTION
Can't even run the tests without this optional dependency being required safely.

I'm narrowing down another issue with the unguarded `require('mime')` in the `data-uri` function, but I thought I'd get this pull request out there to unblock testing.
