### PR TITLE
Raise error callback instead of throwing an exception when parsing.

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -421,7 +421,7 @@ less.Parser = function Parser(env) {
                                 dumpLineNumbers: env.dumpLineNumbers,
                                 strictUnits: Boolean(options.strictUnits)});
                     } catch (e) {
-                        throw new(LessError)(e, env);
+                        callback(new(LessError)(e, env));
                     }
 
                     if (options.yuicompress && less.mode === 'node') {


### PR DESCRIPTION
In development mode one my servers compiles LESS on the fly while debugging. The problem is that certain types of syntax errors (e.g. invalid symbols) cause an exception to be thrown, halting the server. 

Other places in the code, the parser callback is invoked on error, instead of halting program execution. Is there any reason an exception is thrown on line 424 instead of raising the error callback?

If there is no reason, can you accept my patch to raise the callback instead of throw? Would make my development life a lot easier :)
