### PR TITLE
Update parser.js

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -481,7 +481,7 @@ less.Parser = function Parser(env) {
                                 dumpLineNumbers: env.dumpLineNumbers,
                                 strictUnits: Boolean(options.strictUnits)});
                     } catch (e) {
-                        throw new(LessError)(e, env);
+                        callback(new(LessError)(e, env));
                     }
 
                     if (options.cleancss && less.mode === 'node') {


### PR DESCRIPTION
Why parse function throws error? I think it can only report errors through callback function.
