### PR TITLE
Source map basepath works with higher up paths

### DIFF
--- a/lib/less/source-map-output.js
+++ b/lib/less/source-map-output.js
@@ -21,11 +21,8 @@
     };
 
     tree.sourceMapOutput.prototype.normalizeFilename = function(filename) {
-        if (this._sourceMapBasepath && filename.indexOf(this._sourceMapBasepath) === 0) {
-             filename = filename.substring(this._sourceMapBasepath.length);
-             if (filename.charAt(0) === '\\' || filename.charAt(0) === '/') {
-                filename = filename.substring(1);
-             }
+        if(this._sourceMapBasepath) {
+            filename =  require('path').relative(this._sourceMapBasepath, filename);
         }
         return (this._sourceMapRootpath || "") + filename.replace(/\\/g, '/');
     };


### PR DESCRIPTION
Rather than just replacing the basepath we find the relative path. This means if our base is higher up the tree than our less file we can still find it.

For example, I have something like

/
- less/main.less
    @import '../bower_comonents/bootstrap'
- bower_components/bootstrap.less

I set the basepath to be '/less'
