### PR TITLE
Fix selectors folding into directives

### DIFF
--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -1346,7 +1346,7 @@ var Parser = function Parser(context, imports, fileInfo) {
             //
             directive: function () {
                 var index = parserInput.i, name, value, rules, nonVendorSpecificName,
-                    hasIdentifier, hasExpression, hasUnknown, hasBlock = true;
+                    hasIdentifier, hasExpression, hasUnknown, hasBlock = true, isRooted = true;
 
                 if (parserInput.currentChar() !== '@') { return; }
 
@@ -1387,6 +1387,7 @@ var Parser = function Parser(context, imports, fileInfo) {
                     case "@right-middle":
                     case "@right-bottom":
                         hasBlock = true;
+                        isRooted = true;
                         break;
                     */
                     case "@counter-style":
@@ -1406,9 +1407,12 @@ var Parser = function Parser(context, imports, fileInfo) {
                         break;
                     case "@host":
                     case "@page":
+                        hasUnknown = true;
+                        break;
                     case "@document":
                     case "@supports":
                         hasUnknown = true;
+                        isRooted = false;
                         break;
                 }
 
@@ -1437,8 +1441,11 @@ var Parser = function Parser(context, imports, fileInfo) {
 
                 if (rules || (!hasBlock && value && parserInput.$char(';'))) {
                     parserInput.forget();
-                    return new(tree.Directive)(name, value, rules, index, fileInfo,
-                        context.dumpLineNumbers ? getDebugInfo(index) : null);
+                    return new (tree.Directive)(name, value, rules, index, fileInfo,
+                        context.dumpLineNumbers ? getDebugInfo(index) : null,
+                        false,
+                        isRooted
+                    );
                 }
 
                 parserInput.restore("directive options not recognised");

--- a/lib/less/tree/directive.js
+++ b/lib/less/tree/directive.js
@@ -2,7 +2,7 @@ var Node = require("./node"),
     Selector = require("./selector"),
     Ruleset = require("./ruleset");
 
-var Directive = function (name, value, rules, index, currentFileInfo, debugInfo, isReferenced) {
+var Directive = function (name, value, rules, index, currentFileInfo, debugInfo, isReferenced, isRooted) {
     var i;
 
     this.name  = name;
@@ -22,6 +22,7 @@ var Directive = function (name, value, rules, index, currentFileInfo, debugInfo,
     this.currentFileInfo = currentFileInfo;
     this.debugInfo = debugInfo;
     this.isReferenced = isReferenced;
+    this.isRooted = isRooted || false;
 };
 
 Directive.prototype = new Node();
@@ -78,7 +79,7 @@ Directive.prototype.eval = function (context) {
     context.mediaBlocks = mediaBlocksBackup;
 
     return new Directive(this.name, value, rules,
-        this.index, this.currentFileInfo, this.debugInfo, this.isReferenced);
+        this.index, this.currentFileInfo, this.debugInfo, this.isReferenced, this.isRooted);
 };
 Directive.prototype.variable = function (name) {
     if (this.rules) {

--- a/lib/less/visitors/join-selector-visitor.js
+++ b/lib/less/visitors/join-selector-visitor.js
@@ -43,7 +43,7 @@ JoinSelectorVisitor.prototype = {
     visitDirective: function (directiveNode, visitArgs) {
         var context = this.contexts[this.contexts.length - 1];
         if (directiveNode.rules && directiveNode.rules.length) {
-            directiveNode.rules[0].root = (context.length === 0 || null);
+            directiveNode.rules[0].root = (directiveNode.isRooted || context.length === 0 || null);
         }
     }
 };

--- a/test/css/directives-bubling.css
+++ b/test/css/directives-bubling.css
@@ -101,3 +101,19 @@ html {
     property: value;
   }
 }
+.onTop {
+  animation: "textscale";
+  font-family: something;
+}
+@font-face {
+  font-family: something;
+  src: made-up-url;
+}
+@keyframes "textscale" {
+  0% {
+    font-size: 1em;
+  }
+  100% {
+    font-size: 2em;
+  }
+}

--- a/test/less/directives-bubling.less
+++ b/test/less/directives-bubling.less
@@ -111,18 +111,32 @@
 
 //called from mixin 
 .nestedSupportsMixin() {
-    font-weight: 300;
-    -webkit-font-smoothing: subpixel-antialiased;
-    @supports not (-webkit-font-smoothing: subpixel-antialiased) {
-        font-weight: 400;
-        nested {
-          property: value;
-        }
+  font-weight: 300;
+  -webkit-font-smoothing: subpixel-antialiased;
+  @supports not (-webkit-font-smoothing: subpixel-antialiased) {
+    font-weight: 400;
+    nested {
+      property: value;
     }
+  }
 }
 
 html {
     .nestedSupportsMixin;
 }
 
+// selectors should not propagate into all directive types
+.onTop {
+  @font-face {
+    font-family: something;
+    src: made-up-url;
+  }
 
+  @keyframes "textscale" {
+      0% { font-size : 1em; }
+    100% { font-size : 2em; }
+  }
+
+  animation   : "textscale";
+  font-family : something;
+}


### PR DESCRIPTION
When directives bubble up to global scope, selectors are no longer
folded into directives that do not logically allow them.
Fixes #2511