### PR TITLE
FIXES ISSUE #1453: let ModifyVar change numerical variables

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -600,7 +600,7 @@ function serializeVars(vars) {
 
     for (var name in vars) {
         s += ((name.slice(0,1) === '@')? '' : '@') + name +': '+
-                ((vars[name].slice(-1) === ';')? vars[name] : vars[name] +';');
+                ((vars[name].toString().slice(-1) === ';')? vars[name] : vars[name] +';');
     }
 
     return s;

--- a/test/browser/css/modify-vars/simple.css
+++ b/test/browser/css/modify-vars/simple.css
@@ -4,4 +4,5 @@
 .test {
   color1: #008000;
   color2: #800080;
+  scalar: 20;
 }

--- a/test/browser/less/modify-vars/simple.less
+++ b/test/browser/less/modify-vars/simple.less
@@ -1,6 +1,8 @@
 @import "imports/simple2";
 @var1: red;
+@scale: 10;
 .test {
   color1: @var1;
   color2: @var2;
+  scalar: @scale
 }

--- a/test/browser/runner-modify-vars-spec.js
+++ b/test/browser/runner-modify-vars-spec.js
@@ -20,7 +20,8 @@ describe("less.js modify vars", function() {
       lessOutputObj.type = "not compiled yet";
       less.modifyVars({
         var1: "green",
-        var2: "purple"
+        var2: "purple",
+        scale: 20
       });
     });
 


### PR DESCRIPTION
Adding a `toString()` call within `serializeVars()` fixes this issue #1453. If the variable to be modified is numerical, this leaves the passed in value as a number, but converts to string before calling slice.
