### PR TITLE
Fixes small typo in command prompt usage text

### DIFF
--- a/lib/less/lessc_helper.js
+++ b/lib/less/lessc_helper.js
@@ -52,7 +52,7 @@ var lessc_helper = {
         sys.puts("                          media query which is compatible with the SASS");
         sys.puts("                          format, and 'all' which will do both.");
         sys.puts("  -rp, --rootpath=URL     Set rootpath for url rewriting in relative imports and urls.");
-        sys.puts("                          Works with or withour the relative-urls option.");
+        sys.puts("                          Works with or without the relative-urls option.");
         sys.puts("  -ru, --relative-urls    re-write relative urls to the base less file.");
         sys.puts("  -sm, --strict-maths-off Make maths not require brackets, which is similar behaviour");
         sys.puts("                          to before 1.4. This option is for compatability and may be");


### PR DESCRIPTION
Because what kind of @editor would I be if I didn't submit a fix here.
