### PR TITLE
endlines and comments

### DIFF
--- a/lib/less/parser/parser-input.js
+++ b/lib/less/parser/parser-input.js
@@ -126,7 +126,7 @@ module.exports = function() {
             curr = parserInput.i - currentPos,
             endIndex = parserInput.i + current.length - curr,
             mem = (parserInput.i += length),
-            inp = input.replace(/\r\n|\r/gm, "\n"),
+            inp = input,
             c, nextChar, comment;
 
         for (; parserInput.i < endIndex; parserInput.i++) {

--- a/lib/less/parser/parser-input.js
+++ b/lib/less/parser/parser-input.js
@@ -126,7 +126,7 @@ module.exports = function() {
             curr = parserInput.i - currentPos,
             endIndex = parserInput.i + current.length - curr,
             mem = (parserInput.i += length),
-            inp = input,
+            inp = input.replace(/\r\n|\r/gm, "\n"),
             c, nextChar, comment;
 
         for (; parserInput.i < endIndex; parserInput.i++) {

--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -102,7 +102,7 @@ var Parser = function Parser(context, imports, fileInfo) {
                 imports.contentsIgnoredChars[fileInfo.filename] = preText.length;
             }
 
-            str = str.replace(/\r\n/g, '\n');
+            str = str.replace(/\r\n?/g, '\n');
             // Remove potential UTF Byte Order Mark
             str = preText + str.replace(/^\uFEFF/, '') + modifyVars;
             imports.contents[fileInfo.filename] = str;


### PR DESCRIPTION
possible fix for https://github.com/less/less.js/issues/2370

I have used the following command to test this issue: `printf "p {\r//less\rc:1;\r}\r" | lessc -`

I'm not sure if this the most efficient fix.
I also tried `var nextNewLine = inp.substr(parserInput.i + 1).search(/\n|\r/);` to replace the `indexOf` but then i expect possible mismatches for `\r\n` which match on the first `\r`.