### PR TITLE
fix an error about extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@
  - significant bug fixes to our debug options
  - other parameters can be used as defaults in mixins e.g. .a(@a, @b:@a)
  - an error is shown if properties are used outside of a ruleset
- - added extract function which picks a value out of a list, e.g. extract(12 13 14, 3) => 3 
+ - added extract function which picks a value out of a list, e.g. extract(12 13 14, 3) => 14 
  - added luma, hsvhue, hsvsaturation, hsvvalue functions
  - added pow, pi, mod, tan, sin, cos, atan, asin, acos and sqrt math functions
  - added convert function, e.g. convert(1rad, deg) => value in degrees


### PR DESCRIPTION
The example of `extract` should output 14, not 3
