### PR TITLE
Fix isunit() not able to check if dimension has no unit.

### DIFF
--- a/lib/less/functions/types.js
+++ b/lib/less/functions/types.js
@@ -11,6 +11,9 @@ var isa = function (n, Type) {
     return (n instanceof Type) ? Keyword.True : Keyword.False;
     },
     isunit = function (n, unit) {
+        if (unit === undefined) {
+            throw { type: "Argument", message: "missing the required second argument to isunit." };
+        }
         return (n instanceof Dimension) && n.unit.is(unit.value !== undefined ? unit.value : unit) ? Keyword.True : Keyword.False;
     };
 functionRegistry.addMultiple({

--- a/lib/less/functions/types.js
+++ b/lib/less/functions/types.js
@@ -11,7 +11,7 @@ var isa = function (n, Type) {
     return (n instanceof Type) ? Keyword.True : Keyword.False;
     },
     isunit = function (n, unit) {
-        return (n instanceof Dimension) && n.unit.is(unit.value || unit) ? Keyword.True : Keyword.False;
+        return (n instanceof Dimension) && n.unit.is(unit.value !== undefined ? unit.value : unit) ? Keyword.True : Keyword.False;
     };
 functionRegistry.addMultiple({
     iscolor: function (n) {

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -137,6 +137,7 @@
   pixel: true;
   percent: true;
   em: true;
+  unitless: true;
   cat: true;
   case-insensitive-1: true;
   case-insensitive-2: true;

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -147,6 +147,7 @@
     pixel: ispixel(32px);
     percent: ispercentage(32%);
     em: isem(32em);
+    unitless: isunit(32, '');
     cat: isunit(32cat, cat);
     case-insensitive-1: isunit(32CAT, cat);
     case-insensitive-2: isunit(32px, PX);


### PR DESCRIPTION
Currently `isunit(32, '')` evaluates with a cryptic error message: "error evaluating function `isunit`: Object [object Object] has no method 'toUpperCase'. Expected behaviour: it should evaluate to `true` without an error.