### PR TITLE
Keep a copy of less.js/less.min.js that is always latest version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -210,6 +210,15 @@ module.exports = function(grunt) {
     clean: {
       test: ['test/browser/less.js', 'tmp'],
       "sourcemap-test": ['test/sourcemaps/*.css', 'test/sourcemaps/*.map']
+    },
+
+    copy: {
+      stable: {
+        files: [
+          { src: 'dist/less-<%= pkg.version %>.js', dest: 'dist/less.js' },
+          { src: 'dist/less-<%= pkg.version %>.min.js', dest: 'dist/less.min.js' }
+        ]
+      }
     }
   });
 
@@ -227,7 +236,8 @@ module.exports = function(grunt) {
   // Release
   grunt.registerTask('stable', [
     'concat:stable',
-    'uglify:stable'
+    'uglify:stable',
+    'copy:stable'
   ]);
 
   // Run all browser tests

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-connect": "~0.3.0",
+    "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-jasmine": "~0.5.2",
     "grunt-contrib-jshint": "~0.7.2",
     "grunt-contrib-uglify": "~0.2.7",
@@ -59,7 +60,7 @@
     "http-server": "~0.5.5",
     "matchdep": "~0.1.2",
     "time-grunt": "~0.1.1"
- },
+  },
   "keywords": [
     "compile less",
     "css nesting",


### PR DESCRIPTION
This allows people like me to reference less.js/less.min.js in code and have our package managers handle version instead of having to update our paths with every new release.
