### PR TITLE
Minifier complains about annotation in non-JSDoc tag

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function(grunt) {
         ' * \n' +
         ' */ \n\n' +
         ' /**' +
-        ' * @licence <%= meta.license %>\n' +
+        ' * @license <%= meta.license %>\n' +
         ' */ \n\n'
     },
 


### PR DESCRIPTION
When using JSMin, the minifier complains about the annotation in the non-JSDoc tag:

`INFO: [Minify] Minify: Exception in minifier: input:1665: WARNING - Parse error. Non-JSDoc comment has annotations. Did you mean to start it with '/**'?`
