### PR TITLE
Better "JavaScript evaluation error" message

### DIFF
--- a/lib/less/tree/javascript.js
+++ b/lib/less/tree/javascript.js
@@ -19,7 +19,7 @@ tree.JavaScript.prototype = {
         try {
             expression = new(Function)('return (' + expression + ')');
         } catch (e) {
-            throw { message: "JavaScript evaluation error: `" + expression + "`" ,
+            throw { message: "JavaScript evaluation error: " + e.message + " from `" + expression + "`" ,
                     index: this.index };
         }
 


### PR DESCRIPTION
Less's messages for JavaScript evaluation errors do not contain the actual error thrown, making them very hard to debug. This PR adds the error message to the log.
