### PR TITLE
Change paths determination for CLI

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -192,8 +192,9 @@ less.Parser.fileLoader = function (file, currentFileInfo, callback, env) {
         });
     } else {
 
-        var paths = [currentFileInfo.currentDirectory].concat(env.paths);
-        paths.push('.');
+        var paths = [currentFileInfo.currentDirectory];
+        if (env.paths) paths.push.apply(paths, env.paths);
+        if (paths.indexOf('.') === -1) paths.push('.');
 
         if (env.syncImport) {
             for (var i = 0; i < paths.length; i++) {


### PR DESCRIPTION
Just a slight modification to how paths are determined before loading a file. (in the node/cli env)

If `env.paths` does not exist, it introduces `undefined` into the array. This breaks in node v0.10+ by [throwing an exception](http://nodejs.org/docs/latest/api/path.html#path_path_join_path1_path2) when `path.join` is called. Secondly, this also checks for whether or not `.` has already been added to the list before appending it.

Currently, I always have to make sure `paths` is defined in my LESS options, this eliminates that necessity. (since the defaults here are reasonable)
