### PR TITLE
Better output for the warning when file size exceeds

### DIFF
--- a/lib/less/functions/data-uri.js
+++ b/lib/less/functions/data-uri.js
@@ -62,7 +62,7 @@ module.exports = function(environment) {
         if (fileSizeInKB >= DATA_URI_MAX_KB) {
 
             if (this.context.ieCompat !== false) {
-                logger.warn("Skipped data-uri embedding of %s because its size (%dKB) exceeds IE8-safe %dKB!", filePath, fileSizeInKB, DATA_URI_MAX_KB);
+                logger.warn("Skipped data-uri embedding of " + filePath + " because its size (" + fileSizeInKB.toFixed(1) + "KB) exceeds IE8-safe " + DATA_URI_MAX_KB.toFixed(1) + "KB!");
 
                 return fallback(this, filePathNode || mimetypeNode);
             }


### PR DESCRIPTION
As far as i understand does the logger.warn() function not accept such string neither has Less a built-in string format  function?