### PR TITLE
Notify when less.js is done processing

### DIFF
--- a/lib/less-browser/index.js
+++ b/lib/less-browser/index.js
@@ -239,12 +239,12 @@ for (var i = 0; i < links.length; i++) {
 // CSS without reloading less-files
 //
 less.modifyVars = function(record) {
-    less.refresh(false, record);
+    return less.refresh(false, record);
 };
 
 less.refresh = function (reload, modifyVars) {
-    return new PromiseConstructor(function(resolve, reject) {
-        var startTime, endTime;
+    less.hasFinished = new PromiseConstructor(function (resolve, reject) {
+        var startTime, endTime, totalMilliseconds;
         startTime = endTime = new Date();
 
         loadStyleSheets(function (e, css, _, sheet, webInfo) {
@@ -262,14 +262,22 @@ less.refresh = function (reload, modifyVars) {
             }
             less.logger.info("css for " + sheet.href + " generated in " + (new Date() - endTime) + 'ms');
             if (webInfo.remaining === 0) {
-                less.logger.info("less has finished. css generated in " + (new Date() - startTime) + 'ms');
-                resolve();
+                totalMilliseconds = new Date() - startTime;
+                less.logger.info("less has finished. css generated in " + totalMilliseconds + 'ms');
+                resolve({
+                    startTime: startTime,
+                    endTime: endTime,
+                    totalMilliseconds: totalMilliseconds,
+                    sheets: less.sheets.length
+                });
             }
             endTime = new Date();
         }, reload, modifyVars);
     
         loadStyles(modifyVars);
     });
+
+    return less.hasFinished;
 };
 
 less.refreshStyles = loadStyles;


### PR DESCRIPTION
Fixes issue #283 "How to tell when less is done processing ?"

**Problem**
When using less.js in the browser it is sometimes necessary to wait for less.js to finish processing and applying new css values before running additional code or tests. However, there is no way to tell when less.js is done.  This means developers are using timeouts, intervals, and other hacky code as a work around.

**Use cases**
- Executing code that is depending on less.js having finished processing.
- Delaying E2E tests for an in browser theme customizer until less.js has completed its refresh().
- Avoiding FOUC by hiding elements and displaying them after less.js has completed.

**Solutions** (thus far proposed)
- Fire an event after procesing.
- Call a callback function after LESS is done processing.
- Have less.refresh() return a promise.
