### PR TITLE
Expose Less parsing as a top level feature of the less package

### DIFF
--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -17,6 +17,7 @@ module.exports = function(environment, fileManagers) {
         ParseTree: (ParseTree = require('./parse-tree')(SourceMapBuilder)),
         ImportManager: (ImportManager = require('./import-manager')(environment)),
         render: require("./render")(environment, ParseTree, ImportManager),
+        parse: require("./parse")(environment, ParseTree, ImportManager),
         LessError: require('./less-error'),
         transformTree: require('./transform-tree'),
         utils: require('./utils'),

--- a/lib/less/parse.js
+++ b/lib/less/parse.js
@@ -1,0 +1,61 @@
+var PromiseConstructor = typeof Promise === 'undefined' ? require('promise') : Promise,
+    contexts = require("./contexts"),
+    Parser = require('./parser/parser'),
+    PluginManager = require('./plugin-manager');
+
+module.exports = function(environment, ParseTree, ImportManager) {
+    var parse = function (input, options, callback) {
+        options = options || {};
+
+        if (typeof(options) === 'function') {
+            callback = options;
+            options = {};
+        }
+
+        if (!callback) {
+            var self = this;
+            return new PromiseConstructor(function (resolve, reject) {
+                parse.call(self, input, options, function(err, output) {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(output);
+                    }
+                });
+            });
+        } else {
+            var context,
+                rootFileInfo,
+                pluginManager = new PluginManager(this);
+
+            pluginManager.addPlugins(options.plugins);
+            options.pluginManager = pluginManager;
+
+            context = new contexts.Parse(options);
+
+            if (options.rootFileInfo) {
+                rootFileInfo = options.rootFileInfo;
+            } else {
+                var filename = options.filename || "input";
+                var entryPath = filename.replace(/[^\/\\]*$/, "");
+                rootFileInfo = {
+                    filename: filename,
+                    relativeUrls: context.relativeUrls,
+                    rootpath: context.rootpath || "",
+                    currentDirectory: entryPath,
+                    entryPath: entryPath,
+                    rootFilename: filename
+                };
+            }
+
+            var imports = new ImportManager(context, rootFileInfo);
+
+            new Parser(context, imports, rootFileInfo)
+                .parse(input, function (e, root) {
+                if (e) { return callback(e); }
+                callback(null, root, imports, options);
+            }, options);
+        }
+    };
+    return parse;
+};

--- a/lib/less/render.js
+++ b/lib/less/render.js
@@ -1,11 +1,8 @@
-var PromiseConstructor = typeof Promise === 'undefined' ? require('promise') : Promise,
-    contexts = require("./contexts"),
-    Parser = require('./parser/parser'),
-    PluginManager = require('./plugin-manager');
+var PromiseConstructor = typeof Promise === 'undefined' ? require('promise') : Promise;
 
 module.exports = function(environment, ParseTree, ImportManager) {
     var render = function (input, options, callback) {
-        options = options || {};
+        var parse = require('./parse')(environment, ParseTree, ImportManager);
 
         if (typeof(options) === 'function') {
             callback = options;
@@ -24,44 +21,20 @@ module.exports = function(environment, ParseTree, ImportManager) {
                 });
             });
         } else {
-            var context,
-                rootFileInfo,
-                pluginManager = new PluginManager(this);
+            parse(input, options, function(err, root, imports, options) {
+                if (err) { return callback(err); }
 
-            pluginManager.addPlugins(options.plugins);
-            options.pluginManager = pluginManager;
-
-            context = new contexts.Parse(options);
-
-            if (options.rootFileInfo) {
-                rootFileInfo = options.rootFileInfo;
-            } else {
-                var filename = options.filename || "input";
-                var entryPath = filename.replace(/[^\/\\]*$/, "");
-                rootFileInfo = {
-                    filename: filename,
-                    relativeUrls: context.relativeUrls,
-                    rootpath: context.rootpath || "",
-                    currentDirectory: entryPath,
-                    entryPath: entryPath,
-                    rootFilename: filename
-                };
-            }
-
-            var imports = new ImportManager(context, rootFileInfo);
-
-            new Parser(context, imports, rootFileInfo)
-                .parse(input, function (e, root) {
-                if (e) { return callback(e); }
                 var result;
                 try {
                     var parseTree = new ParseTree(root, imports);
                     result = parseTree.toCSS(options);
                 }
-                catch (err) { return callback( err); }
+                catch (err) { return callback(err); }
+
                 callback(null, result);
-            }, options);
+            });
         }
     };
+
     return render;
 };


### PR DESCRIPTION
Converting a Less stylesheet into an AST is a valuable piece of functionality, and worthy of being easily accessible to consumers of less.js. There have been issues submitted in the past about accessing the AST generated by the LESS parser, and without copy/pasting much of the code found within `lib/render.js`, it has thus far been a difficult task.

This pull request strips the parsing functionality out of `render.js` and moves it to `parse.js`, making it a top level property of the `less` module. In the same way that `less.render` takes a less string and returns a css string, `less.parse` takes a less string and returns a less AST.

I would also like to propose having the option to have extra data attached to this AST (for example, line/column location information for tokens like rules, imports, variables, mixin calls, etc), but before I started working on that, I wanted to get your opinion on this feature first.

Thanks.