### PR TITLE
Method url(path) relates to current file instead of root file

### DIFF
--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -16,15 +16,15 @@ tree.URL.prototype = {
     },
     toCSS: tree.toCSS,
     eval: function (ctx) {
-        var val = this.value.eval(ctx), rootpath;
+        var val = this.value.eval(ctx), currentDirectory;
 
         // Add the base path if the URL is relative
-        rootpath = this.currentFileInfo && this.currentFileInfo.rootpath;
-        if (rootpath && typeof val.value === "string" && ctx.isPathRelative(val.value)) {
+        currentDirectory = this.currentFileInfo && (this.currentFileInfo.currentDirectory || this.currentFileInfo.rootpath);
+        if (currentDirectory && typeof val.value === "string" && ctx.isPathRelative(val.value)) {
             if (!val.quote) {
-                rootpath = rootpath.replace(/[\(\)'"\s]/g, function(match) { return "\\"+match; });
+                currentDirectory = currentDirectory.replace(/[\(\)'"\s]/g, function(match) { return "\\"+match; });
             }
-            val.value = rootpath + val.value;
+            val.value = currentDirectory + val.value;
         }
 
         val.value = ctx.normalizePath(val.value);


### PR DESCRIPTION
Recently, url(path) relates to the root LESS file, I consider it as a bug, and fixed it by changing the related path to current file.
