### PR TITLE
Check location.port for truthiness

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -8,7 +8,8 @@ var isFileProtocol = /^(file|chrome(-extension)?|resource|qrc|app):/.test(locati
 less.env = less.env || (location.hostname == '127.0.0.1' ||
                         location.hostname == '0.0.0.0'   ||
                         location.hostname == 'localhost' ||
-                        location.port.length > 0         ||
+                        (location.port &&
+                          location.port.length > 0)      ||
                         isFileProtocol                   ? 'development'
                                                          : 'production');
 


### PR DESCRIPTION
According to the w3 spec for Window:

http://www.w3.org/TR/Window/#location

`location.port` might be null. This PR checks that it is truthy before checking for the port's length.

One place where location.port is null is within [jsdom](https://github.com/tmpvar/jsdom), so if you run less within Node, within jsdom, it throws an exception in this code.
