### PR TITLE
Base64 encode source maps

### DIFF
--- a/lib/less/source-map-output.js
+++ b/lib/less/source-map-output.js
@@ -127,7 +127,7 @@
             if (this._writeSourceMap) {
                 this._writeSourceMap(sourceMapContent);
             } else {
-                sourceMapURL = "data:application/json," + encodeURIComponent(sourceMapContent);
+                sourceMapURL = "data:application/json;base64," + require('./encoder.js').encodeBase64(sourceMapContent);
             }
 
             if (sourceMapURL) {


### PR DESCRIPTION
This prevents some edge cases where encodeURIComponent fails to create a valid
source map.

This particular edge case was identified when trying to create source maps for
the lesshat mixin library.
