### PR TITLE
Remove livereload cache buster param in extractId

### DIFF
--- a/lib/less-browser/utils.js
+++ b/lib/less-browser/utils.js
@@ -1,6 +1,7 @@
 module.exports = {
     extractId: function(href) {
         return href.replace(/^[a-z-]+:\/+?[^\/]+/, '' )  // Remove protocol & domain
+            .replace(/[\?\&]livereload=\w+/,'' )  // Remove LiveReload cachebuster
             .replace(/^\//,                 '' )  // Remove root /
             .replace(/\.[a-zA-Z]+$/,        '' )  // Remove simple extension
             .replace(/[^\.\w-]+/g,          '-')  // Replace illegal characters


### PR DESCRIPTION
When using [grunt-contrib-watch](https://github.com/gruntjs/grunt-contrib-watch) for livereload and using less.js during development causes the reloading of less styles to happen incorrectly.  Basically [tiny-lr](https://github.com/mklabs/tiny-lr) (used by grunt-contrib-watch) adds a query param to all the files it retrieves like "?livereload={{current time}}".  Less.js then uses that url to try to extract the id of the given less file and sees each one as unique instead of the appropriate file.

This causes the livereload/less combination to add the styles from the changed less file but not remove the old ones.  More discussion can be found here:
https://github.com/cgross/generator-cg-angular/issues/60

Credit for researching the issue and determining the fix goes to @bpartridge.
