### PR TITLE
Very small fix for less error output (cloudhead/less.js#1282)

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -259,7 +259,9 @@ less.Parser = function Parser(env) {
             lines[line + 1]
         ];
     }
-    LessError.prototype = Error.prototype;
+    LessError.prototype = new Error();
+    LessError.prototype.constructor = LessError;
+    
 
     this.env = env = env || {};
 


### PR DESCRIPTION
Make LessError inherit from Error to get standard Error methods and have it handled correctly in recess (twitter/recess#73) as part of grunt-recess (sindresorhus/grunt-recess#30)

Fix for issue cloudhead/less.js#1282
