### PR TITLE
Allow imports from self-signed SSL hosts

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -20,6 +20,7 @@ var options = {
     paths: [],
     color: true,
     strictImports: false,
+    insecure: false,
     rootpath: '',
     relativeUrls: false,
     ieCompat: true,
@@ -89,6 +90,9 @@ args = args.filter(function (arg) {
         case 'x':
         case 'compress':
             options.compress = true;
+            break;
+        case 'insecure':
+            options.insecure = true;
             break;
         case 'M':
         case 'depends':

--- a/lib/less/env.js
+++ b/lib/less/env.js
@@ -7,6 +7,7 @@
         'contents',         // browser-only, contents of all the files
         'relativeUrls',     // option - whether to adjust URL's to be relative
         'strictImports',    // option -
+        'insecure',         // option - whether to allow imports from insecure ssl hosts
         'dumpLineNumbers',  // option - whether to dump line numbers
         'compress',         // option - whether to compress
         'processImports',   // option - whether to process imports. if false then imports will not be imported

--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -161,7 +161,7 @@ less.Parser.importer = function (file, currentFileInfo, callback, env) {
                 path:   urlObj.pathname + (urlObj.search||'')
             };
 
-        request.get(urlStr, function (error, res, body) {
+        request.get({uri: urlStr, strictSSL: !env.insecure }, function (error, res, body) {
             if (res.statusCode === 404) {
                 callback({ type: 'File', message: "resource '" + urlStr + "' was not found\n" });
                 return;

--- a/lib/less/lessc_helper.js
+++ b/lib/less/lessc_helper.js
@@ -36,6 +36,7 @@ var lessc_helper = {
         sys.puts("  -l, --lint              Syntax check only (lint).");
         sys.puts("  -s, --silent            Suppress output of error messages.");
         sys.puts("  --strict-imports        Force evaluation of imports.");
+        sys.puts("  --insecure              Allow imports from insecure https hosts.");
         sys.puts("  --verbose               Be verbose.");
         sys.puts("  -v, --version           Print version number and exit.");
         sys.puts("  -x, --compress          Compress output by removing some whitespaces.");


### PR DESCRIPTION
When working on some development environments, it may be useful to import less files from a remote host that uses a self-signed certificate. When using less 1.3.x and less, it was working without any issues, but since 1.4.x it is not possible anymore and fail silently.

This pull request adds a switch named `--insecure` to the binary that allows circumventing the default check made by **_request**_ for those specific cases, as well as an `insecure` option provided to the parser.
