### PR TITLE
DATA_URI_MAX_KB should compare the length of the base64 encoded string

### DIFF
--- a/lib/less/functions/data-uri.js
+++ b/lib/less/functions/data-uri.js
@@ -58,11 +58,13 @@ module.exports = function(environment) {
         // IE8 cannot handle a data-uri larger than 32KB. If this is exceeded
         // and the --ieCompat flag is enabled, return a normal url() instead.
         var DATA_URI_MAX_KB = 32,
-            fileSizeInKB = parseInt((buf.length / 1024), 10);
-        if (fileSizeInKB >= DATA_URI_MAX_KB) {
+            fileSizeInKB = parseInt((buf.length / 1024), 10),
+            Base64SizeInKB = fileSizeInKB * 4/3;
+            
+        if (Base64SizeInKB >= DATA_URI_MAX_KB) {
 
             if (this.context.ieCompat !== false) {
-                logger.warn("Skipped data-uri embedding of %s because its size (%dKB) exceeds IE8-safe %dKB!", filePath, fileSizeInKB, DATA_URI_MAX_KB);
+                logger.warn("Skipped data-uri embedding of " + filePath + " because the base64-encode size of the content (" + Base64SizeInKB.toFixed(1) + "KB) exceeds IE8-safe " + DATA_URI_MAX_KB.toFixed(1) + "KB!");
 
                 return fallback(this, filePathNode || mimetypeNode);
             }


### PR DESCRIPTION
When IE accepts only a string of 32KB, and a base64 encoding has the size of 4/3 * its original (according wikipedia) the max file size should be 32KB / (4/3) = 24KB?