### PR TITLE
Fixes #1619

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,11 +80,10 @@ module.exports = function(grunt) {
     uglify: {
       options: {
         banner: '<%= meta.banner %>',
-        mangle: true,
-        wrap: true
+        mangle: true
       },
       stable: {
-        src: ['<%= concat.stable.src %>'],
+        src: ['<%= concat.stable.dest %>'],
         dest: 'dist/less-<%= pkg.version %>.min.js'
       }
     },


### PR DESCRIPTION
The latest version (1.5.0) of `less.js` conflicts with `require.js` (if loaded before `require.js`), causing the following error:

```
Uncaught TypeError: Object function require(a){return window.less[a.split("/")[1]]} has no method 'config'
```

It seems that this is only an issue with the minified version (`less-1.5.0.min.js`) because the minified JavaScript is not wrapped in an anonymous closure. Adding `function(){` to the beginning and `}())` to the end of the minified file.
