### PR TITLE
Detect when options is empty in the parseEnv

### DIFF
--- a/lib/less/env.js
+++ b/lib/less/env.js
@@ -29,13 +29,13 @@
         if (!this.files) { this.files = {}; }
 
         if (!this.currentFileInfo) {
-            var filename = options.filename || "input";
-            options.filename = null;
+            var filename = options && options.filename || "input";
+            if (options && options.filename) { options.filename = null; }
             var entryPath = filename.replace(/[^\/\\]*$/, "");
             this.currentFileInfo = {
                 filename: filename,
                 relativeUrls: this.relativeUrls,
-                rootpath: options.rootpath || "",
+                rootpath: options && options.rootpath || "",
                 currentDirectory: entryPath,
                 entryPath: entryPath,
                 rootFilename: filename


### PR DESCRIPTION
Potential fix for: https://github.com/cloudhead/less.js/issues/1373

Just adding some checks around the options object
