### PR TITLE
fix for node-webkit

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -7,17 +7,21 @@ if (typeof environment === "object" && ({}).toString.call(environment) === "[obj
     else                                { less = window.less = {} }
     tree = less.tree = {};
     less.mode = 'rhino';
-} else if (typeof(window) === 'undefined') {
-    // Node.js
-    less = exports,
-    tree = require('./tree');
-    less.mode = 'node';
 } else {
-    // Browser
-    if (typeof(window.less) === 'undefined') { window.less = {} }
-    less = window.less,
-    tree = window.less.tree = {};
-    less.mode = 'browser';
+    if (typeof(process) !== 'undefined') {
+        if (process && process.versions && process.versions.node) {
+            // Node.js
+            less = exports,
+            tree = require('./tree');
+            less.mode = 'node';
+        }
+    } else {
+        // Browser
+        if (typeof(window.less) === 'undefined') { window.less = {} }
+        less = window.less,
+        tree = window.less.tree = {};
+        less.mode = 'browser';
+    }
 }
 //
 // less.js - parser


### PR DESCRIPTION
Hi , I use less in [node-webkit](https://github.com/rogerwang/node-webkit) project, `typeof(window)` is `true` because it contains webkit, so I use another detection method. Hope to be improved.
Cheers.
