### PR TITLE
window.ActiveXObject in IE11: fix boolean casting

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -416,7 +416,7 @@ function pathDiff(url, baseUrl) {
 }
 
 function getXMLHttpRequest() {
-    if (window.XMLHttpRequest && (window.location.protocol !== "file:" || !window.ActiveXObject)) {
+    if (window.XMLHttpRequest && (window.location.protocol !== "file:" || !("ActiveXObject" in window))) {
         return new XMLHttpRequest();
     } else {
         try {


### PR DESCRIPTION
Boolean casting bug in Internet Explorer 11:
window.ActiveXObject // returned `function ActiveXObject() {[native code]}`
!window.ActiveXObject // returned **true** instead `false`.
