### PR TITLE
making sure :extend warning does not bubble up, fixes #1618

### DIFF
--- a/lib/less/visitors/extend-visitor.js
+++ b/lib/less/visitors/extend-visitor.js
@@ -105,7 +105,7 @@ ProcessExtendsVisitor.prototype = {
     },
     checkExtendsForNonMatched: function(extendList) {
         extendList.filter(function(extend) {
-            return !extend.hasFoundMatches;
+            return !extend.hasFoundMatches && extend.parent_ids.length == 1;
         }).forEach(function(extend) {
                 var selector = "_unknown_";
                 try {


### PR DESCRIPTION
See discussion in #1618 -- This seems to be the solution:

> parent_ids contains all the selectors which this extend has to draw from. If the extend has more than one parent, it's a reference done in another selector.

I don't know if you can test for warnings in the current setup. The test output for `extend_chaining` seems to be correct.