### PR TITLE
fix url paths escape bug in dumpLineNumbers function  

### DIFF
--- a/lib/less/tree.js
+++ b/lib/less/tree.js
@@ -24,7 +24,7 @@ tree.debugInfo.asComment = function(ctx) {
 
 tree.debugInfo.asMediaQuery = function(ctx) {
     return '@media -sass-debug-info{filename{font-family:' +
-        ('file://' + ctx.debugInfo.fileName).replace(/[\/:.]/g, '\\$&') +
+        ('file://' + ctx.debugInfo.fileName).replace(/([.:/\\])/g, function(a){if(a=='\\') a = '\/'; return '\\' + a}) +
         '}line{font-family:\\00003' + ctx.debugInfo.lineNumber + '}}\n';
 };
 


### PR DESCRIPTION
less node modules in windows system ,path sep is '\',the old regexp is not match it. I whrite a new regexp and fix it;
example:
url: "file://D:\workspace\test\style.less";
error result: "file:\/\/C:\workspace\test\style.less", it's not replace "\";
the right result is: "file:\/\/D:\/workspace\/test\/style\/.less",replace "\" to "\/";
