### PR TITLE
Fix global variable leaks

### DIFF
--- a/lib/less/extend-visitor.js
+++ b/lib/less/extend-visitor.js
@@ -96,7 +96,7 @@
             // this is also the most expensive.. and a match on one selector can cause an extension of a selector we had already processed if
             // we look at each selector at a time, as is done in visitRuleset
 
-            var extendIndex, targetExtendIndex, matches, extendsToAdd = [], newSelector, extendVisitor = this, selectorPath, extend, targetExtend;
+            var extendIndex, targetExtendIndex, matches, extendsToAdd = [], newSelector, extendVisitor = this, selectorPath, extend, targetExtend, newExtend;
 
             iterationCount = iterationCount || 0;
 
@@ -202,7 +202,7 @@
             if (rulesetNode.root) {
                 return;
             }
-            var matches, pathIndex, extendIndex, allExtends = this.allExtendsStack[this.allExtendsStack.length-1], selectorsToAdd = [], extendVisitor = this;
+            var matches, pathIndex, extendIndex, allExtends = this.allExtendsStack[this.allExtendsStack.length-1], selectorsToAdd = [], extendVisitor = this, selectorPath;
 
             // look at each selector path in the ruleset, find any extend matches and then copy, find and replace
 
@@ -324,7 +324,8 @@
                 path = [],
                 matchIndex,
                 selector,
-                firstElement;
+                firstElement,
+                match;
 
             for (matchIndex = 0; matchIndex < matches.length; matchIndex++) {
                 match = matches[matchIndex];

--- a/lib/less/lessc_helper.js
+++ b/lib/less/lessc_helper.js
@@ -1,7 +1,7 @@
 // lessc_helper.js
 //
 //      helper functions for lessc
-sys = require('util');
+var sys = require('util');
 
 var lessc_helper = {
 

--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1097,7 +1097,7 @@ less.Parser = function Parser(env) {
             // we deal with this in *combinator.js*.
             //
             combinator: function () {
-                var match, c = input.charAt(i);
+                var c = input.charAt(i);
 
                 if (c === '>' || c === '+' || c === '~' || c === '|') {
                     i++;
@@ -1119,7 +1119,7 @@ less.Parser = function Parser(env) {
             // Selectors are made out of one or more Elements, see above.
             //
             selector: function () {
-                var sel, e, elements = [], c, match, extend, extendList = [];
+                var sel, e, elements = [], c, extend, extendList = [];
 
                 while ((extend = $(this.extend)) || (e = $(this.element))) {
                     if (extend) {
@@ -1171,7 +1171,7 @@ less.Parser = function Parser(env) {
             // div, .class, body > p {...}
             //
             ruleset: function () {
-                var selectors = [], s, rules, match, debugInfo;
+                var selectors = [], s, rules, debugInfo;
                 
                 save();
 
@@ -1197,7 +1197,7 @@ less.Parser = function Parser(env) {
                 }
             },
             rule: function (tryAnonymous) {
-                var name, value, c = input.charAt(i), important, match;
+                var name, value, c = input.charAt(i), important;
                 save();
 
                 if (c === '.' || c === '#' || c === '&') { return }
@@ -1223,6 +1223,7 @@ less.Parser = function Parser(env) {
                 }
             },
             anonymousValue: function () {
+                var match;
                 if (match = /^([^@+\/'"*`(;{}-]*);/.exec(chunks[j])) {
                     i += match[0].length - 1;
                     return new(tree.Anonymous)(match[1]);

--- a/lib/less/rhino.js
+++ b/lib/less/rhino.js
@@ -37,7 +37,8 @@ function writeFile(filename, content) {
 (function (args) {
     var output,
         compress = false,
-        i;
+        i,
+        path;
         
     for(i = 0; i < args.length; i++) {
         switch(args[i]) {

--- a/lib/less/tree/extend.js
+++ b/lib/less/tree/extend.js
@@ -29,7 +29,8 @@ tree.Extend.prototype = {
         return new(tree.Extend)(this.selector, this.option, this.index);
     },
     findSelfSelectors: function (selectors) {
-        var selfElements = [];
+        var selfElements = [],
+            i;
 
         for(i = 0; i < selectors.length; i++) {
             selfElements = selfElements.concat(selectors[i].elements);

--- a/test/browser/phantom-runner.js
+++ b/test/browser/phantom-runner.js
@@ -88,7 +88,7 @@ function testPage(url) {
                     if (list && list.length > 0) {
                       console.log('');
                       console.log(list.length + ' test(s) FAILED:');
-                      for (i = 0; i < list.length; ++i) {
+                      for (var i = 0; i < list.length; ++i) {
                           var el = list[i],
                               desc = el.querySelector('.description'),
                               msg = el.querySelector('.resultMessage.fail');


### PR DESCRIPTION
At the moment this library has loads of global variable leaks and they're breaking my unit tests.  This change declares all the variables that are used.  I haven't attempted to fix the leaks in `dist` files as I assume those will get fixed automatically when you rebuild.
