### PR TITLE
Quick fix for naked `url` imports

### DIFF
--- a/lib/less/tree/import.js
+++ b/lib/less/tree/import.js
@@ -66,12 +66,8 @@ Import.prototype.genCSS = function (context, output) {
     }
 };
 Import.prototype.getPath = function () {
-    if (this.path instanceof Quoted) {
-        return this.path.value;
-    } else if (this.path instanceof URL) {
-        return this.path.value.value;
-    }
-    return null;
+    return (this.path instanceof URL) ?
+        this.path.value.value : this.path.value;
 };
 Import.prototype.isVariableImport = function () {
     var path = this.path;

--- a/test/css/import.css
+++ b/test/css/import.css
@@ -20,6 +20,9 @@
   height: 10px;
   color: red;
 }
+.test-f {
+  height: 10px;
+}
 .deep-import-url {
   color: red;
 }

--- a/test/less/import/import-test-a.less
+++ b/test/less/import/import-test-a.less
@@ -1,4 +1,5 @@
 @import "import-test-b.less";
+@import url(import-test-f.less);
 @import url("deeper/url-import.less");
 @a: 20%;
 @import "urls.less";


### PR DESCRIPTION
Fixes #2516.

Actually I'm not quite sure: maybe this simplification is too liberal but I did not find any weird consequences except that things like `@import ~"some.less";` now work too. Any other value types won't pass through the parser anyway.