### PR TITLE
Not need create instance of Error for inheritance

### DIFF
--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -330,7 +330,7 @@ less.Parser = function Parser(env) {
         ];
     }
 
-    LessError.prototype = new Error();
+    LessError.prototype = Object.create(Error.prototype);
     LessError.prototype.constructor = LessError;
 
     this.env = env = env || {};


### PR DESCRIPTION
Sorry for my bad English

Not need create instance of Error for inheritance
It's potential memory leak in stack property

Error.stack getter/setter remember all context's from every function in stack
But after first read/write this property convert to static string without getter/setter

demo for look this memory leak:

``` html
<a id="leak" href="#">Error leak</a>
<br>
<a id="gcForce" href="#">More memory for GC force</a>
<script>
document.getElementById('leak').onclick = function() {
    window.q = (function() {
        function SomeObject() {
        }
        function qwe() {
            var asd = new SomeObject(),
                error = new Error();
            //console.log(error.stack);// If uncomment, has no memory leak 
            return error;
        }
        return qwe();
    })();
    return false;
};

document.getElementById('gcForce').onclick = function() {
    var length = 1e6;
    window.someStorage = new Array(length);
    for (var i = 0; i < length; i++) {
        someStorage[i] = {randomValue: Math.random() * 1e9 >>> 0};
    }
    alert('Ok');
    return false;
};
</script>
```

Steps to demonstrate memory leak:
1. Take Heap `Snapshot 1` in Chrome Devtools
2. Click at `Error leak`
3. Take Heap `Snapshot 2` in Chrome Devtools
4. Click ar `More memory for GC force`
5. Take Heap `Snapshot 3` in Chrome Devtools
6. Look at `Snapshot 3` `Objects allocated between Snapshot 1 and Snapshot 2`
You may find instance of SomeObject, which remember in Error.stack
