### PR TITLE
Fix 2440

### DIFF
--- a/lib/less/tree/comment.js
+++ b/lib/less/tree/comment.js
@@ -22,7 +22,4 @@ Comment.prototype.isSilent = function(context) {
 Comment.prototype.markReferenced = function () {
     this.isReferenced = true;
 };
-Comment.prototype.isRulesetLike = function(root) {
-    return Boolean(root);
-};
 module.exports = Comment;

--- a/lib/less/tree/ruleset.js
+++ b/lib/less/tree/ruleset.js
@@ -303,8 +303,6 @@ Ruleset.prototype.genCSS = function (context, output) {
     var i, j,
         charsetRuleNodes = [],
         ruleNodes = [],
-        rulesetNodes = [],
-        rulesetNodeCnt,
         debugInfo,     // Line number debugging
         rule,
         path;
@@ -319,31 +317,38 @@ Ruleset.prototype.genCSS = function (context, output) {
         tabSetStr = context.compress ? '' : Array(context.tabLevel).join("  "),
         sep;
 
-    function isRulesetLikeNode(rule, root) {
+    function isRulesetLikeNode(rule) {
         // if it has nested rules, then it should be treated like a ruleset
         // medias and comments do not have nested rules, but should be treated like rulesets anyway
         // some directives and anonymous nodes are ruleset like, others are not
         if (typeof rule.isRulesetLike === "boolean") {
             return rule.isRulesetLike;
         } else if (typeof rule.isRulesetLike === "function") {
-            return rule.isRulesetLike(root);
+            return rule.isRulesetLike();
         }
 
         //anything else is assumed to be a rule
         return false;
     }
 
+    var charsetNodeIndex = 0;
+    var importNodeIndex = 0;
     for (i = 0; i < this.rules.length; i++) {
         rule = this.rules[i];
-        if (isRulesetLikeNode(rule, this.root)) {
-            rulesetNodes.push(rule);
-        } else {
-            //charsets should float on top of everything
-            if (rule.isCharset && rule.isCharset()) {
-                charsetRuleNodes.push(rule);
-            } else {
-                ruleNodes.push(rule);
+        if (rule.type === "Comment") {
+            if (importNodeIndex === i) {
+                importNodeIndex++;
             }
+            ruleNodes.push(rule);
+        } else if (rule.isCharset && rule.isCharset()) {
+            ruleNodes.splice(charsetNodeIndex, 0, rule);
+            charsetNodeIndex++;
+            importNodeIndex++;
+        } else if (rule.type === "Import") {
+            ruleNodes.splice(importNodeIndex, 0, rule);
+            importNodeIndex++;
+        } else {
+            ruleNodes.push(rule);
         }
     }
     ruleNodes = charsetRuleNodes.concat(ruleNodes);
@@ -384,10 +389,13 @@ Ruleset.prototype.genCSS = function (context, output) {
     for (i = 0; i < ruleNodes.length; i++) {
         rule = ruleNodes[i];
 
-        // @page{ directive ends up with root elements inside it, a mix of rules and rulesets
-        // In this instance we do not know whether it is the last property
-        if (i + 1 === ruleNodes.length && (!this.root || rulesetNodes.length === 0 || this.firstRoot)) {
+        if (i + 1 === ruleNodes.length) {
             context.lastRule = true;
+        }
+
+        var currentLastRule = context.lastRule;
+        if (isRulesetLikeNode(rule)) {
+            context.lastRule = false;
         }
 
         if (rule.genCSS) {
@@ -395,6 +403,8 @@ Ruleset.prototype.genCSS = function (context, output) {
         } else if (rule.value) {
             output.add(rule.value.toString());
         }
+
+        context.lastRule = currentLastRule;
 
         if (!context.lastRule) {
             output.add(context.compress ? '' : ('\n' + tabRuleStr));
@@ -406,17 +416,6 @@ Ruleset.prototype.genCSS = function (context, output) {
     if (!this.root) {
         output.add((context.compress ? '}' : '\n' + tabSetStr + '}'));
         context.tabLevel--;
-    }
-
-    sep = (context.compress ? "" : "\n") + (this.root ? tabRuleStr : tabSetStr);
-    rulesetNodeCnt = rulesetNodes.length;
-    if (rulesetNodeCnt) {
-        if (ruleNodes.length && sep) { output.add(sep); }
-        rulesetNodes[0].genCSS(context, output);
-        for (i = 1; i < rulesetNodeCnt; i++) {
-            if (sep) { output.add(sep); }
-            rulesetNodes[i].genCSS(context, output);
-        }
     }
 
     if (!output.isEmpty() && !context.compress && this.firstRoot) {

--- a/test/css/import.css
+++ b/test/css/import.css
@@ -1,4 +1,5 @@
 @charset "UTF-8";
+/** comment at the top**/
 @import url(http://fonts.googleapis.com/css?family=Open+Sans);
 @import url(/absolute/something.css) screen and (color) and (max-width: 600px);
 @import url("//ha.com/file.css") (min-width: 100px);

--- a/test/css/media.css
+++ b/test/css/media.css
@@ -119,7 +119,6 @@
   }
   @page :first {
     size: 8.5in 11in;
-    
     @top-left {
       margin: 1cm;
     }

--- a/test/less/import.less
+++ b/test/less/import.less
@@ -1,3 +1,4 @@
+/** comment at the top**/
 @import url(http://fonts.googleapis.com/css?family=Open+Sans);
 
 @import url(/absolute/something.css) screen and (color) and (max-width: 600px);


### PR DESCRIPTION
Don't do weird pulling apart of rules and rulesets, just bubble imports and charsets.

I think the code was left over from when we didn't bubble rulesets out of the nesting before calling toCSS

@seven-phases-max would you review? It looks and feels safe to me. Your example output
```
.a {
  @charset "utf-8";
  @import "test.csS";
}
```

is unchanged before and after