### PR TITLE
Source maps generation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
 # Run all tests
 #
-test: 
+test:
 	node test/less-test.js
 
 #
@@ -15,11 +15,12 @@ benchmark:
 #
 SRC = lib/less
 HEADER = build/header.js
-VERSION = `cat package.json | grep version \
-														| grep -o '[0-9]\.[0-9]\.[0-9]\+'`
+VERSION = ${shell cat package.json | grep version \
+														| grep -o '[0-9]\.[0-9]\.[0-9]\+'}
 DIST = dist/less-${VERSION}.js
 RHINO = dist/less-rhino-${VERSION}.js
 DIST_MIN = dist/less-${VERSION}.min.js
+DIST_MAP = dist/less-${VERSION}.min.map
 
 browser-prepare: DIST := test/browser/less.js
 
@@ -42,10 +43,10 @@ less:
 	      build/amd.js >> ${DIST}
 	@@echo "})(window);" >> ${DIST}
 	@@echo ${DIST} built.
-	
+
 browser-prepare: less
 	node test/browser-test-prepare.js
-	
+
 browser-test: browser-prepare
 	phantomjs test/browser/phantom-runner.js
 
@@ -67,7 +68,10 @@ rhino:
 
 min: less
 	@@echo minifying...
-	@@uglifyjs ${DIST} > ${DIST_MIN}
+	@@cd ${dir ${DIST}} && \
+				../node_modules/uglify-js/bin/uglifyjs \
+				--source-map ${notdir ${DIST_MAP}} \
+		    ${notdir ${DIST}} > ${notdir ${DIST_MIN}}
 	@@echo ${DIST_MIN} built.
 
 alpha: min

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "mkdirp": "~0.3.4",
     "ycssmin": ">=1.0.1"
   },
-  "devDependencies" : { "diff": "~1.0" },
+  "devDependencies" : {
+    "diff": "~1.0",
+    "uglify-js": "2.2.x"
+  },
   "scripts": {
    "test": "make test"
   },


### PR DESCRIPTION
jQuery got source maps in the recent 1.9 release, so I figured they must be reasonably stable and well-supported.

This change modifies `make min` to generate a source map. Unfortunately, uglifyjs assumes it's run in the output directory when generating source maps, so I had to hack the Makefile a bit to make this happen.

It would be really nice if less.js 1.4.0 had source maps, so I hope you will consider this change. Also, I'd be happy to add source maps to the recent releases in dist/ in a separate pull request, if that is desirable.
