### PR TITLE
use variables for combinators

### DIFF
--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -94,6 +94,17 @@ var Parser = function Parser(context, imports, fileInfo) {
         parse: function (str, callback, additionalData) {
             var root, error = null, globalVars, modifyVars, ignored, preText = "";
 
+            // combinator variables
+            if (!additionalData.globalVars) {
+                additionalData.globalVars = [];
+            }
+
+            additionalData.globalVars['less-internal-gt'] = "~\">\"";
+            additionalData.globalVars['less-internal-plus'] = "~\"+\"";
+            additionalData.globalVars['less-internal-tilde'] = "~\"~\"";
+            additionalData.globalVars['less-internal-pipe'] = "~\"|\"";
+            additionalData.globalVars['less-internal-deep'] = "~\"/deep/\"";
+
             globalVars = (additionalData && additionalData.globalVars) ? Parser.serializeVars(additionalData.globalVars) + '\n' : '';
             modifyVars = (additionalData && additionalData.modifyVars) ? '\n' + Parser.serializeVars(additionalData.modifyVars) : '';
 
@@ -884,6 +895,28 @@ var Parser = function Parser(context, imports, fileInfo) {
             element: function () {
                 var e, c, v, index = parserInput.i;
 
+                if (parserInput.currentChar() === '>') {
+                    parserInput.i++;
+                    while (parserInput.isWhitespace()) { parserInput.i++; }
+                    return new(tree.Element)(" ", new(tree.Variable)('@less-internal-gt'), index, fileInfo);
+                } else if (parserInput.currentChar() === '+') {
+                    parserInput.i++;
+                    while (parserInput.isWhitespace()) { parserInput.i++; }
+                    return new(tree.Element)(" ", new(tree.Variable)('@less-internal-plus'), index, fileInfo);
+                } else if (parserInput.currentChar() === '~') {
+                    parserInput.i++;
+                    while (parserInput.isWhitespace()) { parserInput.i++; }
+                    return new(tree.Element)(" ", new(tree.Variable)('@less-internal-tilde'), index, fileInfo);
+                } else if (parserInput.currentChar() === '|') {
+                    parserInput.i++;
+                    while (parserInput.isWhitespace()) { parserInput.i++; }
+                    return new(tree.Element)(" ", new(tree.Variable)('@less-internal-pipe'), index, fileInfo);
+                } else if (parserInput.$re(/^\/deep\//)) {
+                    parserInput.i = parserInput.i++;
+                    while (parserInput.isWhitespace()) { parserInput.i++; }
+                    return new(tree.Element)(" ", new(tree.Variable)('@less-internal-deep'), index, fileInfo);
+                }
+
                 c = this.combinator();
 
                 e = parserInput.$re(/^(?:\d+\.\d+|\d+)%/) ||
@@ -919,27 +952,7 @@ var Parser = function Parser(context, imports, fileInfo) {
             // we deal with this in *combinator.js*.
             //
             combinator: function () {
-                var c = parserInput.currentChar();
-
-                if (c === '/') {
-                    parserInput.save();
-                    var slashedCombinator = parserInput.$re(/^\/[a-z]+\//i);
-                    if (slashedCombinator) {
-                        parserInput.forget();
-                        return new(tree.Combinator)(slashedCombinator);
-                    }
-                    parserInput.restore();
-                }
-
-                if (c === '>' || c === '+' || c === '~' || c === '|' || c === '^') {
-                    parserInput.i++;
-                    if (c === '^' && parserInput.currentChar() === '^') {
-                        c = '^^';
-                        parserInput.i++;
-                    }
-                    while (parserInput.isWhitespace()) { parserInput.i++; }
-                    return new(tree.Combinator)(c);
-                } else if (parserInput.isWhitespace(-1)) {
+                if (parserInput.isWhitespace(-1)) {
                     return new(tree.Combinator)(" ");
                 } else {
                     return new(tree.Combinator)(null);


### PR DESCRIPTION
In the current situation combinators should be followed by a selector, this requirement breaks nesting:

```less
p + {
p {
color: red;
}
}
```

outputs:

```less
p p {
color: red;
}
```

The preceding can be solved by using a variable:

```less
@plus : ~"+";
p @{plus} {
p {
color: red;
}
}
```

So i think the "nesting" issue can be solved by using variables for combinators. Code should probably require some factoring.

Related issues:
 - https://github.com/less/less.js/issues/2455
 - https://github.com/less/less.js/issues/2023
 - https://github.com/less/less.js/issues/1949