### PR TITLE
Pass this from promise based calling

### DIFF
--- a/lib/less/render.js
+++ b/lib/less/render.js
@@ -13,8 +13,9 @@ module.exports = function(environment, ParseTree, ImportManager) {
         }
 
         if (!callback) {
+            var self = this;
             return new PromiseConstructor(function (resolve, reject) {
-                render(input, options, function(err, output) {
+                render.call(self, input, options, function(err, output) {
                     if (err) {
                         reject(err);
                     } else {


### PR DESCRIPTION
Fixes https://github.com/less/less-plugin-npm-import/issues/4

Plugins rely on the `this` context being correctly set for the render function, but it was not correctly set in the case of the promise code path.  This fixes that so that it works correctly.
