### PR TITLE
Added `+_` for space separated properties merge.

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1463,7 +1463,7 @@ less.Parser = function Parser(env) {
                 }
             },
             rule: function (tryAnonymous) {
-                var name, value, c = input.charAt(i), important, merge = false;
+                var name, topName, value, c = input.charAt(i), important, merge = "";
                 save();
 
                 if (c === '.' || c === '#' || c === '&') { return; }
@@ -1480,7 +1480,14 @@ less.Parser = function Parser(env) {
                     
                     // a name returned by this.ruleProperty() is always an array of the form:
                     // ["", "string-1", ..., "string-n", ""] or ["", "string-1", ..., "string-n", "+"]
-                    merge = name.pop && (name.pop() === "+");
+                    if (name.pop) {
+                        topName = name.pop();
+                        if (topName === "+") {
+                            merge = ",";
+                        } else if (topName === "+_") {
+                            merge = " ";
+                        }
+                    }
 
                     if (value && this.end()) {
                         return new (tree.Rule)(name, value, important, merge, memo, env.currentFileInfo);
@@ -1922,7 +1929,7 @@ less.Parser = function Parser(env) {
 
                 match(/^(\*?)/);
                 while (match(/^((?:[\w-]+)|(?:@\{[\w-]+\}))/)); // !
-                if ((name.length > 1) && match(/^\s*(\+?)\s*:/)) {
+                if ((name.length > 1) && match(/^\s*((?:\+_|\+)?)\s*:/)) {
                     // at last, we have the complete match now. move forward, 
                     // convert @{var}s to tree.Variable(s) and return:
                     skipWhitespace(length);

--- a/lib/less/to-css-visitor.js
+++ b/lib/less/to-css-visitor.js
@@ -193,20 +193,41 @@
                     } else {
                         rules.splice(i--, 1);
                     }
-
                     groups[key].push(rule);
                 }
             }
 
             Object.keys(groups).map(function (k) {
+                
+                function toExpression(values) {
+                    return new (tree.Expression)(values.map(function (p) {
+                        return p.value;
+                    }));
+                }
+
+                function toValue(values) {
+                    return new (tree.Value)(values.map(function (p) {
+                        return p;
+                    }));
+                }
+
                 parts = groups[k];
 
                 if (parts.length > 1) {
                     rule = parts[0];
-
-                    rule.value = new (tree.Value)(parts.map(function (p) {
-                        return p.value;
-                    }));
+                    var spacedGroups = [];
+                    var lastSpacedGroup = [];
+                    parts.map(function (p) {
+                    if (p.merge===",") {
+                        if (lastSpacedGroup.length > 0) {
+                                spacedGroups.push(toExpression(lastSpacedGroup));
+                            }
+                            lastSpacedGroup = [];
+                        } 
+                        lastSpacedGroup.push(p);
+                    });
+                    spacedGroups.push(toExpression(lastSpacedGroup));
+                    rule.value = toValue(spacedGroups);
                 }
             });
         }

--- a/test/css/merge.css
+++ b/test/css/merge.css
@@ -24,3 +24,10 @@
   transform: t1, t2, t3;
   background: b1, b2, b3;
 }
+.test-spaced {
+  transform: t1 t2 t3;
+  background: b1 b2, b3;
+}
+.test-interleaved-with-spaced {
+  transform: t1a t1b, b1 t2a t2b t2c, b2, b3 t3a t3b;
+}

--- a/test/less/merge.less
+++ b/test/less/merge.less
@@ -57,3 +57,20 @@
     background+: b2, b3;
     transform+:  t3;
 }
+.test-spaced {
+    transform+_:  t1;
+    background+_: b1;
+    transform+_:  t2;
+    background+_: b2, b3;
+    transform+_:  t3;
+}
+.test-interleaved-with-spaced {
+    transform+_:  t1a;
+    transform+_:  t1b;
+    transform+: b1;
+    transform+_:  t2a;
+    transform+_:  t2b t2c;
+    transform+: b2, b3;
+    transform+_:  t3a;
+    transform+_:  t3b;
+}


### PR DESCRIPTION
Pull request for #1756.

Since everybody seems to consider `+_` lesser evil, I implemented it. Merging operator are added in order they are written in, so this:

```
* {
  transform+: first;
  transform+_: spaced;
  transform+: comma;
}
```

compiles into:

```
* {
  transform: first spaced, comma;
}
```
