### PR TITLE
Fix double handling of exceptions

### DIFF
--- a/lib/less/render.js
+++ b/lib/less/render.js
@@ -52,12 +52,13 @@ module.exports = function(environment, ParseTree, ImportManager) {
             new Parser(context, imports, rootFileInfo)
                 .parse(input, function (e, root) {
                 if (e) { return callback(e); }
+                var result;
                 try {
                     var parseTree = new ParseTree(root, imports);
-                    var result = parseTree.toCSS(options);
-                    callback(null, result);
+                    result = parseTree.toCSS(options);
                 }
-                catch (err) { callback( err); }
+                catch (err) { return callback( err); }
+                callback(null, result);
             }, options);
         }
     };


### PR DESCRIPTION
This only effects the callback based code path.  Consider code like:

``` js
less.render(str, options, function (err, res) {
  if (err) {
    console.log('error handler');
    return;
  }
  throw new Error('Ooops, I made a mistake');
});
```

In the case where less rendering succeeds.  This should crash with the error "Ooops, I made a mistake" but instead it logs "error handler" and exists cleanly.  This is because the initial error is incorrectly caught by the try catch block and given back to the callback.

This pull request fixes the bug.
