### PR TITLE
some logical corrections

### DIFF
--- a/lib/less/visitors/to-css-visitor.js
+++ b/lib/less/visitors/to-css-visitor.js
@@ -63,6 +63,12 @@ ToCSSVisitor.prototype = {
             }
             this.charset = true;
         }
+        else if (directiveNode.name === "@namespace") {
+            if (!directiveNode.getIsReferenced()) {
+                return;
+            }
+            this.namespace = true;
+        }
         function hasVisibleChild(directiveNode) {
             //prepare list of childs
             var rule, bodyRules = directiveNode.rules;
@@ -82,7 +88,6 @@ ToCSSVisitor.prototype = {
             }
             return false;
         }
-
         if (directiveNode.rules && directiveNode.rules.length) {
             //it is still true that it is only one ruleset in array
             //this is last such moment
@@ -96,10 +101,6 @@ ToCSSVisitor.prototype = {
                 return directiveNode;
             }
 
-            if (!directiveNode.rules || !directiveNode.rules.length) {
-                return ;
-            }
-
             //the directive was not directly referenced - we need to check whether some of its childs
             //was referenced
             if (hasVisibleChild(directiveNode)) {
@@ -111,9 +112,9 @@ ToCSSVisitor.prototype = {
             //The directive was not directly referenced and does not contain anything that
             //was referenced. Therefore it must not be shown in output.
             return ;
-        } else {
-            if (!directiveNode.getIsReferenced()) {
-                return;
+        } else if (!this.charset && !this.namespace) {
+            if (!directiveNode.rules || !directiveNode.rules.length || !directiveNode.getIsReferenced()) {
+                return ;
             }
         }
         return directiveNode;


### PR DESCRIPTION
As far as i understand the following code can never be true cause it's already wrapped inside `if (directiveNode.rules && directiveNode.rules.length)`:

```
if (!directiveNode.rules || !directiveNode.rules.length) {
                return ;
            }
```

I moved these checks to the `else` part. Not sure these tests are needed at all? Moving the check requires some other changes for the `@charset` and `@namespace` directives.