### PR TITLE
Support reading less options from its script tag data attributes

### DIFF
--- a/lib/less-browser/index.js
+++ b/lib/less-browser/index.js
@@ -16,7 +16,11 @@ var isFileProtocol = /^(file|chrome(-extension)?|resource|qrc|app):/.test(window
     options = window.less || {};
 
 // use options from the current script tag data attribues
-options = addDataAttr(options);
+var script = document.currentScript || (function() {
+    var scripts = document.getElementsByTagName("script");
+    return scripts[scripts.length - 1];
+})();
+options = addDataAttr(options, script);
 
 // shim Promise if required
 require('promise/polyfill.js');
@@ -127,7 +131,7 @@ function loadStyles(modifyVars) {
 
 function loadStyleSheet(sheet, callback, reload, remaining, modifyVars) {
 
-    var instanceOptions = clone(options);
+    var instanceOptions = addDataAttr(clone(options), sheet);
     instanceOptions.mime = sheet.type;
 
     if (modifyVars) {

--- a/lib/less-browser/utils.js
+++ b/lib/less-browser/utils.js
@@ -1,4 +1,3 @@
-/* global document */
 module.exports = {
     extractId: function(href) {
         return href.replace(/^[a-z-]+:\/+?[^\/]+/, '' )  // Remove protocol & domain
@@ -7,17 +6,13 @@ module.exports = {
             .replace(/[^\.\w-]+/g,          '-')  // Replace illegal characters
             .replace(/\./g,                 ':'); // Replace dots with colons(for valid id)
     },
-    addDataAttr: function(options) {
-        var script = document.currentScript || (function() {
-            var scripts = document.getElementsByTagName("script");
-            return scripts[scripts.length - 1];
-        })();
-        for (var opt in script.dataset)
-            if (script.dataset.hasOwnProperty(opt)) {
+    addDataAttr: function(options, tag) {
+        for (var opt in tag.dataset)
+            if (tag.dataset.hasOwnProperty(opt)) {
                 if (opt === "env" || opt === "dumpLineNumbers" || opt === "rootpath" || opt === "errorReporting")
-                    options[opt] = script.dataset[opt];
+                    options[opt] = tag.dataset[opt];
                 else
-                    options[opt] = JSON.parse(script.dataset[opt]);
+                    options[opt] = JSON.parse(tag.dataset[opt]);
             }
         return options;
     }


### PR DESCRIPTION
add support to reading less script tag data attr like this:

``` html
<script defer data-file-async="true"  data-verbose="false" data-log-level="1" src="js/libs/less.min.js" type="text/javascript"></script>
```

it is more easier and cleaner.

 if you found this useful, I will send an extra [commit](https://github.com/lejenome/less.js/compare/lejenome:master...addDataAttr2) that will add support to read data attributes from less files link tag too (useful it needs some specific options per less file like following)

``` html
<link data-dump-line-numbers="all" data-relative-urls="true" data-global-vars='{ myvar: "#ddffee", mystr: "\"quoted\"" }' rel="stylesheet/less" type="text/css" href="less/styles.less">
```
