### PR TITLE
Fragment handling in data-uri function 1959

### DIFF
--- a/lib/less/functions.js
+++ b/lib/less/functions.js
@@ -422,6 +422,13 @@ tree.functions = {
             filePath = mimetype;
         }
 
+        var fragmentStart = filePath.indexOf('#');
+        var fragment = '';
+        if (fragmentStart!==-1) {
+            fragment = filePath.slice(fragmentStart);
+            filePath = filePath.slice(0, fragmentStart);
+        }
+
         if (this.env.isPathRelative(filePath)) {
             if (this.currentFileInfo.relativeUrls) {
                 filePath = path.join(this.currentFileInfo.currentDirectory, filePath);
@@ -470,7 +477,7 @@ tree.functions = {
         buf = useBase64 ? buf.toString('base64')
                         : encodeURIComponent(buf);
 
-        var uri = "\"data:" + mimetype + ',' + buf + "\"";
+        var uri = "\"data:" + mimetype + ',' + buf + fragment + "\"";
         return new(tree.URL)(new(tree.Anonymous)(uri));
     },
 

--- a/test/css/urls.css
+++ b/test/css/urls.css
@@ -53,6 +53,7 @@
 }
 #data-uri {
   uri: url("data:image/jpeg;base64,bm90IGFjdHVhbGx5IGEganBlZyBmaWxlCg==");
+  uri-fragment: url("data:image/jpeg;base64,bm90IGFjdHVhbGx5IGEganBlZyBmaWxlCg==#fragment");
 }
 #data-uri-guess {
   uri: url("data:image/jpeg;base64,bm90IGFjdHVhbGx5IGEganBlZyBmaWxlCg==");

--- a/test/less/urls.less
+++ b/test/less/urls.less
@@ -42,6 +42,7 @@
 
 #data-uri {
   uri: data-uri('image/jpeg;base64', '../data/image.jpg');
+  uri-fragment: data-uri('image/jpeg;base64', '../data/image.jpg#fragment');
 }
 
 #data-uri-guess {


### PR DESCRIPTION
The change removes #fragment from filePath before readig the file and adds it back to the end of the generated uri. Fixes #1959
