### PR TITLE
Always properly insert style block into head

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -376,7 +376,7 @@ function createCSS(styles, sheet, lastModified) {
         if (nextEl) {
             nextEl.parentNode.insertBefore(css, nextEl);
         } else {
-            document.getElementsByTagName('head')[0].appendChild(css);
+            head.appendChild(css);
         }
     }
     if (oldCss && keepOldCss === false) {


### PR DESCRIPTION
When client-side compiling, if the referenced LESS file is the last element in the `<head>`, this code:

```
var nextEl = sheet && sheet.nextSibling || null;
(nextEl || document.getElementsByTagName('head')[0]).parentNode.insertBefore(css, nextEl);
```

...ends up inserting at the end of `<html>` instead since it gets the parent of `<head>` instead of a sibling element.

I'm fixing this by appending to `<head>` if `nextEl` is `null`.

It might not be necessary anymore, but just in case `oldCss` winds up outside of `<head>` I also adjusted the code that removes it from the DOM to not assume it'll be there so it always properly removes it.
