### PR TITLE
Added support and tests for !merge() syntax #700

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1373,12 +1373,13 @@ less.Parser = function Parser(env) {
                 var separator;
                 if (input.charAt(i) === '!') {
                     if ($(/^! *merge\(/)) {
-                        if (input.charAt(i) === ")") {
-                            separator = " ";
-                        } else {
-                            separator = $(/[^)]/);
-                        }
-                        expect(")");
+                        separator = expect(/^ *space|comma */);
+						if (separator) {
+						    separator = (separator.trim() === 'space')
+						        ? ' ' 
+							    : ',';
+						}
+                        expect(')');
                     }
                 }
                 return separator;

--- a/lib/less/tree/ruleset.js
+++ b/lib/less/tree/ruleset.js
@@ -462,9 +462,11 @@ tree.Ruleset.prototype = {
             parts = groups[k];
 
             if (parts.length > 1) {
-                parts[0].value = new (tree.Value)(parts.map(function (p) {
-                    return p.value;
-                }), rule.merge);
+				rule = parts[0];
+				
+				rule.value = new ((rule.merge === ' ') ? tree.Expression : tree.Value)(parts.map(function (p) {
+					return p.value;
+				}));
             }
         });
     }

--- a/lib/less/tree/value.js
+++ b/lib/less/tree/value.js
@@ -1,9 +1,8 @@
 (function (tree) {
 
-tree.Value = function (value, separator) {
+tree.Value = function (value) {
     this.value = value;
     this.is = 'value';
-    this.separator = separator ? separator : ",";
 };
 tree.Value.prototype = {
     eval: function (env) {
@@ -18,7 +17,7 @@ tree.Value.prototype = {
     toCSS: function (env) {
         return this.value.map(function (e) {
             return e.toCSS(env);
-        }).join(this.separator + ((env.compress || this.separator === " ") ? "" : " "));
+        }).join(env.compress ? ',' : ', ');
     }
 };
 

--- a/test/css/merge.css
+++ b/test/css/merge.css
@@ -24,3 +24,6 @@
   transform: rotate(90deg) skew(30deg);
   transform: scale(2, 4) !important;
 }
+.test8 {
+  transform: scale(2, 4);
+}

--- a/test/less/merge.less
+++ b/test/less/merge.less
@@ -1,23 +1,23 @@
 .first-transform() {
-  transform: rotate(90deg) skew(30deg) !merge();
+  transform: rotate(90deg) skew(30deg) !merge(space);
 }
 .second-transform() {
-  transform: scale(2,4) !merge();
+  transform: scale(2,4) !merge(space);
 }
 .third-transform() {
   transform: scaleX(45deg);
 }
 .fourth-transform() {
-  transform: scaleX(45deg) !merge(,);
+  transform: scaleX(45deg) !merge(comma);
 }
 .fifth-transform() {
-  transform: scale(2,4) !important !merge();
+  transform: scale(2,4) !important !merge(space);
 }
 .first-background() {
-  background: url(img1.png) !merge(,);
+  background: url(img1.png) !merge(comma);
 }
 .second-background() {
-  background: url(img2.png) !merge(,);
+  background: url(img2.png) !merge(comma);
 }
 
 .test1 {
@@ -31,7 +31,7 @@
   .third-transform();
 }
 .test3 {
-  // Can merge values with explicit separator 
+  // Can merge values with comma separator
   .first-background();
   .second-background();
 }
@@ -54,4 +54,8 @@
   // Wont merge values from mixins that merked as !important, for backwards compatibility with css 
   .first-transform();
   .second-transform() !important;
+}
+.test8 {
+  // Ignores !merge if no peers found
+  .second-transform();
 }


### PR DESCRIPTION
Support for !merge() directive that i proposed in issue #700.
The !merge() syntax allows for aggregating values from different sources into single property for use with properties like `background` and `transform`.

See [here](https://github.com/cloudhead/less.js/issues/700#issuecomment-13043661) for more info on the syntax.
