### PR TITLE
Remove alpha from contrast calc

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -206,7 +206,7 @@ tree.functions = {
         } else {
             threshold = number(threshold);
         }
-        if ((color.luma() * color.alpha) < threshold) {
+        if (color.luma() < threshold) {
             return light;
         } else {
             return dark;


### PR DESCRIPTION
#1724 highlighted a misunderstanding of how the contrast function works. I'd thought of this at the time I wrote the contrast function, and I'd incorporated the alpha value into the calculation. This is evidently wrong, because we can't know the background colour, so we have no idea whether the alpha will lighten or darken the colour it's comparing. So the alpha term should be removed from the calculation altogether. While this will affect current users, current output is actively wrong so I don't think it's a BC break, just a bug fix.
