### PR TITLE
Refactor Node.js detection in parser.js to fix an issue when global.window has been set.

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -7,7 +7,7 @@ if (typeof environment === "object" && ({}).toString.call(environment) === "[obj
     else                                { less = window.less = {} }
     tree = less.tree = {};
     less.mode = 'rhino';
-} else if (typeof(window) === 'undefined') {
+} else if (typeof(exports) === 'object') {
     // Node.js
     less = exports,
     tree = require('./tree');


### PR DESCRIPTION
Node.js detection fails if any node modules define `global.window`.

I ran into this issue when trying to use [wheat](https://github.com/creationix/wheat) and LESS in node. This code currently throws an exception in 1.3.3:

``` javascript
var wheat = require('wheat'),
    less = require('less');
```

This happens because Wheat uses a version of Google Prettify that defines `global.window` which throws off the current Node.js detection in `parser.js`. 
