### PR TITLE
Set CSS text after style element is added to DOM, to fix crash on IE < 9...

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -118,13 +118,7 @@ function createCSS(styles, sheet, lastModified) {
     }
     css.id = id;
 
-    if (css.styleSheet) { // IE
-        try {
-            css.styleSheet.cssText = styles;
-        } catch (e) {
-            throw new(Error)("Couldn't reassign styleSheet.cssText.");
-        }
-    } else {
+    if (!css.styleSheet) {
         css.appendChild(document.createTextNode(styles));
 
         // If new contents match contents of oldCss, don't replace oldCss
@@ -146,6 +140,17 @@ function createCSS(styles, sheet, lastModified) {
     }
     if (oldCss && keepOldCss === false) {
         oldCss.parentNode.removeChild(oldCss);
+    }
+
+    // For IE.
+    // This needs to happen *after* the style element is added to the DOM, otherwise IE 7 and 8 may crash.
+    // See http://social.msdn.microsoft.com/Forums/en-US/7e081b65-878a-4c22-8e68-c10d39c2ed32/internet-explorer-crashes-appending-style-element-to-head
+    if (css.styleSheet) {
+        try {
+            css.styleSheet.cssText = styles;
+        } catch (e) {
+            throw new(Error)("Couldn't reassign styleSheet.cssText.");
+        }
     }
 
     // Don't update the local store if the file wasn't modified


### PR DESCRIPTION
The fix is based on a comment on this page: http://social.msdn.microsoft.com/Forums/en-US/7e081b65-878a-4c22-8e68-c10d39c2ed32/internet-explorer-crashes-appending-style-element-to-head.

I did not write a test for this fix because i was not able to create a basic scenario to reproduce the issue. Also, it only happens on IE 8 (and 7 too i think).
