### PR TITLE
Windows path fixes

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -200,7 +200,7 @@ function extractUrlParts(url, baseUrl) {
     // urlParts[4] = filename
     // urlParts[5] = parameters
 
-    var urlPartsRegex = /^((?:[a-z-]+:)?\/+?(?:[^\/\?#]*\/)|([\/\\]))?((?:[^\/\\\?#]*[\/\\])*)([^\/\\\?#]*)([#\?].*)?$/,
+    var urlPartsRegex = /^((?:[a-z-]+:)?\/+?(?:[^\/\?#]*\/)|([\/\\]))?((?:[^\/\\\?#]*[\/\\])*)([^\/\\\?#]*)([#\?].*)?$/i,
         urlParts = url.match(urlPartsRegex),
         returner = {}, directories = [], i, baseUrlParts;
 
@@ -221,7 +221,7 @@ function extractUrlParts(url, baseUrl) {
     }
     
     if (urlParts[3]) {
-        directories = urlParts[3].replace("\\", "/").split("/");
+        directories = urlParts[3].replace(/\\/g, "/").split("/");
 
         // extract out . before .. so .. doesn't absorb a non-directory
         for(i = 0; i < directories.length; i++) {


### PR DESCRIPTION
Fix uppercase drive letters, paths with multiple backslashes.

string.replace(string, string) only replaces the first match.

Alleviates https://github.com/madskristensen/WebEssentials2013/blob/master/EditorExtensions/Resources/Scripts/lessc.wsf#L184-L192
