### PR TITLE
Allow detached rulesets as mixin argument defaults

### DIFF
--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -704,10 +704,7 @@ var Parser = function Parser(context, imports, fileInfo) {
                                     expressionContainsNamed = true;
                                 }
 
-                                // we do not support setting a ruleset as a default variable - it doesn't make sense
-                                // However if we do want to add it, there is nothing blocking it, just don't error
-                                // and remove isCall dependency below
-                                value = (isCall && parsers.detachedRuleset()) || parsers.expression();
+                                value = parsers.detachedRuleset() || parsers.expression();
 
                                 if (!value) {
                                     if (isCall) {

--- a/test/css/detached-rulesets.css
+++ b/test/css/detached-rulesets.css
@@ -69,3 +69,8 @@ html.lt-ie9 header {
 .a {
   test: test;
 }
+.argument-default {
+  default: works;
+  direct: works;
+  named: works;
+}

--- a/test/less/detached-rulesets.less
+++ b/test/less/detached-rulesets.less
@@ -101,3 +101,12 @@ header {
 .a {
   .mixin();
 }
+// as mixin argument default
+.mixin-definition(@a: {}; @b: {default: works;};) {
+  @a();
+  @b();
+}
+.argument-default {
+  .mixin-definition();
+  .mixin-definition({direct: works;}; @b: {named: works;});
+}

--- a/test/less/errors/detached-ruleset-4.less
+++ b/test/less/errors/detached-ruleset-4.less
@@ -1,5 +1,0 @@
-.mixin-definition(@a: {
-  b: 1;
-}) {
-  @a();
-}

--- a/test/less/errors/detached-ruleset-4.txt
+++ b/test/less/errors/detached-ruleset-4.txt
@@ -1,4 +1,0 @@
-ParseError: Unrecognised input in {path}detached-ruleset-4.less on line 3, column 4:
-2   b: 1;
-3 }) {
-4   @a();


### PR DESCRIPTION
This fixes #2496, allowing detached rulesets to be allowed as mixin argument defaults.

For example:
```less
.mixin(@size: 30px; @padding: 30px; @additions: {}) { // the "@additions: {}" used to error
  height: @size;
  width: @size;
  padding: @padding;
  @additions();
}

.no-additions {
  .mixin();
}
.additions {
  .mixin(@additions: {color: white;});
}
```
compiles to
```css
.no-additions {
  height: 30px;
  width: 30px;
  padding: 30px;
}
.additions {
  height: 30px;
  width: 30px;
  padding: 30px;
  color: white;
}
```