### PR TITLE
Parser: Multiline strings

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -313,7 +313,7 @@ less.Parser = function Parser(env) {
                 var j = 0,
                     skip = /(?:@\{[\w-]+\}|[^"'`\{\}\/\(\)\\])+/g,
                     comment = /\/\*(?:[^*]|\*+[^\/*])*\*+\/|\/\/.*/g,
-                    string = /"((?:[^"\\\r\n]|\\.)*)"|'((?:[^'\\\r\n]|\\.)*)'|`((?:[^`]|\\.)*)`/g,
+                    string = /(('''|""")(.|\n)*?\2)|"((?:[^"\\\r\n]|\\.)*)"|'((?:[^'\\\r\n]|\\.)*)'|`((?:[^`]|\\.)*)`/g,
                     level = 0,
                     match,
                     chunk = chunks[0],
@@ -644,9 +644,17 @@ less.Parser = function Parser(env) {
                     if (input.charAt(j) !== '"' && input.charAt(j) !== "'") { return; }
 
                     e && $('~');
+                    
+                    var multiline = input.substring(j, j + 3),
+                        rgx;
+                        
+                    rgx = multiline === '"""' || multiline === "'''"
+                        ? /^('''|""")((.|\n)*?)\1/
+                        :/^"((?:[^"\\\r\n]|\\.)*)"|'((?:[^'\\\r\n]|\\.)*)'/
+                        ;
 
-                    if (str = $(/^"((?:[^"\\\r\n]|\\.)*)"|'((?:[^'\\\r\n]|\\.)*)'/)) {
-                        return new(tree.Quoted)(str[0], str[1] || str[2], e, index, env.currentFileInfo);
+                    if (str = $(rgx)) {
+                        return new(tree.Quoted)(str[0], str[2] || str[1], e, index, env.currentFileInfo);
                     }
                 },
 

--- a/test/css/strings.css
+++ b/test/css/strings.css
@@ -41,3 +41,14 @@
 .watermark {
   family: Univers, Arial, Verdana, San-Serif;
 }
+.multiline {
+  content: 'foo
+  bar
+  ';
+}
+.multiline-value-interpolated {
+  content: foo
+  xfoo
+  bar
+  ;
+}

--- a/test/less/strings.less
+++ b/test/less/strings.less
@@ -55,3 +55,17 @@
   @family: ~"Univers, @{test}";
   family: @family;
 }
+
+.multiline {
+  content: '''foo
+  bar
+  ''';
+}
+
+@multi_foo: 'xfoo';
+.multiline-value-interpolated {
+  content: ~'''foo
+  @{multi_foo}
+  bar
+  ''';
+}


### PR DESCRIPTION
Added multiline string feature to the parser:
     `''' long_multiline_string '''`
     `""" long_multiline_string """`

``` ruby
.keyframes(~'''
    foo,
    from { opacity: 0 }
    to { opacity: 1 }
''');
```

As you see from the example above, this is especially useful for the mixin arguments.

In case you have other ideas regarding syntax, etc, I'm eager to change this pull request. 

Things to consider:
- should the new lines and the trailing white-spaces be removed from the string?

What do you think about this pr?

Cheers, Alex
