### PR TITLE
Add Less license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,5 +63,11 @@
     "stylesheet",
     "variables in css",
     "css less"
+  ],
+  "licenses": [
+    {
+      "type": "Apache v2",
+      "url": "https://github.com/cloudhead/less.js/blob/master/LICENSE"
+    }
   ]
 }


### PR DESCRIPTION
NPM spec allows for the Less.js license in the package.json, so for completeness, I added it in :)

https://npmjs.org/doc/json.html
