### PR TITLE
npm ignore dist and test folders

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,3 @@
 .gitattributes
+dist/
+test/


### PR DESCRIPTION
This decreases the generated `tar.gz` published by 1MB.
# Before

```
> ls -alh less-1.4.2.tgz 
-rw-r--r--  1 kevin  staff   1.1M Aug  6 19:47 less-1.4.2.tgz
```
# After

```
> ls -alh less-1.4.2.tgz 
-rw-r--r--  1 kevin  staff    79K Aug  6 19:49 less-1.4.2.tgz

```
