### PR TITLE
Improve comments stripping in compress

### DIFF
--- a/lib/less/tree/comment.js
+++ b/lib/less/tree/comment.js
@@ -7,6 +7,7 @@ tree.Comment = function (value, silent) {
 tree.Comment.prototype = {
     type: "Comment",
     toCSS: function (env) {
+        if (this.value.match(/\/\*!/)) return this.value;
         return env.compress ? '' : this.value;
     },
     eval: function () { return this }


### PR DESCRIPTION
Leave comments as is during compress if starts with exclamation mark.

There will be 3 types of comments

```
// less code comment
/* striped css comment */
/*! ignored comment */
```

`lessc --compress` will produce css `/*! ignored comment */`
