### PR TITLE
Split out rhino version of lessc

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -70,6 +70,15 @@ module.exports = function(grunt) {
         src: ['<%= build.rhino %>'],
         dest: 'dist/less-rhino-<%= pkg.version %>.js'
       },
+      // lessc for Rhino
+      rhinolessc: {
+        options: {
+          banner: '/* LESS.js v<%= pkg.version %> RHINO | <%= meta.copyright %>, <%= pkg.author.name %> <<%= pkg.author.email %>> */\n\n',
+          footer: '' // override task-level footer
+        },
+        src: ['<%= build.rhinolessc %>'],
+        dest: 'dist/lessc-rhino-<%= pkg.version %>.js'
+      },
       // Generate readme
       readme: {
         // override task-level banner and footer
@@ -234,7 +243,8 @@ module.exports = function(grunt) {
 
   // Release Rhino Version
   grunt.registerTask('rhino', [
-    'concat:rhino'
+    'concat:rhino',
+    'concat:rhinolessc'
   ]);
   
   // Run all browser tests

--- a/build.gradle
+++ b/build.gradle
@@ -36,23 +36,13 @@ project.ext {
     testOut = 'out/test'
 }
 
-javascript.source {
-    test {
-        js {
-            srcDir '.'
-            include 'test/rhino/test-header.js'
-            include "dist/less-rhino-${packageProps.version}.js"
-        }
-    }
-}
-
 task runGruntRhino(type: GruntTask) {
     gruntArgs = "rhino"
 }
 
 combineJs {
 	dependsOn runGruntRhino
-    source = javascript.source.test.js.files
+    source = ["dist/less-rhino-${packageProps.version}.js", "test/rhino/test-header.js","dist/lessc-rhino-${packageProps.version}.js"]
     dest = file(rhinoTestSrc)
 }
 

--- a/build/build.yml
+++ b/build/build.yml
@@ -102,7 +102,9 @@ rhino:
   - <%= build.less.source_map_output %>
   - <%= build.source_map %>
 
-  # append rhino-specific code
+
+# <%= build.rhinolessc %>
+rhinolessc:
   - <%= build.append.rhino %>
 
 

--- a/lib/less/rhino.js
+++ b/lib/less/rhino.js
@@ -1,9 +1,5 @@
 /*jshint rhino:true, unused: false */
-/*global name:true, less, loadStyleSheet, initRhinoTest, os */
-
-if (typeof initRhinoTest === 'function') { // definition of additional test functions (see rhino/test-header.js)
-    initRhinoTest();
-}
+/*global name:true, less, loadStyleSheet, os */
 
 function formatError(ctx, options) {
     options = options || {};

--- a/test/rhino/test-header.js
+++ b/test/rhino/test-header.js
@@ -11,3 +11,5 @@ function initRhinoTest() {
         if (str.value === "evil red") { return new(less.tree.Color)("600"); }
     };
 }
+
+initRhinoTest();


### PR DESCRIPTION
This lets us have cleaner tests (since we don't need to include the test code in the rhino source). Also sets the stage for sharing lessc code between bin/lessc and rhino lessc (issue #14 in @SomMeri less-rhino repo) and provides a hook so other projects (like lesscss-java) can have js in between the rhino code and the rhino-lessc (or not use the rhino-lessc at all).

Note that the build.gradle had to move the source from javascript.source {} to combineJS so we could have control over the order that the files get included in the output.
