### PR TITLE
Recognize compilation errors by a thrown error instead of parsing the output

### DIFF
--- a/lib/less/rhino.js
+++ b/lib/less/rhino.js
@@ -56,7 +56,8 @@ function formatError(ctx, options) {
 function writeError(ctx, options) {
     options = options || {};
     if (options.silent) { return; }
-    print(formatError(ctx, options));
+    var message = formatError(ctx, options);
+    throw new Error(message);
 }
 
 function loadStyleSheet(sheet, callback, reload, remaining) {


### PR DESCRIPTION
This pull request just throws an error on `writeError()` instead of printing the error message to the output.
