### PR TITLE
Allow logging in production and set the logLevel appropriate for the environment

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -20,11 +20,13 @@ var logLevel = {
 };
 
 // The amount of logging in the javascript console.
-// 2 - Information and errors
+// 2 - Everything (Information and errors)
 // 1 - Errors
 // 0 - None
-// Defaults to 2
-less.logLevel = typeof(less.logLevel) != 'undefined' ? less.logLevel : logLevel.info;
+// Development defaults is 2. Production default is 1.
+if (typeof(less.logLevel) === 'undefined') {
+        less.logLevel = (less.env === 'development' ?  logLevel.info : logLevel.errors);
+    }
 
 // Load styles asynchronously (default: false)
 //
@@ -56,7 +58,7 @@ var fileCache = {};
 var varsPre = "";
 
 function log(str, level) {
-    if (less.env == 'development' && typeof(console) !== 'undefined' && less.logLevel >= level) {
+    if (typeof(console) !== 'undefined' && less.logLevel >= level) {
         console.log('less: ' + str);
     }
 }


### PR DESCRIPTION
In development, the default logLevel is 2, so you will see everything by default.

In production, the default logLevel is 1, so you will ony see errors by default.

If a logLevel is already specified, then it is not overwritten.

Also ensured that logging can occur in development.
