### PR TITLE
Imported mixin generates wrong relative path for unquoted path

### DIFF
--- a/test/css/static-urls/urls.css
+++ b/test/css/static-urls/urls.css
@@ -40,3 +40,7 @@
 #secret {
   font-family: xecret, sans-serif;
 }
+#imported-relative-path {
+  background-image: url(folder\ \(1\)/../../data/image.jpg);
+  border-image: url('folder (1)/../../data/image.jpg');
+}

--- a/test/css/urls.css
+++ b/test/css/urls.css
@@ -44,6 +44,14 @@
 #secret {
   font-family: xecret, sans-serif;
 }
+#imported-relative-path {
+  background-image: url(import/../../data/image.jpg);
+  border-image: url('import/../../data/image.jpg');
+}
+#relative-url-import {
+  background-image: url(import/../../data/image.jpg);
+  border-image: url('import/../../data/image.jpg');
+}
 #data-uri {
   uri: url('data:image/jpeg;base64,bm90IGFjdHVhbGx5IGEganBlZyBmaWxlCg==');
 }

--- a/test/less/import/import-and-relative-paths-test.less
+++ b/test/less/import/import-and-relative-paths-test.less
@@ -4,3 +4,14 @@
 @import "imports/logo";
 @import "imports/font";
 
+.unquoted-relative-path-bg() {
+    background-image: url(../../data/image.jpg);
+}
+.quoted-relative-path-border-image() {
+    border-image: url('../../data/image.jpg');
+}
+
+#imported-relative-path {
+    .unquoted-relative-path-bg;
+    .quoted-relative-path-border-image;
+}

--- a/test/less/urls.less
+++ b/test/less/urls.less
@@ -34,6 +34,11 @@
 
 @import "import/import-and-relative-paths-test";
 
+#relative-url-import {
+    .unquoted-relative-path-bg;
+    .quoted-relative-path-border-image;
+}
+
 #data-uri {
   uri: data-uri('image/jpeg;base64', '../data/image.jpg');
 }


### PR DESCRIPTION
When relative URLs are on, and there's an image referenced via `url(...)`,
if the URL is unquoted, the generated CSS duplicates the base path.
This is a failing test which demonstrates the problem.  It fails in 1.4.1,
as well as in the 1.5.0-wp branch.
