### PR TITLE
If result of evaluated javascript is a number return it as Dimension.

### DIFF
--- a/lib/less/tree/javascript.js
+++ b/lib/less/tree/javascript.js
@@ -39,7 +39,9 @@ tree.JavaScript.prototype = {
             throw { message: "JavaScript evaluation error: '" + e.name + ': ' + e.message + "'" ,
                     index: this.index };
         }
-        if (typeof(result) === 'string') {
+        if (typeof(result) === 'number') {
+            return new(tree.Dimension)(result);
+        } else if (typeof(result) === 'string') {
             return new(tree.Quoted)('"' + result + '"', result, this.escaped, this.index);
         } else if (Array.isArray(result)) {
             return new(tree.Anonymous)(result.join(', '));


### PR DESCRIPTION
Fix for issue #1768

Use-case:

```
@outerWidthPx: 100px;
@borderWidthPx: 1px;

.element {
  width: @outerWidthPx - @borderWidthPx * 2;
  border: @borderWidthPx solid #000;

  &.small {
    // Half of @borderWidthPx, but not smaller than 1px
    @halfBorderWidth: unit(~`Math.max(1, Math.floor(parseInt("@{borderWidthPx}") / 2))`, px);

    border-width: @halfBorderWidth;
    width: floor(@outerWidthPx / 2) - @halfBorderWidth * 2;
  }
}
```
