### PR TITLE
Initial support for variable expansion in at-rules (needs decision/discussion).

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1684,8 +1684,6 @@ less.Parser = function Parser(env) {
 
                 switch(nonVendorSpecificName) {
                     case "@font-face":
-                        hasBlock = true;
-                        break;
                     case "@viewport":
                     case "@top-left":
                     case "@top-left-corner":
@@ -1719,21 +1717,23 @@ less.Parser = function Parser(env) {
                 }
 
                 if (hasIdentifier) {
-                    identifier = ($re(/^[^{]+/) || '').trim();
-                    if (identifier) {
-                        name += " " + identifier;
+                    // identifier may be split over chunks because of @{var}s
+                    // so we need to ensure we'll stop at '{' here:
+                    identifier = '';
+                    while (input.charAt(i) !== '{') {
+                        identifier += ($re(/^(?:@{|[^{])+/) || '').trim();
                     }
                 }
 
                 if (hasBlock) {
                     rules = this.block();
                     if (rules) {
-                        return new(tree.Directive)(name, rules, index, env.currentFileInfo);
+                        return new(tree.Directive)(name, identifier, rules, index, env.currentFileInfo);
                     }
                 } else {
                     value = hasExpression ? this.expression() : this.entity();
                     if (value && $char(';')) {
-                        var directive = new(tree.Directive)(name, value, index, env.currentFileInfo);
+                        var directive = new(tree.Directive)(name, identifier, value, index, env.currentFileInfo);
                         if (env.dumpLineNumbers) {
                             directive.debugInfo = getDebugInfo(i, input, env);
                         }

--- a/lib/less/tree/directive.js
+++ b/lib/less/tree/directive.js
@@ -1,7 +1,9 @@
 (function (tree) {
 
-tree.Directive = function (name, value, index, currentFileInfo) {
+tree.Directive = function (name, identifier, value, index, currentFileInfo) {
     this.name = name;
+    // note: identifier is actually anything between name and '{':
+    this.identifier = identifier; 
 
     if (Array.isArray(value)) {
         this.rules = [new(tree.Ruleset)(null, value)];
@@ -35,10 +37,22 @@ tree.Directive.prototype = {
     },
     toCSS: tree.toCSS,
     eval: function (env) {
-        var evaldDirective = this;
+        var evaldDirective = this, name= this.name, 
+            identifier = this.identifier, index;
+            
+        function evalVar(_, name, offset) {
+            return new(tree.Variable)('@' + name, index + offset).eval(env).toCSS(env);
+        }
+            
         if (this.rules) {
             env.frames.unshift(this);
-            evaldDirective = new(tree.Directive)(this.name, null, this.index, this.currentFileInfo);
+            if (identifier) {
+                index = this.index + name.length + 1;
+                name += " " + identifier
+                    .replace(/@\{([\w-]+)\}/g, evalVar)
+                    .replace(/@(@?[\w-]+)(?![^\(]*:)/g, evalVar);
+            }
+            evaldDirective = new(tree.Directive)(name, null, null, this.index, this.currentFileInfo);
             evaldDirective.rules = [this.rules[0].eval(env)];
             evaldDirective.rules[0].root = true;
             env.frames.shift();

--- a/test/css/at-rules-interpolation.css
+++ b/test/css/at-rules-interpolation.css
@@ -1,0 +1,29 @@
+@supports (display: flexbox) and (width: 25%) or (height: 25%) {
+  div {
+    width: 100px;
+  }
+}
+@keyframes enlarger {
+  from {
+    font-size: 12px;
+  }
+  to {
+    font-size: 15px;
+  }
+}
+@-webkit-keyframes reducer {
+  from {
+    font-size: 13px;
+  }
+  to {
+    font-size: 10px;
+  }
+}
+@page :left, toc, index {
+  margin: 2cm;
+}
+@document url(http://www.w4.org/), domain(lesscss.org) {
+  body {
+    color: purple;
+  }
+}

--- a/test/css/debug/linenumbers-all.css
+++ b/test/css/debug/linenumbers-all.css
@@ -41,7 +41,7 @@
 .tst2 {
   color: white;
 }
-/* line 27, c:\git\less.js\test\less\debug\linenumbers.less */
+/* line 27, {path}linenumbers.less */
 @media -sass-debug-info{filename{font-family:file\:\/\/{pathesc}linenumbers\.less}line{font-family:\0000327}}
 .test {
   color: red;

--- a/test/less/at-rules-interpolation.less
+++ b/test/less/at-rules-interpolation.less
@@ -1,0 +1,41 @@
+
+@a: display;
+@b: flexbox;
+@c: 25%;
+@d: c;
+
+@supports (@{a}: @b) and (width: @{c}) or (height: @@d) {
+    div {
+        width: 100px;
+    }
+}
+
+@name: enlarger;
+@keyframes @name {
+    from {font-size: 12px;}
+    to   {font-size: 15px;}
+}
+
+.m(reducer);
+.m(@name) {
+    @-webkit-keyframes @name {
+        from {font-size: 13px;}
+        to   {font-size: 10px;}
+    }
+}
+
+@types: toc, index;
+@dir:   :left;
+
+@page @dir, @types {
+    margin: 2cm;
+}
+
+@url:    url(http://www.w4.org/);
+@prefix: less;
+
+@document @url, domain(@{prefix}css.org) {
+    body {
+        color: purple;
+    }
+}

--- a/test/less/errors/at-rules-undefined-var.less
+++ b/test/less/errors/at-rules-undefined-var.less
@@ -1,0 +1,4 @@
+
+@keyframes @name {
+    50% {width: 20px;}
+}

--- a/test/less/errors/at-rules-undefined-var.txt
+++ b/test/less/errors/at-rules-undefined-var.txt
@@ -1,0 +1,4 @@
+NameError: variable @name is undefined in {path}at-rules-undefined-var.less on line 2, column 12:
+1 
+2 @keyframes @name {
+3     50% {width: 20px;}


### PR DESCRIPTION
In fact I just wanted to provide a variable interpolation for the `@keyframes` name (i.e. #1264, #1640 etc.). But since `@keyframes` rule is currently implemented as a generic "directive" ruleset also handling `@supports`, `@document` and similiar at-rules, this feature automatically applies to all of those and that makes an interpolation syntax to be used/allowed there not so obvious.
First of all I planned to make it simply `@keyframes @name {...}` but for `@supports` that would mean the following code possible: `@supports (@var: @var) {...}` with both `@var`s expanded which is barely can be accepted.
So insipired by https://github.com/less/less.js/pull/1648#issuecomment-33879011 I decided to allow both `@var` and `@{var}` expansions possible with certain (optional) restrictions.

To give a basic idea of what is theoretically possible w/o major refactoring of current "directive" implementation, here's 5 basis interpolation variants for the same example input:

```
@a: X;
@supports @a @{a} (@a: @{a}) and (@{a}: @a) {}
```

**[1]** expand only `@var` everywhere:
`@supports X @{a} (X: @{a}) and (@{a}: X) {}`

**[2]** only `@var` when not before `:`:
`@supports X @{a} (@a: @{a}) and (@{a}: X) {}`

**[3]** only `@{var}`:
`@supports @a X (@a: X) and (X: @a) {}`

**[4]** `@{var}` and `@var` everywhere:
`@supports X X (X: X) and (X: X) {}`

**[5]** `@{var}` everywhere and `@var` when not before `:`:
`@supports X X (@a: X) and (X: X) {}`

This PR implements [5], but can be switched to any of above. Additionally the variable expansion can be enabled/disabled for either of affected at-rules, so for example we can change it to the most safe and minimalistic [1] enabled for `@keyframes` only.
The list of affected at-rules:
`@host`
`@page`
`@document`
`@supports`
`@keyframes`

My main concern with these changes is future compatibility, i.e. current "directives" implementation with no doubt will be improved/changed/refactored eventually and then it may be not so easy to maintain too complex variable interpolation (like [5]) as things go further (for instance, `@supports` will need its bubbling and other `@media` like stuff, actually most likely `@supports` and `@media` implementations are about to be combined since they are pretty much identical feature in fact).

Other important notes, known issues etc.:

**Variable reference support:** `@@var` expansion is also supported (anywhere the `@var` expansion is allowed).

**Comments & strings (issue).** The block where the vars are expanded (i.e. `@directive <here> {...}`) is implemented just as a plain string (not really parsed) so the expansion works like plain text-replace stuff thus it also applies to any strings and comments happened to appear there, e.g.:

```
@a: X;
@supports "@a pple" /* banan @a*/ {}
```

expands to:

```
@supports "X pple" /* banan X*/ {}
```

**Escaping.** Escaping is not supported:
`@supports ~"@{a}pple" {}` -> `@supports ~"Xpple" {}`

**Concatenated vars expansion.** There's difference between expansion of concatenated `@var`s and `@{var}`s. Also notice the difference between how `@var` is expanded inside at-rules and within standard Less code:

```
@foo:      foo;
@baz:      baz;
@foo-bar-: mambo;

@keyframes @{foo}-bar-@{baz} {}
@keyframes @foo-bar-@baz     {}

.standard-var-expansion {
    value: @foo-bar-@baz;
}
```

result:

```
@keyframes foo-bar-baz {
}
@keyframes mambobaz {
}
.standard-var-expansion {
  value: mambo baz;
}
```
