### PR TITLE
Add .gitattributes to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+.gitattributes


### PR DESCRIPTION
One of the dependencies, hawk, uses CRLF line endings. If you use less
in your project and check in node_modules to source control, git sees
the .gitattributes that is packaged with less and obeys it for that
subdirectory. This gives you line ending conflicts with hawk.

.gitattributes is not relevant to the packaged module and should not be
included anyway.
