### PR TITLE
Fix #2510 regression in commandline argument processing

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -275,7 +275,7 @@ function printUsage() {
     var filenames = [args[1], args[2]].map(function (arg) {
         var match;
 
-        match = arg.match(/^'(.+)'$/);
+        match = arg && arg.match(/^'(.+)'$/);
         if (match) {
             return match[1];
         } else {


### PR DESCRIPTION
Fixes a regression introduced in #2510 which causes lessc to crash when no output file is given and it should output to stdout.