### PR TITLE
Minor `replace` and `%` funcs improvement.

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -218,25 +218,25 @@ tree.functions = {
     escape: function (str) {
         return new(tree.Anonymous)(encodeURI(str.value).replace(/=/g, "%3D").replace(/:/g, "%3A").replace(/#/g, "%23").replace(/;/g, "%3B").replace(/\(/g, "%28").replace(/\)/g, "%29"));
     },
-    replace: function (subject, pattern, replacement, flags) {
-        var str = subject.value;
+    replace: function (string, pattern, replacement, flags) {
+        var result = string.value;
 
-        str = str.replace(new RegExp(pattern.value, flags ? flags.value : ""), replacement.value);
-        return new(tree.Quoted)(subject.quote || '', str, subject.escaped);
+        result = result.replace(new RegExp(pattern.value, flags ? flags.value : ''), replacement.value);
+        return new(tree.Quoted)(string.quote || '', result, string.escaped);
     },
-    '%': function (quoted /* arg, arg, ...*/) {
+    '%': function (string /* arg, arg, ...*/) {
         var args = Array.prototype.slice.call(arguments, 1),
-            str = quoted.value;
+            result = string.value;
 
         for (var i = 0; i < args.length; i++) {
             /*jshint loopfunc:true */
-            str = str.replace(/%[sda]/i, function(token) {
+            result = result.replace(/%[sda]/i, function(token) {
                 var value = token.match(/s/i) ? args[i].value : args[i].toCSS();
                 return token.match(/[A-Z]$/) ? encodeURIComponent(value) : value;
             });
         }
-        str = str.replace(/%%/g, '%');
-        return new(tree.Quoted)('"' + str + '"', str);
+        result = result.replace(/%%/g, '%');
+        return new(tree.Quoted)(string.quote || '', result, string.escaped);
     },
     unit: function (val, unit) {
         if(!(val instanceof tree.Dimension)) {

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -48,10 +48,15 @@
   replace: "Hello, World!";
   replace-captured: "This is a new string.";
   replace-with-flags: "2 + 2 = 4";
+  replace-single-quoted: 'foo-2';
+  replace-escaped-string: bar-2;
+  replace-keyword: baz-2;
   format: "rgb(32, 128, 64)";
   format-string: "hello world";
   format-multiple: "hello earth 2";
   format-url-encode: "red is %23ff0000";
+  format-single-quoted: 'hello single world';
+  format-escaped-string: hello escaped world;
   eformat: rgb(32, 128, 64);
   unitless: 12;
   unit: 14em;

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -52,10 +52,15 @@
   replace: replace("Hello, Mars.", "Mars\.", "World!");
   replace-captured: replace("This is a string.", "(string)\.$", "new $1.");
   replace-with-flags: replace("One + one = 4", "one", "2", "gi");
+  replace-single-quoted: replace('foo-1', "1", "2");
+  replace-escaped-string: replace(~"bar-1", "1", "2");
+  replace-keyword: replace(baz-1, "1", "2");
   format: %("rgb(%d, %d, %d)", @r, 128, 64);
   format-string: %("hello %s", "world");
   format-multiple: %("hello %s %d", "earth", 2);
-  format-url-encode: %('red is %A', #ff0000);
+  format-url-encode: %("red is %A", #ff0000);
+  format-single-quoted: %('hello %s', "single world");
+  format-escaped-string: %(~"hello %s", "escaped world");
   eformat: e(%("rgb(%d, %d, %d)", @r, 128, 64));
   
   unitless: unit(12px);


### PR DESCRIPTION
I just noticed that the following code:

```
.test {
    1: replace( "foo", "1", "2");
    2: replace( 'bar', "1", "2");
    3: replace(  baz,  "1", "2");
    4: replace(~"qux", "1", "2");
}
```

compiles to:

```
.test {
  1: "foo";
  2: "bar";
  3: "baz";
  4: "qux";
}
```

So this PR is an attempt to bring some consistency there:
- preserve quote char (`"`, `'` or `none`)
- preserve escaped flag.
