### PR TITLE
Support importing from npm packages

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1,9 +1,10 @@
-var less, tree;
+var less, tree, resolveNpmFile;
 
 // Node.js does not have a header file added which defines less
 if (less === undefined) {
     less = exports;
     tree = require('./tree');
+    resolveNpmFile = require('resolve').sync;
     less.mode = 'node';
 }
 //
@@ -82,6 +83,27 @@ less.Parser = function Parser(env) {
                 callback(e, root, importedPreviously, fullPath);
             };
 
+            if (importOptions.npm) {
+              path = resolveNpmFile(path.replace(/\.less$/, ''), {
+                basedir: currentFileInfo.currentDirectory,
+                extensions: ['.less', '.css'],
+                packageFilter: function packageFilter(info, pkgdir) {
+                  // no style field, keep info unchanged
+                  if (!info.style) {
+                    return info;
+                  }
+
+                  // replace main
+                  if (typeof info.style === 'string') {
+                    info.main = info.style;
+                    return info;
+                  }
+
+                  return info;
+                },
+                paths: process.env.NODE_PATH ? process.env.NODE_PATH.split(':') : []
+              });
+            }
             if (less.Parser.importer) {
                 less.Parser.importer(path, currentFileInfo, fileParsedFunc, env);
             } else {
@@ -1660,7 +1682,7 @@ less.Parser = function Parser(env) {
             },
 
             importOption: function() {
-                var opt = $re(/^(less|css|multiple|once|inline|reference)/);
+                var opt = $re(/^(less|css|multiple|once|inline|reference|npm)/);
                 if (opt) {
                     return opt[1];
                 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "request": ">=2.33.0",
     "mkdirp": "~0.3.5",
     "clean-css": "2.1.x",
-    "source-map": "0.1.x"
+    "source-map": "0.1.x",
+    "resolve": "0.6.2"
   },
   "devDependencies": {
     "diff": "~1.0",


### PR DESCRIPTION
This adds support for importing from npm packages installed to node_modules.  For example, having installed `twbs` via npm you can import the entirety of bootstrap using:

``` less
@import (npm) "twbs";
```

or a specific file via:

``` less
@import (npm) "twbs/less/code";
```

The syntax and resolution algorithm will be familiar to most node.js developers, and is becoming increasingly popular on the client side too with libraries such as browserify.

closes #1965
