### PR TITLE
Provide fallback 'mime' object that covers 80% case of data-uri usage.

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -375,7 +375,13 @@ tree.functions = {
 
         // detect the mimetype if not given
         if (arguments.length < 2) {
-            var mime = require('mime');
+            var mime;
+            try {
+                mime = require('mime');
+            } catch (ex) {
+                mime = tree._mime;
+            }
+
             path = mimetype;
             mimetype = mime.lookup(path);
 
@@ -395,6 +401,34 @@ tree.functions = {
 
         var uri = "'data:"+mimetype+','+buf+"'";
         return new(tree.URL)(new(tree.Anonymous)(uri));
+    }
+};
+
+// these static methods are used as a fallback when the optional 'mime' dependency is missing
+tree._mime = {
+    // this map is intentionally incomplete
+    // if you want more, install 'mime' dep
+    _types: {
+        '.htm' : 'text/html',
+        '.html': 'text/html',
+        '.gif' : 'image/gif',
+        '.jpg' : 'image/jpeg',
+        '.jpeg': 'image/jpeg',
+        '.png' : 'image/png'
+    },
+    lookup: function (filepath) {
+        var ext = require('path').extname(filepath),
+            type = tree._mime._types[ext];
+        if (type === undefined) {
+            throw new Error('Optional dependency "mime" is required for ' + ext);
+        }
+        return type;
+    },
+    charsets: {
+        lookup: function (type) {
+            // assumes all text types are UTF-8
+            return type && (/^text\//).test(type) ? 'UTF-8' : '';
+        }
     }
 };
 


### PR DESCRIPTION
This is the final result of the diff hinted at in #1123 (I moved it into a static object to enable future unit testing).

Throwing the error when `mime` is missing (like the `request` workaround) seems a bit blunt. This stays compatible with the browser version, while ensuring the most commonly-embedded types always work, regardless of the state of the dependencies.
