### PR TITLE
Avoid fs.statSync unless env.syncImports is specified

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -167,25 +167,22 @@ less.Parser.fileLoader = function (file, currentFileInfo, callback, env) {
         var paths = [currentFileInfo.currentDirectory].concat(env.paths);
         paths.push('.');
 
-        for (var i = 0; i < paths.length; i++) {
-            try {
-                pathname = path.join(paths[i], file);
-                fs.statSync(pathname);
-                break;
-            } catch (e) {
-                pathname = null;
+        if (env.syncImports) {
+            for (var i = 0; i < paths.length; i++) {
+                try {
+                    pathname = path.join(paths[i], file);
+                    fs.statSync(pathname);
+                    break;
+                } catch (e) {
+                    pathname = null;
+                }
             }
-        }
-        
-        if (!pathname) {
 
-            callback({ type: 'File', message: "'" + file + "' wasn't found" });
-            return;
-        }
-        
-        dirname = path.dirname(pathname);
+            if (!pathname) {
+                callback({ type: 'File', message: "'" + file + "' wasn't found" });
+                return;
+            }
 
-        if (env.syncImport) {
             try {
                 data = fs.readFileSync(pathname, 'utf-8');
                 handleDataAndCallCallback(data);
@@ -193,10 +190,23 @@ less.Parser.fileLoader = function (file, currentFileInfo, callback, env) {
                 callback(e);
             }
         } else {
-            fs.readFile(pathname, 'utf-8', function(e, data) {
-                if (e) { callback(e); }
-                handleDataAndCallCallback(data);
-            });
+            (function tryPathIndex(i) {
+                if (i < paths.length) {
+                    pathname = path.join(paths[i], file);
+                    fs.stat(pathname, function (err) {
+                        if (err) {
+                            tryPathIndex(i + 1);
+                        } else {
+                            fs.readFile(pathname, 'utf-8', function(e, data) {
+                                if (e) { callback(e); }
+                                handleDataAndCallCallback(data);
+                            });
+                        }
+                    });
+                } else {
+                    callback({ type: 'File', message: "'" + file + "' wasn't found" });
+                }
+            }(0));
         }
     }
 };


### PR DESCRIPTION
`less.Parser.fileLoader` uses `fs.statSync` even when used in an asynchronous context. This is bad for performance when the less compiler is used as a library that wants do things in parallel. Also, it happens to break a project I'm working on where I'm using the less compiler in a linting tool that works on a synthetic `fs` module that gets its data from a git repository and doesn't support the synchronous methods very well.

This commit switches to `fs.stat`, except when `env.syncImports` is specified.
