### PR TITLE
Add support for `:` or `;` path separators in `--include-path`

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -2,7 +2,6 @@
 
 var path = require('path'),
     fs = require('../lib/less-node/fs'),
-    os = require('os'),
     errno,
     mkdirp;
 
@@ -153,8 +152,13 @@ function printUsage() {
                 break;
             case 'include-path':
                 if (checkArgFunc(arg, match[2])) {
-                    options.paths = match[2].split(os.type().match(/Windows/) ? ';' : ':')
+                    // support for both ; and : path separators
+                    // even on windows when using absolute paths with drive letters (eg C:\path:D:\path)
+                    var uniqueString = '!@#$%^&*()';
+                    options.paths = match[2].replace(/\b([a-z]):([\\\/])/gi, '$1' + uniqueString + '$2')
+                        .split(/[;:]/)
                         .map(function(p) {
+                            p = p.replace(uniqueString, ':');
                             if (p) {
                                 return path.resolve(process.cwd(), p);
                             }

--- a/lib/less-node/lessc-helper.js
+++ b/lib/less-node/lessc-helper.js
@@ -27,7 +27,7 @@ var lessc_helper = {
         console.log("");
         console.log("options:");
         console.log("  -h, --help               Prints help (this message) and exit.");
-        console.log("  --include-path=PATHS     Sets include paths. Separated by `:'. Use `;' on Windows.");
+        console.log("  --include-path=PATHS     Sets include paths. Separated by `:'. `;' also supported.");
         console.log("  -M, --depends            Outputs a makefile import dependency list to stdout.");
         console.log("  --no-color               Disables colorized output.");
         console.log("  --no-ie-compat           Disables IE compatibility checks.");

--- a/lib/less-rhino/index.js
+++ b/lib/less-rhino/index.js
@@ -1,5 +1,5 @@
 /*jshint rhino:true, unused: false */
-/*global name:true, less, loadStyleSheet, os */
+/*global name:true, less, loadStyleSheet */
 
 function formatError(ctx, options) {
     options = options || {};
@@ -263,13 +263,18 @@ function writeFile(filename, content) {
                 break;
             case 'include-path':
                 if (checkArgFunc(arg, match[2])) {
-                    options.paths = match[2].split(os.type().match(/Windows/) ? ';' : ':')
-                            .map(function(p) {
-                                if (p) {
-//                                    return path.resolve(process.cwd(), p);
-                                    return p;
-                                }
-                            });
+                    // support for both ; and : path separators
+                    // even on windows when using absolute paths with drive letters (eg C:\path:D:\path)
+                    var uniqueString = '!@#$%^&*()';
+                    options.paths = match[2].replace(/\b([a-z]):([\\\/])/gi, '$1' + uniqueString + '$2')
+                        .split(/[;:]/)
+                        .map(function(p) {
+                            p = p.replace(uniqueString, ':');
+                            if (p) {
+//                                return path.resolve(process.cwd(), p);
+                                return p;
+                            }
+                        });
                 }
                 break;
             case 'line-numbers':


### PR DESCRIPTION
Add support for `:` or `;` path separators in `--include-path` regardless of platform. Understands absolute paths with Windows drive letters (ie. `some/relative/dir/:C:\absolute\path`).

Before this change it was impossible to specify custom include paths that would work on Windows as well as other platforms.