### PR TITLE
Make clean-css truly an optional dependency.

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -605,8 +605,16 @@ less.Parser = function Parser(env) {
                     }
 
                     if (options.cleancss && less.mode === 'node') {
-                        var CleanCSS = require('clean-css'),
-                            cleancssOptions = options.cleancssOptions || {};
+                        var CleanCSS;
+                        try {
+                            CleanCSS = require('clean-css');
+                        } catch (ex) {
+                            throw new(LessError)({
+                                type: 'Dependency',
+                                message: 'Optional dependency "clean-css" required to use the cleancss option.',
+                            }, env);
+                        }
+                        var cleancssOptions = options.cleancssOptions || {};
 
                         if (cleancssOptions.keepSpecialComments === undefined) {
                             cleancssOptions.keepSpecialComments = "*";


### PR DESCRIPTION
The less parser treated clean-css as a required dependency when the cleancss
option was used. This causes an error when optional dependencies aren't
installed.

Fixes #2011
