### PR TITLE
Property nesting

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -95,7 +95,8 @@ var less = {
  'call',       'url',        'alpha',              'import',
  'mixin',      'comment',    'anonymous',          'value',
  'javascript', 'assignment', 'condition',          'paren',
- 'media',      'unicode-descriptor', 'negative',   'extend'
+ 'media',      'unicode-descriptor', 'negative',   'extend',
+ 'rulegroup'
 ].forEach(function (n) {
     require('./tree/' + n);
 });

--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1203,6 +1203,13 @@ less.Parser = function Parser(env) {
                 if (c === '.' || c === '#' || c === '&') { return }
 
                 if (name = $(this.variable) || $(this.property)) {
+                    
+                    // grouped rules
+                    if (input.charAt(i) === '{') {
+                        value = $(this.block);
+                        return new(tree.RuleGroup)(name, value);
+                    }
+                    
                     // prefer to try to parse first if its a variable or we are compressing
                     // but always fallback on the other one
                     value = !tryAnonymous && (env.compress || (name.charAt(0) === '@')) ?

--- a/lib/less/tree/rulegroup.js
+++ b/lib/less/tree/rulegroup.js
@@ -1,0 +1,36 @@
+(function (tree) {
+
+tree.RuleGroup = function (name, group){
+    this.name = name;
+    this.group = group;
+};
+
+tree.RuleGroup.prototype = {
+    constructor: tree.RuleGroup,
+    type: "RuleGroup",
+    toCSS: function(env){
+        var result = '';
+        
+        for(var i = 0, imax = this.group.length; i < imax; i++){
+            result += this.name  + '-' + this.group[i].toCSS(env);
+        }
+
+        return result;
+    },
+    eval: function (env){
+        return new(tree.RuleGroup)(this.name, eval_Group(env, this.group));
+    }
+};
+
+
+function eval_Group (env, group) {
+    var array = [],
+        imax = group.length,
+        i = 0;
+    for(; i < imax; i++){
+        array[i] = group[i].eval(env);
+    }
+    return array;
+}
+
+})(require('../tree'));

--- a/test/css/rulegroup.css
+++ b/test/css/rulegroup.css
@@ -1,0 +1,10 @@
+._x1 {
+  font-size: 1em;font-family: sans-serif;
+  margin: auto;
+  boder-right: solid 1px green;boder-left: dotted 1px green;
+}
+._x2 {
+  font-size: 1em;font-family: sans-serif;
+  margin: auto;
+  boder-right: solid 1px #000000;boder-left: dotted 1px #000000;
+}

--- a/test/less/rulegroup.less
+++ b/test/less/rulegroup.less
@@ -1,0 +1,28 @@
+._x1 {
+	font: {
+		size: 1em;
+		family: sans-serif;
+	}
+	margin: auto;
+	
+	boder: {
+		right: solid 1px green;
+		left: dotted 1px green;
+	}
+}
+
+@size: 1em;
+@color: black;
+
+._x2 {
+	font: {
+		size: @size;
+		family: sans-serif;
+	}
+	margin: auto;
+	
+	boder: {
+		right: solid 1px @color;
+		left: dotted 1px @color;
+	}
+}


### PR DESCRIPTION
Hi,

added rule groups. Example:

``` sass
body {
    text: {
        align: center;
        transform: uppercase;
    }
}
```

parsed to

``` css
body {
    text-align: center; text-transform: uppercase
}
```

_Could not found this feature._ Would be this useful? 

Can also do some code tweaks, if needed, and send a new request.

Cheers.
