### PR TITLE
Import into media 1645

### DIFF
--- a/lib/less/import-visitor.js
+++ b/lib/less/import-visitor.js
@@ -133,7 +133,7 @@
             this.env.frames.shift();
         },
         visitMedia: function (mediaNode, visitArgs) {
-            this.env.frames.unshift(mediaNode.ruleset);
+            this.env.frames.unshift(mediaNode.rules[0]);
             return mediaNode;
         },
         visitMediaOut: function (mediaNode) {

--- a/test/css/import.css
+++ b/test/css/import.css
@@ -35,3 +35,8 @@
     color: yellow;
   }
 }
+@media print {
+  body {
+    width: 100%;
+  }
+}

--- a/test/less/import.less
+++ b/test/less/import.less
@@ -20,3 +20,7 @@
 @import (multiple) "import/import-test-e" screen and (max-width: 602px);
 
 @import (less, multiple) url("import/import-test-d.css") screen and (max-width: 603px);
+
+@media print {
+  @import (multiple) "import/import-test-e";
+}


### PR DESCRIPTION
Fixes interpolated import into media #1645

Media objects do not have ruleset property. They have [rules property](https://github.com/less/less.js/blob/a168b1f638d9e77681e882875056a8a87044af14/lib/less/tree/media.js#L10) which always contains one-member array with fake ruleset in it.
