### PR TITLE
Check value of elements before getting mixin args

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1091,17 +1091,20 @@ less.Parser = function Parser(env) {
                         if (elements) { elements.push(elem); } else { elements = [ elem ]; }
                         c = $char('>');
                     }
-                    if ($char('(')) {
-                        args = this.args(true).args;
-                        expectChar(')');
-                    }
 
-                    if (parsers.important()) {
-                        important = true;
-                    }
+                    if (elements) {
+                        if ($char('(')) {
+                            args = this.args(true).args;
+                            expectChar(')');
+                        }
 
-                    if (elements && ($char(';') || peekChar('}'))) {
-                        return new(tree.mixin.Call)(elements, args, index, env.currentFileInfo, important);
+                        if (parsers.important()) {
+                            important = true;
+                        }
+
+                        if (parsers.end()) {
+                            return new(tree.mixin.Call)(elements, args, index, env.currentFileInfo, important);
+                        }
                     }
 
                     restore();


### PR DESCRIPTION
When parsing, mixin.call() doesn't need to look for mixin.args if there weren't any elements
