### PR TITLE
Remove the "done" message displayed at the end of the compilation with Rhino.

### DIFF
--- a/lib/less/rhino.js
+++ b/lib/less/rhino.js
@@ -445,5 +445,4 @@ function writeFile(filename, content) {
         writeError(e, options);
         quit(1);
     }
-    console.log("done");
 }(arguments));


### PR DESCRIPTION
Hi.

The "done" message, displayed at the end of the compilation, is useless, in my opinion.

Moreover, in the context of a web application that computes the stylesheet when it is necessary (through [lesscss-java](https://github.com/marceloverdijk/lesscss-java), for instance), the done message is stored in the log of the application, meanwhile no bug has happened. I personally try to only display bugs and warning in the logs, in order to not pollute them.

That is why I suggest to remove this message.

What do you think?

Thanks,
Guillaume
