### PR TITLE
Ensure modifyVars does not call refresh if no variables are specified #1699

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -649,7 +649,12 @@ for (var i = 0; i < links.length; i++) {
 // CSS without reloading less-files
 //
 less.modifyVars = function(record) {
-    less.refresh(false, serializeVars(record));
+    var vars = serializeVars(record);
+    if (vars) {
+        less.refresh(false, vars);
+    } else {
+        log("modifyVars was invoked with no variables.");
+    }
 };
 
 less.refresh = function (reload, newVars) {


### PR DESCRIPTION
See issue #1699.
