### PR TITLE
#1778 standardised using starting index, to fix incorrectly mapped sourcemaps

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1073,7 +1073,7 @@ less.Parser = function Parser(env) {
                 // selector for now.
                 //
                 call: function () {
-                    var s = input.charAt(i), important = false, index = i,
+                    var s = input.charAt(i), important = false, index = i, elemIndex,
                         elements, elem, e, c, args;
 
                     if (s !== '.' && s !== '#') { return; }
@@ -1081,11 +1081,12 @@ less.Parser = function Parser(env) {
                     save(); // stop us absorbing part of an invalid selector
 
                     while (true) {
+                        elemIndex = i;
                         e = $re(/^[#.](?:[\w-]|\\(?:[A-Fa-f0-9]{1,6} ?|[^A-Fa-f0-9]))+/);
                         if (!e) {
                             break;
                         }
-                        elem = new(tree.Element)(c, e, i, env.currentFileInfo);
+                        elem = new(tree.Element)(c, e, elemIndex, env.currentFileInfo);
                         if (elements) { elements.push(elem); } else { elements = [ elem ]; }
                         c = $char('>');
                     }
@@ -1313,7 +1314,7 @@ less.Parser = function Parser(env) {
             // and an element name, such as a tag a class, or `*`.
             //
             element: function () {
-                var e, c, v;
+                var e, c, v, index = i;
 
                 c = this.combinator();
 
@@ -1329,7 +1330,7 @@ less.Parser = function Parser(env) {
                     }
                 }
 
-                if (e) { return new(tree.Element)(c, e, i, env.currentFileInfo); }
+                if (e) { return new(tree.Element)(c, e, index, env.currentFileInfo); }
             },
 
             //
@@ -1370,7 +1371,7 @@ less.Parser = function Parser(env) {
             // Selectors are made out of one or more Elements, see above.
             //
             selector: function (isLess) {
-                var $re = _$re, elements, extendList, c, e, extend, when, condition;
+                var index = i, $re = _$re, elements, extendList, c, e, extend, when, condition;
 
                 while ((isLess && (extend = this.extend())) || (isLess && (when = $re(/^when/))) || (e = this.element())) {
                     if (when) {
@@ -1390,7 +1391,7 @@ less.Parser = function Parser(env) {
                     }
                 }
 
-                if (elements) { return new(tree.Selector)(elements, extendList, condition, i, env.currentFileInfo); }
+                if (elements) { return new(tree.Selector)(elements, extendList, condition, index, env.currentFileInfo); }
                 if (extendList) { error("Extend must be used to extend a selector, it cannot be used on its own"); }
             },
             attribute: function () {
@@ -1639,7 +1640,7 @@ less.Parser = function Parser(env) {
             //     @charset "utf-8";
             //
             directive: function () {
-                var name, value, rules, nonVendorSpecificName,
+                var index = i, name, value, rules, nonVendorSpecificName,
                     hasBlock, hasIdentifier, hasExpression, identifier;
 
                 if (input.charAt(i) !== '@') { return; }
@@ -1706,12 +1707,12 @@ less.Parser = function Parser(env) {
                 if (hasBlock) {
                     rules = this.block();
                     if (rules) {
-                        return new(tree.Directive)(name, rules, i, env.currentFileInfo);
+                        return new(tree.Directive)(name, rules, index, env.currentFileInfo);
                     }
                 } else {
                     value = hasExpression ? this.expression() : this.entity();
                     if (value && $char(';')) {
-                        var directive = new(tree.Directive)(name, value, i, env.currentFileInfo);
+                        var directive = new(tree.Directive)(name, value, index, env.currentFileInfo);
                         if (env.dumpLineNumbers) {
                             directive.debugInfo = getDebugInfo(i, input, env);
                         }

--- a/lib/less/tree/directive.js
+++ b/lib/less/tree/directive.js
@@ -9,6 +9,7 @@ tree.Directive = function (name, value, index, currentFileInfo) {
     } else {
         this.value = value;
     }
+    this.index = index;
     this.currentFileInfo = currentFileInfo;
 
 };


### PR DESCRIPTION
Fixes #1778.

Appears that there is already convention to use the starting index for most of the nodes, just a couple had not implemented it correctly, or only half implemented it (ie. had index set but still used i). This fixes that to ensure consistency and produce correct sourcemaps.

It does break the sourcemap test because that test tests against a previously generated sourcemap which contains incorrect mappings, rookie testing error I'll leave that to the person that created the rookie test to fix.

Would suggest using http://sokra.github.io/source-map-visualization/ to test sourcemaps. 
