### PR TITLE
Fix for import relative path for url with parameters

### DIFF
--- a/lib/less/environment/abstract-file-manager.js
+++ b/lib/less/environment/abstract-file-manager.js
@@ -2,7 +2,11 @@ var abstractFileManager = function() {
 };
 
 abstractFileManager.prototype.getPath = function (filename) {
-    var j = filename.lastIndexOf('/');
+    var j = filename.lastIndexOf('?');
+    if (j < 0) {
+        filename = filename.slice(0, j);
+    }
+    j = filename.lastIndexOf('/');
     if (j < 0) {
         j = filename.lastIndexOf('\\');
     }


### PR DESCRIPTION
We generate final less file by script on server with parameters like `blah1/blah2/blah_pack.script?use=/less/src` in generated final less file we import `./variables.less` with relative path.
In older version of less.js it's works fine. But in 2.0.0 it's broken.

less.js tries to load variables.less by url `blah1/blah2/blah_pack.script?use=/less/variables.less` but it's wrong
