### PR TITLE
Pass options object to parser.parse in less.render

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -27,7 +27,7 @@ var less = {
                 } 
                 catch (err) { callback(err); return; }
                 callback(null, css);
-            });
+            }, options);
         } else {
             ee = new (require('events').EventEmitter)();
 
@@ -36,7 +36,7 @@ var less = {
                     if (e) { return ee.emit('error', e); }
                     try { ee.emit('success', root.toCSS(options)); } 
                     catch (err) { ee.emit('error', err); }
-                });
+                }, options);
             });
             return ee;
         }

--- a/test/modify-vars.js
+++ b/test/modify-vars.js
@@ -1,0 +1,17 @@
+var less = require('../lib/less'),
+  fs = require('fs')
+
+var input = fs.readFileSync("./test/less/modifyVars/extended.less", 'utf8')
+var expectedCss = fs.readFileSync('./test/css/modifyVars/extended.css', 'utf8')
+var options = {
+  modifyVars: JSON.parse(fs.readFileSync("./test/less/modifyVars/extended.json", 'utf8'))
+}
+
+less.render(input, options, function (err, css) {
+  if (err) console.log(err);
+  if (css === expectedCss) {
+    console.log("PASS")
+  } else {
+    console.log("FAIL")
+  }
+})


### PR DESCRIPTION
The options object is not passed to less.Parser.parse in less.render. This means that variables can't be overridden with modifyVars.

The tests for this pass because lessTester.runTestSet does not call less.render, but instead calls less.Parser.parse directly.

test/modify-vars.js contains a test that uses less.render to demonstrate the bug.
