### PR TITLE
Adding replace function

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -218,10 +218,10 @@ tree.functions = {
     escape: function (str) {
         return new(tree.Anonymous)(encodeURI(str.value).replace(/=/g, "%3D").replace(/:/g, "%3A").replace(/#/g, "%23").replace(/;/g, "%3B").replace(/\(/g, "%28").replace(/\)/g, "%29"));
     },
-    replace: function (subject, pattern, replacement, options) {
+    replace: function (subject, pattern, replacement, flags) {
         var str = subject.value;
 
-        str = str.replace(new RegExp(pattern.value, options ? options.value : ""), replacement.value);
+        str = str.replace(new RegExp(pattern.value, flags ? flags.value : ""), replacement.value);
 
         return new(tree.Quoted)('"' + str + '"', str);
     },

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -47,7 +47,7 @@
   contrast-low-thresh-per: #111111;
   replace: "Hello, World!";
   replace-captured: "This is a new string.";
-  replace-options: "2 + 2 = 4";
+  replace-with-flags: "2 + 2 = 4";
   format: "rgb(32, 128, 64)";
   format-string: "hello world";
   format-multiple: "hello earth 2";

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -51,7 +51,7 @@
   contrast-low-thresh-per: contrast(#555, #111111, #eeeeee, 10%);
   replace: replace("Hello, Mars.", "Mars\.", "World!");
   replace-captured: replace("This is a string.", "(string)\.$", "new $1.");
-  replace-options: replace("One + one = 4", "one", "2", "gi");
+  replace-with-flags: replace("One + one = 4", "one", "2", "gi");
   format: %("rgb(%d, %d, %d)", @r, 128, 64);
   format-string: %("hello %s", "world");
   format-multiple: %("hello %s %d", "earth", 2);


### PR DESCRIPTION
This patch adds support for a `replace` function that replaces text using regex which was previously discussed in #1511. I believe that this function should be in the core library because string replacement is a basic feature that has a multitude of use cases.
#### `replace(subject, pattern, replacement, flags)`

This function returns a String.
- **subject** - (String) the string to search and replace.
- **pattern** - (String) the pattern to search for.
- **replacement** - (String) the string to replace the matched text.
- **flags** - (String, optional) string of [regular expression flags](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Advanced_Searching_With_Flags).
## Use case: high-DPI image mixin

``` scss
.hd-background-image (@src, @size) {
  background-image: url(@src);

  @media only screen and (-webkit-min-device-pixel-ratio 2, min-resolution 2dppx) {
    @hdSrc: replace(@src, "\.([a-zA-Z]{3,4})$", "_2x.$1");

    background-image: url(@hdSrc);
    background-size: @size;
  }
}
```

The mixin above will load the normal background image for normal DPI devices and the background image with `_2x` appended to the filename for high DPI devices.
