### PR TITLE
Adding handling for upper case drive letter in Windows

### DIFF
--- a/lib/less/browser.js
+++ b/lib/less/browser.js
@@ -469,7 +469,7 @@ function doXHR(url, type, callback, errback) {
 
 function loadFile(originalHref, currentFileInfo, callback, env, modifyVars) {
 
-    if (currentFileInfo && currentFileInfo.currentDirectory && !/^([a-z-]+:)?\//.test(originalHref)) {
+    if (currentFileInfo && currentFileInfo.currentDirectory && !/^([A-Za-z-]+:)?\//.test(originalHref)) {
         originalHref = currentFileInfo.currentDirectory + originalHref;
     }
 


### PR DESCRIPTION
The check fails when the path starts with a Windows letter drive that’s
upper case, causing the path to then include the currentDirectory.
This fails when a rootPath is specified along with an import statements
like:

@import url("brackets_colors.less");
