### PR TITLE
Fix for running test cases in a regular browser like Firefox or Chrome

### DIFF
--- a/test/browser/common.js
+++ b/test/browser/common.js
@@ -54,7 +54,7 @@ var testSheet = function(sheet) {
     }, "generation of " + lessOutputId + "", 700);
 
     runs(function() {
-      lessOutput = lessOutputObj.innerText;
+      lessOutput = lessOutputObj.innerText || lessOutputObj.innerHTML;
     });
 
     waitsFor(function() {


### PR DESCRIPTION
I tried running:
grunt connect:server:keepalive

and then running the tests like:
http://localhost:8081/tmp/browser/test-runner-rootpath-relative.html

but most of the tests failed in Firefox and Chrome because lessOutputObj.innerText was empty, however, innerHTML was populated.  So if you add an "or" check it won't break the phantomjs tests but will also work in a regular browser.
