### PR TITLE
add color functions to raise/lower brightness

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -157,6 +157,22 @@ tree.functions = {
 
         return hsla(hsl);
     },
+    brighten: function (color, amount) {
+        var hsv = color.toHSV();
+
+        hsv.v += amount.value / 100;
+        hsv.v = clamp(hsv.v);
+
+        return hsva(hsv);
+    },
+    dim: function (color, amount) {
+        var hsv = color.toHSV();
+
+        hsv.v -= amount.value / 100;
+        hsv.v = clamp(hsv.v);
+
+        return hsva(hsv);
+    },
     //
     // Copyright (c) 2006-2009 Hampton Catlin, Nathan Weizenbaum, and Chris Eppstein
     // http://sass-lang.com
@@ -639,6 +655,10 @@ for(var i = 0; i < mathFunctions.length; i++) {
 
 function hsla(color) {
     return tree.functions.hsla(color.h, color.s, color.l, color.a);
+}
+
+function hsva(color) {
+    return tree.functions.hsva(color.h, color.s, color.v, color.a);
 }
 
 function scaled(n, size) {

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -12,6 +12,8 @@
   darken: #330000;
   saturate: #203c31;
   desaturate: #29332f;
+  brighten: #cc0000;
+  dim: #660000;
   greyscale: #2e2e2e;
   hsl-clamp: #ffffff;
   spin-p: #bf6a40;

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -16,6 +16,8 @@
   darken: darken(#ff0000, 40%);
   saturate: saturate(#29332f, 20%);
   desaturate: desaturate(#203c31, 20%);
+  brighten: brighten(#660000, 40%);
+  dim: dim(#cc0000, 40%);
   greyscale: greyscale(#203c31);
   hsl-clamp: hsl(380, 150%, 150%);
   spin-p: spin(hsl(340, 50%, 50%), 40);


### PR DESCRIPTION
`brighten(color, amount)` and `dim(color, amount)` which use the existing HSV helpers to adjust the brightness of a color.

As long as Photoshop remains a dominant force in the design world, we're going to have to deal with HSV (aka HSB). The ability to adjust "brightness" makes dealing with these much easier.