### PR TITLE
small compatibility fix for prototype.js

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1934,7 +1934,7 @@ less.Parser = function Parser(env) {
                     // at last, we have the complete match now. move forward, 
                     // convert @{var}s to tree.Variable(s) and return:
                     skipWhitespace(length);
-                    for (var k in name) {
+                    for (var k=0; k < name.length; k++) {
                         if (name[k].charAt(0) === '@') {
                             name[k] = new tree.Variable('@' + name[k].slice(2, -1), 
                                 index[k], env.currentFileInfo);


### PR DESCRIPTION
for (var i in array) loop is causing errors when using less.watch(), this converts loop into standart numerical indexed for loop, so that using less.js with pages that also uses prototype.js would not cause any errors of the following kind:

"name[k].charAt is not a function"
