### PR TITLE
Fix a bug: if the less file end line is comments, the lessc command option "modify-var" will have no effect.

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -336,7 +336,7 @@ var parseLessFile = function (e, data) {
         return;
     }
 
-    data = options.globalVariables + data + options.modifyVariables;
+    data = options.globalVariables + data + '\n' + options.modifyVariables;
 
     options.paths = [path.dirname(input)].concat(options.paths);
     options.filename = input;


### PR DESCRIPTION
Here is an example: the test.less file source code:

``` less
@height: 20px;
.cls {
    height: @height;
}
// comments
```

now execute the command:

``` shell
bin/lessc test.less --modify-var="height=30px"
```

the expected result is the @height will transform to 30px, but it is still 20px.
