### PR TITLE
Update license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                               Apache License
                         Version 2.0, January 2004
                      http://www.apache.org/licenses/
@@ -176,4 +175,4 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
 END OF TERMS AND CONDITIONS
 
-Copyright (c) 2009-2010 Alexis Sellier
+Copyright (c) 2009-2014 Alexis Sellier


### PR DESCRIPTION
Fix outdated copyright year (updated to 2014).
The copyright year was out of date. Copyright notices must reflect the current year, so this commit updates the listed year to 2014.

See http://www.copyright.gov/circs/circ01.pdf for more info.
