### PR TITLE
variable variables with named colors error

### DIFF
--- a/lib/less/tree/variable.js
+++ b/lib/less/tree/variable.js
@@ -7,11 +7,12 @@ var Variable = function (name, index, currentFileInfo) {
 };
 Variable.prototype = new Node();
 Variable.prototype.type = "Variable";
-Variable.prototype.eval = function (context) {
+Variable.prototype.eval = function (context,variablevariable) {
     var variable, name = this.name;
-
+    variablevariable !== 'undefined' ? true : false;
+    
     if (name.indexOf('@@') === 0) {
-        name = '@' + new Variable(name.slice(1), this.index, this.currentFileInfo).eval(context).value;
+        name = '@' + new Variable(name.slice(1), this.index, this.currentFileInfo).eval(context,true).value;
     }
 
     if (this.evaluating) {
@@ -30,6 +31,13 @@ Variable.prototype.eval = function (context) {
                 var importantScope = context.importantScope[context.importantScope.length-1];
                 importantScope.important = v.important;
             }
+            if(variablevariable && v.value.keyword && v.value.rgb){
+		    //v.value.value = v.value.keyword;
+		    throw { type: 'Name',
+                message: "the name of a variable should be a string not a color(" + v.value.keyword + ")",
+                filename: v.currentFileInfo.filename,
+                index: v.index };
+		    } 
             return v.value.eval(context);
         }
     });


### PR DESCRIPTION
I not sure if this PR make sense at all. But i found that:

```css
@color: blue;
@blue: yellow;
s{
p: @@color;
}
```

throws: `NameError: variable @undefined is undefined in`, the error makes sense cause a color can not be the name of a variable, but the error message does not.
Instead of trowing an error, the problems seems also to fix with `v.value.value = v.value.keyword;`.

Possible everybody knows already have to use only strings  or only the documentation at http://lesscss.org/features/#variables-feature-variable-names should be updated for that.