### PR TITLE
Allow for useFileCache to read from env.contents

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -497,9 +497,9 @@ function loadFile(originalHref, currentFileInfo, callback, env, modifyVars) {
         }
     }
 
-    if (env.useFileCache && fileCache[href]) {
+    if (env.useFileCache && (fileCache[href] || env.contents[href])) {
         try {
-            var lessText = fileCache[href];
+            var lessText = fileCache[href] || env.contents[href];
             callback(null, lessText, href, newFileInfo, { lastModified: new Date() });
         } catch (e) {
             callback(e, null, href);


### PR DESCRIPTION
Added in ability for useFileCache to search env.contents, in addition to the fileCache object.  This allows for users to prime env.contents with less file contents, but does not impact the current functionality. 
