### PR TITLE
fix rootpath without / at the end handling

### DIFF
--- a/lib/less/render.js
+++ b/lib/less/render.js
@@ -45,6 +45,9 @@ module.exports = function(environment, ParseTree, ImportManager) {
                 };
             }
 
+            if (rootFileInfo.rootpath && rootFileInfo.rootpath.slice(-1) !== "/")
+                rootFileInfo.rootpath += "/";
+
             var imports = new ImportManager(context, rootFileInfo);
             var parser = new Parser(context, imports, rootFileInfo);
 


### PR DESCRIPTION
less does not handle pathroot option without "/" at the end
e.g, ```data-rootpath=".."``` or ```-rp=..``` with this code
```css
backgroud-image: url("imgs/pic.png")
```
will outputs:
```css
backgroud-image: url("..imgs/pic.png")
```
instead of
```css
backgroud-image: url("../imgs/pic.png")
```
**NOTE:** I'm not sure if others options need this check too (e.g: --source-map-rootpath,...)