### PR TITLE
Add missing var statement in anonymousValue function

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1223,6 +1223,7 @@ less.Parser = function Parser(env) {
                 }
             },
             anonymousValue: function () {
+                var match;
                 if (match = /^([^@+\/'"*`(;{}-]*);/.exec(chunks[j])) {
                     i += match[0].length - 1;
                     return new(tree.Anonymous)(match[1]);


### PR DESCRIPTION
the match variable was being implicitly declared in the global scope. Made 1.4.0-b4 fail when I was running it under rhino.
