### PR TITLE
Removed redundant code from tree.Selector.match()

### DIFF
--- a/lib/less/tree/selector.js
+++ b/lib/less/tree/selector.js
@@ -32,7 +32,7 @@ tree.Selector.prototype = {
     match: function (other) {
         var elements = this.elements,
             len = elements.length,
-            oelements, olen, max, i;
+            oelements, olen, i;
             
         oelements = other.elements.map( function(v) {
             return v.combinator.value + (v.value.value || v.value);
@@ -51,14 +51,13 @@ tree.Selector.prototype = {
         if (olen === 0 || len < olen) {
             return 0;
         } else {
-            max = Math.min(len, olen);
-            for (i = 0; i < max; i++) {
+            for (i = 0; i < olen; i++) {
                 if (elements[i].value !== oelements[i]) {
                     return 0;
                 }
             }
         }
-        return max; // return number of matched elements
+        return olen; // return number of matched elements
     },
     eval: function (env) {
         var evaldCondition = this.condition && this.condition.eval(env),


### PR DESCRIPTION
This is just an updated version of #1746.
Removes redundant Math.min call from tree.Selector.match() code.
