### PR TITLE
Fixes #2001

### DIFF
--- a/lib/less/tree/mixin.js
+++ b/lib/less/tree/mixin.js
@@ -283,7 +283,7 @@ tree.mixin.Definition.prototype = {
     matchCondition: function (args, env) {
         if (this.condition && !this.condition.eval(
             new(tree.evalEnv)(env,
-                [this.evalParams(env, new(tree.evalEnv)(env, this.frames.concat(env.frames)), args, [])] // the parameter variables
+                [this.evalParams(env, new(tree.evalEnv)(env, this.frames ? this.frames.concat(env.frames) : env.frames), args, [])] // the parameter variables
                     .concat(this.frames) // the parent namespace/mixin frames
                     .concat(env.frames)))) { // the current environment frames
             return false;

--- a/test/css/mixins-guards.css
+++ b/test/css/mixins-guards.css
@@ -88,3 +88,6 @@
   a: 1;
   x: 1;
 }
+.mixin-generated-class {
+  a: 1;
+}

--- a/test/less/mixins-guards.less
+++ b/test/less/mixins-guards.less
@@ -161,3 +161,13 @@
   }
 }
 .bug-100cm-1m(100cm);
+
+#ns {
+    .mixin-for-root-usage(@a) when (@a > 0) {
+        .mixin-generated-class {
+            a: @a;
+        }
+    }
+}
+
+#ns > .mixin-for-root-usage(1);


### PR DESCRIPTION
Fixes a regression when a mixin guard can't see the mixin parameter variables in certain cases (#2001, #1920).
