### PR TITLE
Bubbling of nested directives

### DIFF
--- a/lib/less/tree/directive.js
+++ b/lib/less/tree/directive.js
@@ -8,7 +8,6 @@ var Directive = function (name, value, rules, index, currentFileInfo, debugInfo,
     this.name  = name;
     this.value = value;
     if (rules) {
-        //FIXME: that isArray should be only temporary and removed afterwards
         if (Array.isArray(rules)) {
             this.rules = rules;
         } else {
@@ -50,17 +49,22 @@ Directive.prototype.genCSS = function (context, output) {
         value.genCSS(context, output);
     }
     if (rules) {
-        //FIXME: change to not array test
-        if (rules.type === "Ruleset") { //FIXME: this will not happen again, ruels are now arrays
-            rules = [rules];
-        }
         this.outputRuleset(context, output, rules);
     } else {
         output.add(';');
     }
 };
 Directive.prototype.eval = function (context) {
-    var value = this.value, rules = this.rules;
+    var mediaPathBackup, mediaBlocksBackup, value = this.value, rules = this.rules;
+
+    //media stored inside other directive should not bubble over it
+    //backpup media bubbling information
+    mediaPathBackup = context.mediaPath;
+    mediaBlocksBackup = context.mediaBlocks;
+    //deleted media bubbling information
+    context.mediaPath = [];
+    context.mediaBlocks = [];
+
     if (value) {
         value = value.eval(context);
     }
@@ -69,10 +73,13 @@ Directive.prototype.eval = function (context) {
         rules = [rules[0].eval(context)];
         rules[0].root = true;
     }
+    //restore media bubbling information
+    context.mediaPath = mediaPathBackup;
+    context.mediaBlocks = mediaBlocksBackup;
+
     return new Directive(this.name, value, rules,
         this.index, this.currentFileInfo, this.debugInfo, this.isReferenced);
 };
-//FIXME: following three functions are done like inside media
 Directive.prototype.variable = function (name) {
     if (this.rules) {
         // assuming that there is only one rule at this point - that is how parser constructs the rule

--- a/lib/less/tree/directive.js
+++ b/lib/less/tree/directive.js
@@ -1,12 +1,23 @@
 var Node = require("./node"),
+    Selector = require("./selector"),
     Ruleset = require("./ruleset");
 
 var Directive = function (name, value, rules, index, currentFileInfo, debugInfo, isReferenced) {
+    var i;
+
     this.name  = name;
     this.value = value;
     if (rules) {
-        this.rules = rules;
-        this.rules.allowImports = true;
+        //FIXME: that isArray should be only temporary and removed afterwards
+        if (Array.isArray(rules)) {
+            this.rules = rules;
+        } else {
+            this.rules = [rules];
+            this.rules[0].selectors = (new Selector([], null, null, this.index, currentFileInfo)).createEmptySelectors();
+        }
+        for (i = 0; i < this.rules.length; i++) {
+            this.rules[i].allowImports = true;
+        }
     }
     this.index = index;
     this.currentFileInfo = currentFileInfo;
@@ -19,7 +30,7 @@ Directive.prototype.type = "Directive";
 Directive.prototype.accept = function (visitor) {
     var value = this.value, rules = this.rules;
     if (rules) {
-        this.rules = visitor.visit(rules);
+        this.rules = visitor.visitArray(rules);
     }
     if (value) {
         this.value = visitor.visit(value);
@@ -39,7 +50,8 @@ Directive.prototype.genCSS = function (context, output) {
         value.genCSS(context, output);
     }
     if (rules) {
-        if (rules.type === "Ruleset") {
+        //FIXME: change to not array test
+        if (rules.type === "Ruleset") { //FIXME: this will not happen again, ruels are now arrays
             rules = [rules];
         }
         this.outputRuleset(context, output, rules);
@@ -53,32 +65,37 @@ Directive.prototype.eval = function (context) {
         value = value.eval(context);
     }
     if (rules) {
-        rules = rules.eval(context);
-        rules.root = true;
+        // assuming that there is only one rule at this point - that is how parser constructs the rule
+        rules = [rules[0].eval(context)];
+        rules[0].root = true;
     }
     return new Directive(this.name, value, rules,
         this.index, this.currentFileInfo, this.debugInfo, this.isReferenced);
 };
+//FIXME: following three functions are done like inside media
 Directive.prototype.variable = function (name) {
     if (this.rules) {
-        return Ruleset.prototype.variable.call(this.rules, name);
+        // assuming that there is only one rule at this point - that is how parser constructs the rule
+        return Ruleset.prototype.variable.call(this.rules[0], name);
     }
 };
 Directive.prototype.find = function () {
     if (this.rules) {
-        return Ruleset.prototype.find.apply(this.rules, arguments);
+        // assuming that there is only one rule at this point - that is how parser constructs the rule
+        return Ruleset.prototype.find.apply(this.rules[0], arguments);
     }
 };
 Directive.prototype.rulesets = function () {
     if (this.rules) {
-        return Ruleset.prototype.rulesets.apply(this.rules);
+        // assuming that there is only one rule at this point - that is how parser constructs the rule
+        return Ruleset.prototype.rulesets.apply(this.rules[0]);
     }
 };
 Directive.prototype.markReferenced = function () {
     var i, rules;
     this.isReferenced = true;
     if (this.rules) {
-        rules = this.rules.rules;
+        rules = this.rules;
         for (i = 0; i < rules.length; i++) {
             if (rules[i].markReferenced) {
                 rules[i].markReferenced();

--- a/lib/less/tree/media.js
+++ b/lib/less/tree/media.js
@@ -1,6 +1,5 @@
 var Ruleset = require("./ruleset"),
     Value = require("./value"),
-    Element = require("./element"),
     Selector = require("./selector"),
     Anonymous = require("./anonymous"),
     Expression = require("./expression"),
@@ -10,7 +9,7 @@ var Media = function (value, features, index, currentFileInfo) {
     this.index = index;
     this.currentFileInfo = currentFileInfo;
 
-    var selectors = this.emptySelectors();
+    var selectors = (new Selector([], null, null, this.index, this.currentFileInfo)).createEmptySelectors();
 
     this.features = new Value(features);
     this.rules = [new Ruleset(selectors, value)];
@@ -69,32 +68,12 @@ Media.prototype.eval = function (context) {
     return context.mediaPath.length === 0 ? media.evalTop(context) :
                 media.evalNested(context);
 };
-//TODO merge with directive
-Media.prototype.variable = function (name) { return Ruleset.prototype.variable.call(this.rules[0], name); };
-Media.prototype.find = function () { return Ruleset.prototype.find.apply(this.rules[0], arguments); };
-Media.prototype.rulesets = function () { return Ruleset.prototype.rulesets.apply(this.rules[0]); };
-Media.prototype.emptySelectors = function() {
-    var el = new Element('', '&', this.index, this.currentFileInfo),
-        sels = [new Selector([el], null, null, this.index, this.currentFileInfo)];
-    sels[0].mediaEmpty = true;
-    return sels;
-};
-Media.prototype.markReferenced = function () {
-    var i, rules = this.rules[0].rules;
-    this.rules[0].markReferenced();
-    this.isReferenced = true;
-    for (i = 0; i < rules.length; i++) {
-        if (rules[i].markReferenced) {
-            rules[i].markReferenced();
-        }
-    }
-};
 Media.prototype.evalTop = function (context) {
     var result = this;
 
     // Render all dependent Media blocks.
     if (context.mediaBlocks.length > 1) {
-        var selectors = this.emptySelectors();
+        var selectors = (new Selector([], null, null, this.index, this.currentFileInfo)).createEmptySelectors();
         result = new Ruleset(selectors, context.mediaBlocks);
         result.multiMedia = true;
     }

--- a/lib/less/tree/selector.js
+++ b/lib/less/tree/selector.js
@@ -1,4 +1,5 @@
-var Node = require("./node");
+var Node = require("./node"),
+    Element = require("./element");
 
 var Selector = function (elements, extendList, condition, index, currentFileInfo, isReferenced) {
     this.elements = elements;
@@ -29,6 +30,12 @@ Selector.prototype.createDerived = function(elements, extendList, evaldCondition
     newSelector.evaldCondition = evaldCondition;
     newSelector.mediaEmpty = this.mediaEmpty;
     return newSelector;
+};
+Selector.prototype.createEmptySelectors = function() {
+    var el = new Element('', '&', this.index, this.currentFileInfo),
+        sels = [new Selector([el], null, null, this.index, this.currentFileInfo)];
+    sels[0].mediaEmpty = true;
+    return sels;
 };
 Selector.prototype.match = function (other) {
     var elements = this.elements,

--- a/lib/less/visitors/import-visitor.js
+++ b/lib/less/visitors/import-visitor.js
@@ -147,7 +147,7 @@ ImportVisitor.prototype = {
         visitArgs.visitDeeper = false;
     },
     visitDirective: function (directiveNode, visitArgs) {
-        this.context.frames.unshift(directiveNode);
+        this.context.frames.unshift(directiveNode); //TODO: this works differently then media, why?
     },
     visitDirectiveOut: function (directiveNode) {
         this.context.frames.shift();

--- a/lib/less/visitors/import-visitor.js
+++ b/lib/less/visitors/import-visitor.js
@@ -147,7 +147,7 @@ ImportVisitor.prototype = {
         visitArgs.visitDeeper = false;
     },
     visitDirective: function (directiveNode, visitArgs) {
-        this.context.frames.unshift(directiveNode); //TODO: this works differently then media, why?
+        this.context.frames.unshift(directiveNode);
     },
     visitDirectiveOut: function (directiveNode) {
         this.context.frames.shift();

--- a/lib/less/visitors/join-selector-visitor.js
+++ b/lib/less/visitors/join-selector-visitor.js
@@ -39,6 +39,12 @@ JoinSelectorVisitor.prototype = {
     visitMedia: function (mediaNode, visitArgs) {
         var context = this.contexts[this.contexts.length - 1];
         mediaNode.rules[0].root = (context.length === 0 || context[0].multiMedia);
+    },
+    visitDirective: function (directiveNode, visitArgs) {
+        var context = this.contexts[this.contexts.length - 1];
+        if (directiveNode.rules && directiveNode.rules.length) {
+            directiveNode.rules[0].root = (context.length === 0 || null);
+        }
     }
 };
 

--- a/lib/less/visitors/to-css-visitor.js
+++ b/lib/less/visitors/to-css-visitor.js
@@ -63,8 +63,10 @@ ToCSSVisitor.prototype = {
             }
             this.charset = true;
         }
-        if (directiveNode.rules && directiveNode.rules.rules) {
-            this._mergeRules(directiveNode.rules.rules);
+        if (directiveNode.rules && directiveNode.rules.length) {
+            //FIXME: unsure about this one, it is still true that it is only one ruleset in array
+            //but maybe it should loop anyway
+            this._mergeRules(directiveNode.rules[0].rules);
             //process childs
             directiveNode.accept(this._visitor);
             visitArgs.visitDeeper = false;
@@ -74,13 +76,20 @@ ToCSSVisitor.prototype = {
                 return directiveNode;
             }
 
-            if (!directiveNode.rules.rules) {
+            if (!directiveNode.rules || !directiveNode.rules.length) {
                 return ;
             }
 
             //the directive was not directly referenced
-            for (var r = 0; r < directiveNode.rules.rules.length; r++) {
-                var rule = directiveNode.rules.rules[r];
+            //FIXME: lepsi komentar
+            //if there is only one nested ruleset and that one has no path, then it means actual body is inside that
+            //think on @font-face
+            var bodyRules = directiveNode.rules;
+            if (bodyRules.length === 1 && (!bodyRules[0].paths || bodyRules[0].paths.length === 0)) {
+                bodyRules = bodyRules[0].rules;
+            }
+            for (var r = 0; r < bodyRules.length; r++) {
+                var rule = bodyRules[r];
                 if (rule.getIsReferenced && rule.getIsReferenced()) {
                     //the directive contains something that was referenced (likely by extend)
                     //therefore it needs to be shown in output too

--- a/lib/less/visitors/to-css-visitor.js
+++ b/lib/less/visitors/to-css-visitor.js
@@ -63,9 +63,29 @@ ToCSSVisitor.prototype = {
             }
             this.charset = true;
         }
+        function hasVisibleChild(directiveNode) {
+            //prepare list of childs
+            var rule, bodyRules = directiveNode.rules;
+            //if there is only one nested ruleset and that one has no path, then it is
+            //just fake ruleset that got not replaced and we need to look inside it to
+            //get real childs
+            if (bodyRules.length === 1 && (!bodyRules[0].paths || bodyRules[0].paths.length === 0)) {
+                bodyRules = bodyRules[0].rules;
+            }
+            for (var r = 0; r < bodyRules.length; r++) {
+                rule = bodyRules[r];
+                if (rule.getIsReferenced && rule.getIsReferenced()) {
+                    //the directive contains something that was referenced (likely by extend)
+                    //therefore it needs to be shown in output too
+                    return true;
+                }
+            }
+            return false;
+        }
+
         if (directiveNode.rules && directiveNode.rules.length) {
-            //FIXME: unsure about this one, it is still true that it is only one ruleset in array
-            //but maybe it should loop anyway
+            //it is still true that it is only one ruleset in array
+            //this is last such moment
             this._mergeRules(directiveNode.rules[0].rules);
             //process childs
             directiveNode.accept(this._visitor);
@@ -80,25 +100,14 @@ ToCSSVisitor.prototype = {
                 return ;
             }
 
-            //the directive was not directly referenced
-            //FIXME: lepsi komentar
-            //if there is only one nested ruleset and that one has no path, then it means actual body is inside that
-            //think on @font-face
-            var bodyRules = directiveNode.rules;
-            if (bodyRules.length === 1 && (!bodyRules[0].paths || bodyRules[0].paths.length === 0)) {
-                bodyRules = bodyRules[0].rules;
+            //the directive was not directly referenced - we need to check whether some of its childs
+            //was referenced
+            if (hasVisibleChild(directiveNode)) {
+                //marking as referenced in case the directive is stored inside another directive
+                directiveNode.markReferenced();
+                return directiveNode;
             }
-            for (var r = 0; r < bodyRules.length; r++) {
-                var rule = bodyRules[r];
-                if (rule.getIsReferenced && rule.getIsReferenced()) {
-                    //the directive contains something that was referenced (likely by extend)
-                    //therefore it needs to be shown in output too
 
-                    //marking as referenced in case the directive is stored inside another directive
-                    directiveNode.markReferenced();
-                    return directiveNode;
-                }
-            }
             //The directive was not directly referenced and does not contain anything that
             //was referenced. Therefore it must not be shown in output.
             return ;

--- a/test/css/directives-bubling.css
+++ b/test/css/directives-bubling.css
@@ -1,0 +1,103 @@
+.parent {
+  color: green;
+}
+@document url-prefix() {
+  .parent .child {
+    color: red;
+  }
+}
+@supports (sandwitch: butter) {
+  .inside .top {
+    property: value;
+  }
+}
+@supports (sandwitch: bread) {
+  .in1 .in2 {
+    property: value;
+  }
+}
+@supports (sandwitch: ham) {
+  .inside .top {
+    property: value;
+  }
+}
+@supports (font-family: weirdFont) {
+  @font-face {
+    font-family: something;
+    src: made-up-url;
+  }
+}
+@font-face {
+  @supports not (-webkit-font-smoothing: subpixel-antialiased) {
+    font-family: something;
+    src: made-up-url;
+  }
+}
+@supports (property: value) {
+  @media (max-size: 2px) {
+    @supports (whatever: something) {
+      .outOfMedia  {
+        property: value;
+      }
+    }
+  }
+}
+@supports (property: value) {
+  @media (max-size: 2px) {
+    @supports (whatever: something) {
+      .onTop  {
+        property: value;
+      }
+    }
+  }
+}
+@media print {
+  html {
+    in-html: visible;
+  }
+  @supports (upper: test) {
+    html {
+      in-supports: first;
+    }
+    html div {
+      in-div: visible;
+    }
+    @supports not (-webkit-font-smoothing: subpixel-antialiased) {
+      html div {
+        in-supports: second;
+      }
+      @media screen {
+        html div {
+          font-weight: 400;
+        }
+        html div nested {
+          property: value;
+        }
+      }
+    }
+  }
+}
+@media print and (max-size: 2px) {
+  .in1 {
+    stay: here;
+  }
+  @supports not (-webkit-font-smoothing: subpixel-antialiased) {
+    @supports (whatever: something) {
+      .in2 .in1 {
+        property: value;
+      }
+    }
+  }
+}
+html {
+  font-weight: 300;
+  -webkit-font-smoothing: subpixel-antialiased;
+}
+@supports not (-webkit-font-smoothing: subpixel-antialiased) {
+  html {
+    font-weight: 400;
+  }
+  html nested {
+    property: value;
+  }
+}

--- a/test/less/directives-bubling.less
+++ b/test/less/directives-bubling.less
@@ -1,0 +1,128 @@
+//simple case: @document
+.parent {
+  color:green;
+  
+  @document url-prefix() {
+    .child {
+      color:red;
+    }
+  }   
+}
+
+//selectors joinings test
+.top {
+  @supports (sandwitch: butter) {
+    .inside & {
+      property: value;
+    }
+  }
+}
+
+@supports (sandwitch: bread) {
+  .in1 {
+    .in2 {
+      property: value;
+    }
+  }
+}
+
+.top {
+  .inside & {
+    @supports (sandwitch: ham) {
+      property: value;
+    }
+  }
+}
+
+//combined with @font-face which has different kind of body
+@supports (font-family: weirdFont) {
+  @font-face {
+    font-family: something;
+    src: made-up-url;
+  }
+}
+
+@font-face {
+  @supports not (-webkit-font-smoothing: subpixel-antialiased) {
+    font-family: something;
+    src: made-up-url;
+  }
+}
+
+//bubling through media
+@supports (property: value) {
+  .outOfMedia & {
+    @media (max-size: 2px) {
+      @supports (whatever: something) {
+        property: value;
+      } 
+    }
+  }
+}
+
+.onTop & {
+  @supports (property: value) {
+    @media (max-size: 2px) {
+      @supports (whatever: something) {
+        property: value;
+      } 
+    }
+  }
+}
+
+
+//long combination of supports and media
+@media print {
+  html {
+    in-html: visible;
+    @supports (upper: test) {
+      in-supports: first;
+      div {
+        in-div: visible;
+        @supports not (-webkit-font-smoothing: subpixel-antialiased) {
+          in-supports: second;
+          @media screen {
+            font-weight: 400;
+            nested {
+              property: value;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+//another long combination of supports and media
+@media print {
+  @media (max-size: 2px) {
+    .in1 {
+      stay: here;
+      @supports not (-webkit-font-smoothing: subpixel-antialiased) {
+        .in2 & {
+          @supports (whatever: something) {
+            property: value;
+          } 
+        }
+      }
+    }
+  }
+}
+
+//called from mixin 
+.nestedSupportsMixin() {
+    font-weight: 300;
+    -webkit-font-smoothing: subpixel-antialiased;
+    @supports not (-webkit-font-smoothing: subpixel-antialiased) {
+        font-weight: 400;
+        nested {
+          property: value;
+        }
+    }
+}
+
+html {
+    .nestedSupportsMixin;
+}
+
+


### PR DESCRIPTION
Related to #1691 and #2104 

Directives are changed to work the same way as media. The biggest code change is that the `rules` property of `directive.js` contains an array instead of just a ruleset. 

Directive bubbling ends at the closest directive or media, e.g. this remains unchaged by compilation:
````
@media print {
    @supports (upper: test) {
        @supports not (-webkit-font-smoothing: subpixel-antialiased) {
           @media screen {
              nested {
                property: value;
              }
           }
        }
    }
}
````
