### PR TITLE
Method to scan for and register stylesheets

### DIFF
--- a/lib/less-browser/index.js
+++ b/lib/less-browser/index.js
@@ -223,7 +223,7 @@ if (/!watch/.test(location.hash)) {
 //
 // Get all <link> tags with the 'rel' attribute set to "stylesheet/less"
 //
-less.registerStylesheets = function(callback) {
+less.registerStylesheets = function() {
     return new PromiseConstructor(function(resolve, reject) {
         var links = document.getElementsByTagName('link');
         less.sheets = [];


### PR DESCRIPTION
**Problem**
As web apps become more dynamic developers are now finding they have the need to load/unload stylesheets dynamically.  Currently, less does one initial scan for stylesheets on load.  This means less will not parse stylesheets added dynamically after page load, even when calling `less.refresh()` or `less.modifyVars()`.

**Proposed Solution**
Make the stylesheet loading code available as a method, returning a promise.  On resolve, you can `.then()` call a `less.refresh()` or `less.modifyVars()`:

``` javascript
less.registerStylesheets().then(
    function () {
        less.modifyVars(record);
    }
);
```
