### PR TITLE
Allow source map input

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -357,6 +357,7 @@ var parseLessFile = function (e, data) {
                     cleancssOptions: cleancssOptions,
                     sourceMap: Boolean(options.sourceMap),
                     sourceMapFilename: options.sourceMap,
+                    sourceMapOriginalFilename: options.sourceMapOriginalFilename,
                     sourceMapURL: options.sourceMapURL,
                     sourceMapOutputFilename: options.sourceMapOutputFilename,
                     sourceMapBasepath: options.sourceMapBasepath,

--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -577,6 +577,7 @@ less.Parser = function Parser(env) {
                                     rootNode: evaldRoot,
                                     contentsMap: parser.imports.contents,
                                     sourceMapFilename: options.sourceMapFilename,
+                                    sourceMapOriginalFilename: options.sourceMapOriginalFilename,
                                     sourceMapURL: options.sourceMapURL,
                                     outputFilename: options.sourceMapOutputFilename,
                                     sourceMapBasepath: options.sourceMapBasepath,
@@ -587,6 +588,7 @@ less.Parser = function Parser(env) {
                         }
 
                         css = evaldRoot.toCSS({
+                                sourceMapOriginalFilename: options.sourceMapOriginalFilename,
                                 compress: Boolean(options.compress),
                                 dumpLineNumbers: env.dumpLineNumbers,
                                 strictUnits: Boolean(options.strictUnits)});

--- a/lib/less/source-map-output.js
+++ b/lib/less/source-map-output.js
@@ -7,6 +7,7 @@
         this._contentsMap = options.contentsMap;
         this._contentsIgnoredCharsMap = options.contentsIgnoredCharsMap;
         this._sourceMapFilename = options.sourceMapFilename;
+        this._sourceMapOriginalFilename = options.sourceMapOriginalFilename;
         this._outputFilename = options.outputFilename;
         this._sourceMapURL = options.sourceMapURL;
         if (options.sourceMapBasepath) {
@@ -15,6 +16,7 @@
         this._sourceMapRootpath = options.sourceMapRootpath;
         this._outputSourceFiles = options.outputSourceFiles;
         this._sourceMapGeneratorConstructor = options.sourceMapGenerator || require("source-map").SourceMapGenerator;
+        this._sourceMapConsumerConstructor = options.sourceMapConsumer || require("source-map").SourceMapConsumer;
 
         if (this._sourceMapRootpath && this._sourceMapRootpath.charAt(this._sourceMapRootpath.length-1) !== '/') {
             this._sourceMapRootpath += '/';
@@ -68,15 +70,36 @@
         lines = chunk.split("\n");
         columns = lines[lines.length-1];
 
+        function getOriginal(line, column) {
+            var originalLine;
+            var originalColumn;
+            if (this._originalSourceMap) {
+                var originalSourceMapInfo = this._originalSourceMap.originalPositionFor({
+                    line: originalLine,
+                    column: originalColumn
+                });
+                originalLine = originalSourceMapInfo.line;
+                originalColumn = originalSourceMapInfo.column;
+            } else {
+                originalLine = sourceLines.length;
+                originalColumn = sourceColumns.length;
+            }
+
+            return {
+                line: originalLine,
+                column: originalColumn
+            };
+        }
+
         if (fileInfo) {
             if (!mapLines) {
                 this._sourceMapGenerator.addMapping({ generated: { line: this._lineNumber + 1, column: this._column},
-                    original: { line: sourceLines.length, column: sourceColumns.length},
+                    original: getOriginal(sourceLines.length, sourceColumns.length),
                     source: this.normalizeFilename(fileInfo.filename)});
             } else {
                 for(i = 0; i < lines.length; i++) {
                     this._sourceMapGenerator.addMapping({ generated: { line: this._lineNumber + i + 1, column: i === 0 ? this._column : 0},
-                        original: { line: sourceLines.length + i, column: i === 0 ? sourceColumns.length : 0},
+                        original: getOriginal(sourceLines.length + i, i === 0 ? sourceColumns.length : 0),
                         source: this.normalizeFilename(fileInfo.filename)});
                 }
             }
@@ -98,6 +121,7 @@
 
     tree.sourceMapOutput.prototype.toCSS = function(env) {
         this._sourceMapGenerator = new this._sourceMapGeneratorConstructor({ file: this._outputFilename, sourceRoot: null });
+        this._originalSourceMap = this._sourceMapOriginalFilename && new this._sourceMapConsumerConstructor(this._sourceMapOriginalFilename);
 
         if (this._outputSourceFiles) {
             for(var filename in this._contentsMap) {


### PR DESCRIPTION
I am looking for a CSS minifier that can receive an input source map, minify
the CSS, and produce a new source map from the original. For example, when I
compile my CSS with LESS, it produces a source map. A separate task might then
minify my compiled CSS, but I want the minified CSS to be mapped to the
original LESS source files.

LESS is currently the only CSS minifier that is able to produce a source map.
This is because it appears to be the only minifier that uses an AST. In my use
case, I would like to use LESS only for minification.

[UglifyJS does a good job of this](https://github.com/mishoo/UglifyJS2/blob/master/lib/sourcemap.js). I've taken the ideas from their code
to see if I could make LESS's minifier (albeit only compression(?)) also accept
an input source map. I haven't tested this code because I'm currently having
trouble getting LESS setup for development on my machine, but it would be good
to throw this out there nonetheless.
