### PR TITLE
Charsets should float on top #2126

### DIFF
--- a/lib/less/tree/directive.js
+++ b/lib/less/tree/directive.js
@@ -24,7 +24,10 @@ tree.Directive.prototype = {
         }
     },
     isRulesetLike: function() {
-        return "@charset" !== this.name;
+        return !this.isCharset();
+    },
+    isCharset: function() {
+        return "@charset" === this.name;
     },
     genCSS: function (env, output) {
         var value = this.value, rules = this.rules;

--- a/lib/less/tree/ruleset.js
+++ b/lib/less/tree/ruleset.js
@@ -266,6 +266,7 @@ tree.Ruleset.prototype = {
     },
     genCSS: function (env, output) {
         var i, j,
+            charsetRuleNodes = [],
             ruleNodes = [],
             rulesetNodes = [],
             rulesetNodeCnt,
@@ -306,9 +307,15 @@ tree.Ruleset.prototype = {
             if (isRulesetLikeNode(rule, this.root)) {
                 rulesetNodes.push(rule);
             } else {
-                ruleNodes.push(rule);
+                //charsets should float on top of everything
+                if (rule.isCharset && rule.isCharset()) {
+                    charsetRuleNodes.push(rule);
+                } else {
+                    ruleNodes.push(rule);
+                }
             }
         }
+        ruleNodes = charsetRuleNodes.concat(ruleNodes);
 
         // If this is the root node, we don't render
         // a selector, or {}.

--- a/test/less/import.less
+++ b/test/less/import.less
@@ -1,4 +1,3 @@
-@charset "UTF-8"; // stay on top #2013
 @import url(http://fonts.googleapis.com/css?family=Open+Sans);
 
 @import url(/absolute/something.css) screen and (color) and (max-width: 600px);
@@ -24,3 +23,6 @@
 @media print {
   @import (multiple) "import/import-test-e";
 }
+
+@charset "UTF-8"; // climb on top #2126
+


### PR DESCRIPTION
Fixes #2126

Charsets are placed in front of `ruleNodes` and thus printed first. 
