### PR TITLE
Fix getting of character at index

### DIFF
--- a/lib/less/parser/parser-input.js
+++ b/lib/less/parser/parser-input.js
@@ -132,7 +132,7 @@ module.exports = function() {
             c = inp.charCodeAt(parserInput.i);
 
             if (parserInput.autoCommentAbsorb && c === CHARCODE_FORWARD_SLASH) {
-                nextChar = inp[parserInput.i + 1];
+                nextChar = inp.charAt(parserInput.i + 1);
                 if (nextChar === '/') {
                     comment = {index: parserInput.i, isLineComment: true};
                     var nextNewLine = inp.indexOf("\n", parserInput.i + 1);


### PR DESCRIPTION
Getting of character at index is not working in Internet Explorer 7 and below.
