### PR TITLE
allow `less.modifyVars` option to overwrite variable before initial parse

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -645,6 +645,7 @@ for (var i = 0; i < links.length; i++) {
 // With this function, it's possible to alter variables and re-render
 // CSS without reloading less-files
 //
+var temp_modifyVars=less.modifyVars; //--save client side config option
 less.modifyVars = function(record) {
     less.refresh(false, record);
 };
@@ -679,4 +680,4 @@ less.refreshStyles = loadStyles;
 
 less.Parser.fileLoader = loadFile;
 
-less.refresh(less.env === 'development');
+less.refresh(less.env === 'development',temp_modifyVars);

--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -99,7 +99,7 @@ function errorConsole(e, rootHref) {
     log(content, logLevel.errors);
 }
 
-function createCSS(styles, sheet, lastModified) {
+function createCSS(styles, sheet, lastModified, modifyVars) {
     // Strip the query-string
     var href = sheet.href || '';
 
@@ -153,12 +153,13 @@ function createCSS(styles, sheet, lastModified) {
         }
     }
 
-    // Don't update the local store if the file wasn't modified
-    if (lastModified && cache) {
+    // Don't update the local store if the file wasn't modified or modifyVars option was set
+    if ((lastModified || modifyVars) && cache) {
         log('saving ' + href + ' to cache.', logLevel.info);
         try {
             cache.setItem(href, styles);
             cache.setItem(href + ':timestamp', lastModified);
+            cache.setItem(href + ':modifyVarsHash', modifyVars?JSON.stringify(modifyVars):'');
         } catch(e) {
             //TODO - could do with adding more robust error handling
             log('failed to save', logLevel.errors);
@@ -542,11 +543,15 @@ function loadStyleSheet(sheet, callback, reload, remaining, modifyVars) {
             webInfo.remaining = remaining;
 
             var css       = cache && cache.getItem(path),
-                timestamp = cache && cache.getItem(path + ':timestamp');
+                timestamp = cache && cache.getItem(path + ':timestamp'),
+                modifyVarsHash = cache && cache.getItem(path + ':modifyVarsHash'),
+                currentModifyVarsHash = modifyVars?JSON.stringify(modifyVars):'';
 
             if (!reload && timestamp && webInfo.lastModified &&
                 (new(Date)(webInfo.lastModified).valueOf() ===
-                    new(Date)(timestamp).valueOf())) {
+                    new(Date)(timestamp).valueOf()) &&
+                currentModifyVarsHash == modifyVarsHash
+               ) {
                 // Use local copy
                 createCSS(css, sheet);
                 webInfo.local = true;
@@ -645,7 +650,7 @@ for (var i = 0; i < links.length; i++) {
 // With this function, it's possible to alter variables and re-render
 // CSS without reloading less-files
 //
-var temp_modifyVars=less.modifyVars; //--save client side config option
+var tempModifyVars=less.modifyVars; //--save client side config option
 less.modifyVars = function(record) {
     less.refresh(false, record);
 };
@@ -664,7 +669,7 @@ less.refresh = function (reload, modifyVars) {
             log("parsed " + sheet.href + " successfully.", logLevel.debug);
             var styles = root.toCSS(less);
             styles = postProcessCSS(styles);
-            createCSS(styles, sheet, env.lastModified);
+            createCSS(styles, sheet, env.lastModified, modifyVars);
         }
         log("css for " + sheet.href + " generated in " + (new Date() - endTime) + 'ms', logLevel.info);
         if (env.remaining === 0) {
@@ -680,4 +685,4 @@ less.refreshStyles = loadStyles;
 
 less.Parser.fileLoader = loadFile;
 
-less.refresh(less.env === 'development',temp_modifyVars);
+less.refresh(less.env === 'development',tempModifyVars);


### PR DESCRIPTION
When Set options in a global less object before loading the less.js script, less.modifyVars config option doesn't work as promised here:

http://lesscss.org/usage/#using-less-in-the-browser-poll

It will be useful when you define variable default value in a less file and overwrite default in the runtime before the first time parse.

e.g. overwrite the default value using the value in cookie