### PR TITLE
Add unused files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,13 @@
 .gitattributes
+benchmark
+build
+dist
+gradle*
+Gruntfile.js
+projectFilesBackup
+.idea
+test
+tmp
+.jshintrc
+.travis.yml
+build.gradle


### PR DESCRIPTION
There is a lot of files in npm repository, causing it being 10MB+ (mainly due to unused `dist` folder). This is really annoying for CI usage or similar cases where this additional size causes unnecessary slow-down.

You can inspect results of this change on my release: https://www.npmjs.org/package/less-minimal. It should work exactly the same as node version only requires files in `lib` and `bin`
