### PR TITLE
Proper non-primitive value replacement for `%` and `replace`

### DIFF
--- a/lib/less/functions/string.js
+++ b/lib/less/functions/string.js
@@ -14,8 +14,9 @@ functionRegistry.addMultiple({
     },
     replace: function (string, pattern, replacement, flags) {
         var result = string.value;
-
-        result = result.replace(new RegExp(pattern.value, flags ? flags.value : ''), replacement.value);
+        replacement = (replacement.type === "Quoted") ?
+            replacement.value : replacement.toCSS();
+        result = result.replace(new RegExp(pattern.value, flags ? flags.value : ''), replacement);
         return new Quoted(string.quote || '', result, string.escaped);
     },
     '%': function (string /* arg, arg, ...*/) {
@@ -25,7 +26,8 @@ functionRegistry.addMultiple({
         for (var i = 0; i < args.length; i++) {
             /*jshint loopfunc:true */
             result = result.replace(/%[sda]/i, function(token) {
-                var value = token.match(/s/i) ? args[i].value : args[i].toCSS();
+                var value = ((args[i].type === "Quoted") &&
+                    token.match(/s/i)) ? args[i].value : args[i].toCSS();
                 return token.match(/[A-Z]$/) ? encodeURIComponent(value) : value;
             });
         }

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -60,12 +60,16 @@
   replace-single-quoted: 'foo-2';
   replace-escaped-string: bar-2;
   replace-keyword: baz-2;
+  replace-with-color: "#113355#1133557";
+  replace-with-number: "2em07";
   format: "rgb(32, 128, 64)";
   format-string: "hello world";
   format-multiple: "hello earth 2";
   format-url-encode: "red is %23ff0000";
   format-single-quoted: 'hello single world';
   format-escaped-string: hello escaped world;
+  format-color-as-string: "#112233";
+  format-number-as-string: "4px";
   eformat: rgb(32, 128, 64);
   unitless: 12;
   unit: 14em;

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -64,12 +64,16 @@
   replace-single-quoted: replace('foo-1', "1", "2");
   replace-escaped-string: replace(~"bar-1", "1", "2");
   replace-keyword: replace(baz-1, "1", "2");
+  replace-with-color: replace("007", "0", #135, g);
+  replace-with-number: replace("007", "0", 2em);
   format: %("rgb(%d, %d, %d)", @r, 128, 64);
   format-string: %("hello %s", "world");
   format-multiple: %("hello %s %d", "earth", 2);
   format-url-encode: %("red is %A", #ff0000);
   format-single-quoted: %('hello %s', "single world");
   format-escaped-string: %(~"hello %s", "escaped world");
+  format-color-as-string: %("%s", #123);
+  format-number-as-string: %("%s", 4px);
   eformat: e(%("rgb(%d, %d, %d)", @r, 128, 64));
 
   unitless: unit(12px);


### PR DESCRIPTION
Fixes #2480 as well as similar code with other non-primitive value types. 
E.g.:
```
replace("007", "0", #135); // "#11335507"   / was "undefined07"
replace("007", "0", 2em);  // "2em07"       / was "207"
%("foo-%s", #123);         // "foo-#112233" / was "foo-undefined"
%("bar-%s", 4px);          // "bar-4px"     / was "bar-4"
// etc.
```