### PR TITLE
Apply path normalization in compiled CSS

### DIFF
--- a/lib/less/env.js
+++ b/lib/less/env.js
@@ -89,6 +89,33 @@
         return !/^(?:[a-z-]+:|\/)/.test(path);
     };
 
+    tree.evalEnv.prototype.normalizePath = function( path ) {
+        var
+          segments = path.split("/").reverse(),
+          segment;
+
+        path = [];
+        while (segments.length !== 0 ) {
+            segment = segments.pop();
+            switch( segment ) {
+                case ".":
+                    break;
+                case "..":
+                    if ((path.length === 0) || (path[path.length - 1] === "..")) {
+                        path.push( segment );
+                    } else {
+                        path.pop();
+                    }
+                    break;
+                default:
+                    path.push( segment );
+                    break;
+            }
+        }
+
+        return path.join("/");
+    };
+
     //todo - do the same for the toCSS env
     //tree.toCSSEnv = function (options) {
     //};

--- a/lib/less/tree/import.js
+++ b/lib/less/tree/import.js
@@ -70,13 +70,18 @@ tree.Import.prototype = {
     evalPath: function (env) {
         var path = this.path.eval(env);
         var rootpath = this.currentFileInfo && this.currentFileInfo.rootpath;
-        if (rootpath && !(path instanceof tree.URL)) {
-            var pathValue = path.value;
-            // Add the base path if the import is relative
-            if (pathValue && env.isPathRelative(pathValue)) {
-                path.value =  rootpath + pathValue;
+
+        if (!(path instanceof tree.URL)) {
+            if (rootpath) {
+                var pathValue = path.value;
+                // Add the base path if the import is relative
+                if (pathValue && env.isPathRelative(pathValue)) {
+                    path.value = rootpath + pathValue;
+                }
             }
+            path.value = env.normalizePath(path.value);
         }
+
         return path;
     },
     eval: function (env) {

--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -24,6 +24,8 @@ tree.URL.prototype = {
             val.value = rootpath + val.value;
         }
 
+        val.value = ctx.normalizePath(val.value);
+
         return new(tree.URL)(val, null);
     }
 };

--- a/test/css/static-urls/urls.css
+++ b/test/css/static-urls/urls.css
@@ -1,4 +1,4 @@
-@import "folder (1)/../css/background.css";
+@import "css/background.css";
 
 @import "folder (1)/import-test-d.css";
 @font-face {
@@ -31,11 +31,11 @@
 #logo {
   width: 100px;
   height: 100px;
-  background: url('folder (1)/../assets/logo.png');
+  background: url('assets/logo.png');
 }
 @font-face {
   font-family: xecret;
-  src: url('folder (1)/../assets/xecret.ttf');
+  src: url('assets/xecret.ttf');
 }
 #secret {
   font-family: xecret, sans-serif;

--- a/test/css/urls.css
+++ b/test/css/urls.css
@@ -1,4 +1,4 @@
-@import "import/../css/background.css";
+@import "css/background.css";
 
 @import "import/import-test-d.css";
 
@@ -35,11 +35,11 @@
 #logo {
   width: 100px;
   height: 100px;
-  background: url('import/imports/../assets/logo.png');
+  background: url('import/assets/logo.png');
 }
 @font-face {
   font-family: xecret;
-  src: url('import/imports/../assets/xecret.ttf');
+  src: url('import/assets/xecret.ttf');
 }
 #secret {
   font-family: xecret, sans-serif;


### PR DESCRIPTION
This pull request adds a path normalization feature to `evalEnv` and calls it from both `tree.import` and `tree.URL` nodes to ensure that paths with `..` or `.` segments inside them, [as exhibited in a comment on #1470](https://github.com/less/less.js/issues/1470#issuecomment-22174938), are cleaned up properly. For example:
`@import "foo/bar/../baz.css"` becomes `@import "foo/baz.css"`,
`url("foo/bar/../baz.jpg")` becomes `url("foo/baz.jpg")`,
etc.

When a rootpath is specified or relative URL rewriting is enabled and a path is inherited from it, then those paths will be honored and combined with the URL before normalization. For example:
`url("../baz.jpg")` inside a sheet imported as `@import "foo/bar.less"` will have an intermediate representation of `url("foo/../baz.jpg")` which will be normalized and output as `url("baz.jpg")`.

When URL normalization cannot completely eliminate `..` segments by traversing up directories, then it will retain any remaining leading `..` segments. For example, as a variation on the previous:
`url("../../baz.jpg")` inside a sheet imported as `@import "foo/bar.less"` will become `url("../baz.jpg")`.

Unit tests have been updated to reflect normalized URLs.
