### PR TITLE
Fixed empty args matching for named variadics.

### DIFF
--- a/lib/less/tree/mixin.js
+++ b/lib/less/tree/mixin.js
@@ -187,14 +187,15 @@ tree.mixin.Definition.prototype = {
         var frame = new(tree.Ruleset)(null, null),
             varargs, arg,
             params = this.params.slice(0),
-            i, j, val, name, isNamedFound, argIndex;
+            i, j, val, name, isNamedFound, argIndex, argsLength = 0;
 
         mixinEnv = new tree.evalEnv(mixinEnv, [frame].concat(mixinEnv.frames));
 
         if (args) {
             args = args.slice(0);
+            argsLength = args.length;
 
-            for(i = 0; i < args.length; i++) {
+            for(i = 0; i < argsLength; i++) {
                 arg = args[i];
                 if (name = (arg && arg.name)) {
                     isNamedFound = false;
@@ -224,9 +225,9 @@ tree.mixin.Definition.prototype = {
             arg = args && args[argIndex];
 
             if (name = params[i].name) {
-                if (params[i].variadic && args) {
+                if (params[i].variadic) {
                     varargs = [];
-                    for (j = argIndex; j < args.length; j++) {
+                    for (j = argIndex; j < argsLength; j++) {
                         varargs.push(args[j].value.eval(env));
                     }
                     frame.prependRule(new(tree.Rule)(name, new(tree.Expression)(varargs).eval(env)));
@@ -239,7 +240,7 @@ tree.mixin.Definition.prototype = {
                         frame.resetCache();
                     } else {
                         throw { type: 'Runtime', message: "wrong number of arguments for " + this.name +
-                            ' (' + args.length + ' for ' + this.arity + ')' };
+                            ' (' + argsLength + ' for ' + this.arity + ')' };
                     }
                     
                     frame.prependRule(new(tree.Rule)(name, val));
@@ -248,7 +249,7 @@ tree.mixin.Definition.prototype = {
             }
 
             if (params[i].variadic && args) {
-                for (j = argIndex; j < args.length; j++) {
+                for (j = argIndex; j < argsLength; j++) {
                     evaldArguments[j] = args[j].value.eval(env);
                 }
             }

--- a/test/css/mixins-pattern.css
+++ b/test/css/mixins-pattern.css
@@ -1,5 +1,6 @@
 .zero {
   variadic: true;
+  named-variadic: true;
   zero: 0;
   one: 1;
   two: 2;
@@ -7,6 +8,7 @@
 }
 .one {
   variadic: true;
+  named-variadic: true;
   one: 1;
   one-req: 1;
   two: 2;
@@ -14,11 +16,13 @@
 }
 .two {
   variadic: true;
+  named-variadic: true;
   two: 2;
   three: 3;
 }
 .three {
   variadic: true;
+  named-variadic: true;
   three-req: 3;
   three: 3;
 }

--- a/test/less/mixins-pattern.less
+++ b/test/less/mixins-pattern.less
@@ -1,6 +1,9 @@
 .mixin (...) {
   variadic: true;
 }
+.mixin (@a...) {
+  named-variadic: true;
+}
 .mixin () {
     zero: 0;
 }


### PR DESCRIPTION
Fixes #1852, e.g. `.mixin(@a...) {}` works same way as `.mixin(...) {}` does with 0 arguments passed in.
