### PR TITLE
Implement syntax in gh #1185 for @import options.  Implement multiple & ...

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1198,16 +1198,45 @@ less.Parser = function Parser(env) {
 
                 var dir = $(/^@import(?:-(once|multiple))?\s+/);
 
+                var options = (dir ? $(this.importOptions) : null) || {};
+
                 if (dir && (path = $(this.entities.quoted) || $(this.entities.url))) {
                     features = $(this.mediaFeatures);
                     if ($(';')) {
                         features = features && new(tree.Value)(features);
-                        var importOnce = dir[1] !== 'multiple';
-                        return new(tree.Import)(path, imports, features, importOnce, index, env.rootpath);
+                        if (dir[1] === 'multiple') { options.multiple = true; }
+                        return new(tree.Import)(path, imports, features, options, index, env.rootpath);
                     }
                 }
 
                 restore();
+            },
+
+            importOptions: function() {
+                var o, options = {};
+
+                // single option, no parens
+                if (o = $(this.importOption)) {
+                    options[o] = true;
+                    return options;
+                }
+                // list of options, surrounded by parens
+                if (! $('(')) { return null; }
+                do {
+                    if (o = $(this.importOption)) {
+                        options[o] = true;
+                        if (! $(',')) { break }
+                    }
+                } while (o);
+                expect(')');
+                return options;
+            },
+
+            importOption: function() {
+                var opt = $(/^(less|multiple)/);
+                if (opt) {
+                    return opt[1];
+                }
             },
 
             mediaFeature: function () {

--- a/lib/less/tree/import.js
+++ b/lib/less/tree/import.js
@@ -11,10 +11,10 @@
 // `import,push`, we also pass it a callback, which it'll call once
 // the file has been fetched, and parsed.
 //
-tree.Import = function (path, imports, features, once, index, rootpath) {
+tree.Import = function (path, imports, features, options, index, rootpath) {
     var that = this;
 
-    this.once = once;
+    this.options = options;
     this.index = index;
     this._path = path;
     this.features = features;
@@ -28,12 +28,13 @@ tree.Import = function (path, imports, features, once, index, rootpath) {
     }
 
     this.css = /css([\?;].*)?$/.test(this.path);
+    if (this.options.less) { this.css = false; }
 
     // Only pre-compile .less files
     if (! this.css) {
         imports.push(this.path, function (e, root, imported) {
             if (e) { e.index = index; }
-            if (imported && that.once) { that.skip = imported; }
+            if (imported && !that.options.multiple) { that.skip = imported; }
             that.root = root || new(tree.Ruleset)([], []);
         });
     }
@@ -68,7 +69,7 @@ tree.Import.prototype = {
         if (this.skip) { return []; }
 
         if (this.css) {
-            return new(tree.Import)(this._path, null, features, this.once, this.index, this.rootpath);
+            return new(tree.Import)(this._path, null, features, this.options, this.index, this.rootpath);
         } else {
             ruleset = new(tree.Ruleset)([], this.root.rules.slice(0));
 

--- a/test/css/import.css
+++ b/test/css/import.css
@@ -21,3 +21,18 @@
   height: 10px;
   color: #ff0000;
 }
+@media screen and (max-width: 601px) {
+  #css {
+    color: yellow;
+  }
+}
+@media screen and (max-width: 602px) {
+  body {
+    width: 100%;
+  }
+}
+@media screen and (max-width: 603px) {
+  #css {
+    color: yellow;
+  }
+}

--- a/test/less/import.less
+++ b/test/less/import.less
@@ -13,3 +13,9 @@
 @import "import/import-test-e" screen and (max-width: 600px);
 
 @import url("import/import-test-a.less");
+
+@import less "import/import-test-d.css" screen and (max-width: 601px);
+
+@import multiple "import/import-test-e" screen and (max-width: 602px);
+
+@import (less, multiple) url("import/import-test-d.css") screen and (max-width: 603px);


### PR DESCRIPTION
...less.

First step in implementing syntax for @import options, proposed in
https://github.com/cloudhead/less.js/issues/1185#issuecomment-13710620
(steps (1) and (2)).

I've implemented the 'multiple' and 'less' options.  One could trivially
add 'once' and 'css' options as well, if there was need.  Proposed
"silent" and "inline" options are deferred for future work.

I left the existing "@import-multiple" and "@import-once" syntax in place,
although the proposal is for this to be deprecated once the new option
syntax is in place.
