### PR TITLE
Bug: extend doesn't work when appended on nested selector with &

### DIFF
--- a/lib/less/tree/ruleset.js
+++ b/lib/less/tree/ruleset.js
@@ -498,7 +498,7 @@ Ruleset.prototype.joinSelector = function (paths, context, selector) {
         // }
         // == [[.a] [.c]] [[.b] [.c]]
         //
-        var i, j, k, currentElements, newSelectors, selectorsMultiplied, sel, el, hadParentSelector = false;
+        var i, j, k, currentElements, newSelectors, selectorsMultiplied, sel, el, hadParentSelector = false, length, lastSelector;
         function findNestedSelector(element) {
             var maybeSelector;
             if (element.value.type !== 'Paren') {
@@ -592,8 +592,11 @@ Ruleset.prototype.joinSelector = function (paths, context, selector) {
         mergeElementsOnToSelectors(currentElements, newSelectors);
 
         for (i = 0; i < newSelectors.length; i++) {
-            if (newSelectors[i].length > 0) {
+            length = newSelectors[i].length;
+            if (length > 0) {
                 paths.push(newSelectors[i]);
+                lastSelector = newSelectors[i][length - 1];
+                newSelectors[i][length - 1] = lastSelector.createDerived(lastSelector.elements, inSelector.extendList);
             }
         }
 

--- a/test/css/selectors.css
+++ b/test/css/selectors.css
@@ -163,3 +163,8 @@ blank blank blank blank blank blank blank blank blank blank blank blank blank bl
 .selector:not(:hover) {
   test: global scope;
 }
+.extend-this,
+.active.first-level .second-level,
+.first-level .second-level.active2 {
+  content: '\2661';
+}

--- a/test/less/selectors.less
+++ b/test/less/selectors.less
@@ -172,3 +172,13 @@ blank blank blank blank blank blank blank blank blank blank blank blank blank bl
 .selector:not(&:hover) {
   test: global scope;
 }
+// https://github.com/less/less.js/issues/2206
+.extend-this {
+  content: '\2661';
+}
+.first-level {
+  .second-level {
+    .active&:extend(.extend-this) { }
+    &.active2:extend(.extend-this) { }
+  }
+}


### PR DESCRIPTION
Selector composed from multiple joined selectors should keep original extends. #2206