### PR TITLE
double proctocol

### DIFF
--- a/lib/less/tree/debug-info.js
+++ b/lib/less/tree/debug-info.js
@@ -22,7 +22,7 @@ debugInfo.asComment = function(ctx) {
 
 debugInfo.asMediaQuery = function(ctx) {
     return '@media -sass-debug-info{filename{font-family:' +
-        ('file://' + ctx.debugInfo.fileName).replace(/([.:\/\\])/g, function (a) {
+        ctx.debugInfo.fileName.replace(/([.:\/\\])/g, function (a) {
             if (a == '\\') {
                 a = '\/';
             }


### PR DESCRIPTION
As far as i understand `ctx.debugInfo.fileName` already contains the full path including protocol, so prepending `file:` is not necessary.