### PR TITLE
Catch errors thrown by root.toCSS() in less.render()

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -21,15 +21,17 @@ var less = {
 
         if (callback) {
             parser.parse(input, function (e, root) {
-                callback(e, root && root.toCSS && root.toCSS(options));
+                try { callback(e, root && root.toCSS && root.toCSS(options)); } 
+                catch (err) { callback(err); }
             });
         } else {
             ee = new(require('events').EventEmitter);
 
             process.nextTick(function () {
                 parser.parse(input, function (e, root) {
-                    if (e) { ee.emit('error', e) }
-                    else   { ee.emit('success', root.toCSS(options)) }
+                    if (e) { return ee.emit('error', e); }
+                    try { ee.emit('success', root.toCSS(options)); } 
+                    catch (err) { ee.emit('error', err); }
                 });
             });
             return ee;


### PR DESCRIPTION
Calling `root.toCSS()` can cause a `LessError` to be thrown:
https://github.com/cloudhead/less.js/blob/master/lib/less/parser.js#L424

The `less.render()` function (which takes a callback or returns an `EventEmitter`) calls `toCSS()` without wrapping it in a try/catch block, which breaks node-style callback conventions and leads to a very cryptic `[object, Object]` being logged.
https://github.com/cloudhead/less.js/blob/master/lib/less/index.js#L24

Passes both `make test` and `make browser-test`.
