### PR TITLE
Color functions, amount argument handling improvement.

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -163,7 +163,7 @@ tree.functions = {
     //
     mix: function (color1, color2, weight) {
         if (!weight) {
-            weight = new(tree.Dimension)(50);
+            weight = new(tree.Dimension)(0.5);
         }
         var p = number(weight);
         var w = p * 2 - 1;

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -94,11 +94,11 @@
   max: max(3%, 1cm, 8%, 2mm);
   percentage: percentage((10px / 50));
   color: color("#ff0011");
-  tint: tint(#777777, 13);
-  tint-full: tint(#777777, 100);
+  tint: tint(#777777, .13);
+  tint-full: tint(#777777, 1);
   tint-percent: tint(#777777, 13%);
-  shade: shade(#777777, 13);
-  shade-full: shade(#777777, 100);
+  shade: shade(#777777, .13);
+  shade-full: shade(#777777, 1);
   shade-percent: shade(#777777, 13%);
 
   fade-out: fadeOut(red, 5%); // support fadeOut and fadeout
@@ -107,9 +107,9 @@
   hsv: hsv(5, 50%, 30%);
   hsva: hsva(3, 50%, 30%, 0.2);
 
-  mix: mix(#ff0000, #ffff00, 80);
+  mix: mix(#ff0000, #ffff00, 0.8);
   mix-0: mix(#ff0000, #ffff00, 0);
-  mix-100: mix(#ff0000, #ffff00, 100);
+  mix-100: mix(#ff0000, #ffff00, 100%);
   mix-weightless: mix(#ff0000, #ffff00);
   mixt: mix(#ff0000, transparent);
 


### PR DESCRIPTION
This quick-fix is inspired by issue found in #1655:
Color functions with `amount` parameter now distinguish between `%` and non-`%` values.
The following functions are changed:

```
saturate
desaturate
lighten
darken
fadein
fadeout
fade
mix
```

Known issues: To keep things simple I reused existing `functions.js:number` goody. This function tests only for `%` and non-`%` values so for example `fade(#111, 1px)` gives same result as `fade(#111, 1.0)` with no error thrown.
