### PR TITLE
Allow selector interpolation inside pseudoselectors. #1294

### DIFF
--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -858,7 +858,7 @@ var Parser = function Parser(context, imports, fileInfo) {
                 c = this.combinator();
 
                 e = parserInput.$re(/^(?:\d+\.\d+|\d+)%/) || parserInput.$re(/^(?:[.#]?|:*)(?:[\w-]|[^\x00-\x9f]|\\(?:[A-Fa-f0-9]{1,6} ?|[^A-Fa-f0-9]))+/) ||
-                    parserInput.$char('*') || parserInput.$char('&') || this.attribute() || parserInput.$re(/^\([^()@]+\)/) || parserInput.$re(/^[\.#](?=@)/) ||
+                    parserInput.$char('*') || parserInput.$char('&') || this.attribute() || parserInput.$re(/^\([^()@]+\)/) || parserInput.$re(/^[\.#:](?=@)/) ||
                     this.entities.variableCurly();
 
                 if (! e) {

--- a/test/css/selectors.css
+++ b/test/css/selectors.css
@@ -119,7 +119,7 @@ p a span {
 .bloodred {
   color: green;
 }
-#blood.blood.red.black {
+#blood.blood.red.black:blood {
   color: black;
 }
 :nth-child(3) {

--- a/test/less/selectors.less
+++ b/test/less/selectors.less
@@ -117,7 +117,7 @@ a {
   color: green;
 }
 .red {
-  #@{theme}.@{theme}&.black {
+  #@{theme}.@{theme}&.black:@{theme} {
     color:black;
   }
 }


### PR DESCRIPTION
Added pseudoselector symbol `:` into set of characters that allow curly variable after them. #1294