### PR TITLE
Support non-JSON script attributes

### DIFF
--- a/lib/less-browser/utils.js
+++ b/lib/less-browser/utils.js
@@ -13,7 +13,10 @@ module.exports = {
                 if (opt === "env" || opt === "dumpLineNumbers" || opt === "rootpath" || opt === "errorReporting") {
                     options[opt] = tag.dataset[opt];
                 } else {
-                    options[opt] = JSON.parse(tag.dataset[opt]);
+                    try {
+                        options[opt] = JSON.parse(tag.dataset[opt]);
+                    }
+                    catch(_) {}
                 }
             }
         }


### PR DESCRIPTION
This change was necessary to support loading `lessc` through RequireJS which adds the `requirecontext` and `requiremodule` attributes.
