### PR TITLE
no sourcemap without  css filename

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -274,10 +274,15 @@ if (output) {
 if (options.sourceMap) {
 
     sourceMapOptions.sourceMapInputFilename = input;
-    if (!sourceMapOptions.sourceMapFullFilename) {
+    if (!sourceMapOptions.sourceMapFullFilename || (!output && sourceMapOptions.sourceMapFullFilename)) {
         if (!output && !sourceMapFileInline) {
-            console.log("the sourcemap option only has an optional filename if the css filename is given");
-            console.log("consider adding --source-map-map-inline which embeds the sourcemap into the css");
+            if(sourceMapOptions.sourceMapFullFilename) {
+            console.warn("the sourcemap option requires the css filename to be given");
+            }
+            else { 
+            console.warn("the sourcemap option only has an optional filename if the css filename is given");
+            }
+            console.warn("consider adding --source-map-map-inline which embeds the sourcemap into the css");
             return;
         }
         // its in the same directory, so always just the basename


### PR DESCRIPTION
As far as i understand, sourcemaps should not be generate when the css filename has not been set.
See also: http://stackoverflow.com/questions/27918017/lessc-source-maps-not-working/27926182

In the case you are redirecting the output to a file, `console.log` is also redirect, so changed it to `console.warn`