### PR TITLE
Improve keyword and anonymous input for replace function (fixes #2308).

### DIFF
--- a/lib/less/tree/quoted.js
+++ b/lib/less/tree/quoted.js
@@ -3,7 +3,7 @@ var Node = require("./node"),
     Variable = require("./variable");
 
 var Quoted = function (str, content, escaped, index, currentFileInfo) {
-    this.escaped = escaped;
+    this.escaped = (escaped == null) ? true : escaped;
     this.value = content || '';
     this.quote = str.charAt(0);
     this.index = index;

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -161,3 +161,15 @@
   extract: 3 2 1 C B A;
   length: 6;
 }
+#quoted-functions-in-mixin {
+  replace-double-quoted: 'foo-2';
+  replace-single-quoted: 'foo-4';
+  replace-escaped-string: bar-2;
+  replace-keyword: baz-2;
+  replace-anonymous: qux-2;
+  format-double-quoted: "hello world";
+  format-single-quoted: 'hello single world';
+  format-escaped-string: hello escaped world;
+  format-keyword: hello;
+  format-anonymous: hello anonymous world;
+}

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -176,3 +176,21 @@
   extract: extract(@anon, 6) extract(@anon, 5) extract(@anon, 4) extract(@anon, 3) extract(@anon, 2) extract(@anon, 1);
   length: length(@anon);
 }
+
+#quoted-functions-in-mixin {
+  // Quoted type may have some weird side-effects when used in mixins (#2308)
+  .mixin();
+  .mixin() {
+    replace-double-quoted: replace('foo-1', "1", "2");
+    replace-single-quoted: replace('foo-3', "3", "4");
+    replace-escaped-string: replace(~"bar-1", "1", "2");
+    replace-keyword: replace(baz-1, "1", "2");
+    replace-anonymous: replace(e("qux-1"), "1", "2");
+    format-double-quoted: %("hello %s", "world");
+    format-single-quoted: %('hello %s', "single world");
+    format-escaped-string: %(~"hello %s", "escaped world");
+    format-keyword: %(hello);
+    format-anonymous: %(e("hello %s"), "anonymous world");
+  }
+}
+


### PR DESCRIPTION
See #2308. For a consistency the same fix is applied to the `%` function (I actually made it by less verbose `Quoted` constructor change instead of modifying functions themselves).
Fixes code like:

```
#quoted-functions-in-mixin {
  .mixin();
  .mixin() {
    replace-keyword: replace(baz-1, "1", "2");
    replace-anonymous: replace(e("qux-1"), "1", "2");
    format-keyword: %(hello);
    format-anonymous: %(e("hello %s"), "anonymous world");
  }
}
```
