### PR TITLE
Recursive mixin calls regression fix.

### DIFF
--- a/lib/less/tree/mixin.js
+++ b/lib/less/tree/mixin.js
@@ -21,7 +21,7 @@ tree.mixin.Call.prototype = {
     eval: function (env) {
         var mixins, mixin, args, rules = [], match = false, i, m, f, isRecursive, isOneFound, rule,
             candidates = [], candidate, conditionResult = [], defaultFunc = tree.defaultFunc,
-            defaultResult, defNone = 0, defTrue = 1, defFalse = 2, count; 
+            defaultResult, defNone = 0, defTrue = 1, defFalse = 2, count, originalRuleset; 
 
         args = this.arguments && this.arguments.map(function (a) {
             return { name: a.name, value: a.value.eval(env) };
@@ -99,8 +99,9 @@ tree.mixin.Call.prototype = {
                         try {
                             mixin = candidates[m].mixin;
                             if (!(mixin instanceof tree.mixin.Definition)) {
+                                originalRuleset = mixin.originalRuleset || mixin;
                                 mixin = new tree.mixin.Definition("", [], mixin.rules, null, false);
-                                mixin.originalRuleset = mixins[m].originalRuleset || mixins[m];
+                                mixin.originalRuleset = originalRuleset;
                             }
                             Array.prototype.push.apply(
                                   rules, mixin.evalCall(env, args, this.important).rules);

--- a/test/less/mixins.less
+++ b/test/less/mixins.less
@@ -136,6 +136,9 @@ h3 { .margin_between(15px, 5px); }
 .clearfix {
   .clearfix();
 }
+.clearfix {
+  .clearfix();
+}
 .foo {
   .clearfix();
 }


### PR DESCRIPTION
Fixes detection of recursive calls broken in https://github.com/less/less.js/commit/6d3414d217b881284e6a2b6fa0ce46446fdc0bbd. Fixes #1915 and #1928 (?).

@lukeapage Let me know if it's better to PR this to the 2.0 branch instead (I'm not sure what state it is in for the moment).
