### PR TITLE
Fix formatting to meet jscs settings

### DIFF
--- a/lib/less-rhino/index.js
+++ b/lib/less-rhino/index.js
@@ -1,5 +1,6 @@
-/*jshint rhino:true, unused: false */
-/*global name:true, less, loadStyleSheet, os */
+/* jshint rhino:true, unused: false */
+/* jscs:disable validateIndentation */
+/* global name:true, less, loadStyleSheet, os */
 
 function formatError(ctx, options) {
     options = options || {};

--- a/lib/less/parser/parser-input.js
+++ b/lib/less/parser/parser-input.js
@@ -166,8 +166,7 @@ module.exports = function() {
         currentPos = parserInput.i;
 
         if (!current.length) {
-            if (j < chunks.length - 1)
-            {
+            if (j < chunks.length - 1) {
                 current = chunks[++j];
                 skipWhitespace(0); // skip space at the beginning of a chunk
                 return true; // things changed

--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -240,8 +240,7 @@ var Parser = function Parser(context, imports, fileInfo) {
             primary: function () {
                 var mixin = this.mixin, root = [], node;
 
-                while (true)
-                {
+                while (true) {
                     while (true) {
                         node = this.comment();
                         if (!node) { break; }
@@ -1207,8 +1206,7 @@ var Parser = function Parser(context, imports, fileInfo) {
                         features = features && new(tree.Value)(features);
                         return new(tree.Import)(path, features, options, index, fileInfo);
                     }
-                    else
-                    {
+                    else {
                         parserInput.i = index;
                         error("malformed import statement");
                     }
@@ -1360,8 +1358,7 @@ var Parser = function Parser(context, imports, fileInfo) {
 
                         return new(tree.Import)(path, null, options, index, fileInfo);
                     }
-                    else
-                    {
+                    else {
                         parserInput.i = index;
                         error("malformed plugin statement");
                     }

--- a/lib/less/source-map-output.js
+++ b/lib/less/source-map-output.js
@@ -105,8 +105,7 @@ module.exports = function (environment) {
 
         if (this._outputSourceFiles) {
             for (var filename in this._contentsMap) {
-                if (this._contentsMap.hasOwnProperty(filename))
-                {
+                if (this._contentsMap.hasOwnProperty(filename)) {
                     var source = this._contentsMap[filename];
                     if (this._contentsIgnoredCharsMap[filename]) {
                         source = source.slice(this._contentsIgnoredCharsMap[filename]);

--- a/lib/less/tree/dimension.js
+++ b/lib/less/tree/dimension.js
@@ -127,7 +127,7 @@ Dimension.prototype.convertTo = function (conversions) {
         conversions = derivedConversions;
     }
     applyUnit = function (atomicUnit, denominator) {
-      /*jshint loopfunc:true */
+        /* jshint loopfunc:true */
         if (group.hasOwnProperty(atomicUnit)) {
             if (denominator) {
                 value = value / (group[atomicUnit] / group[targetUnit]);

--- a/lib/less/visitors/extend-visitor.js
+++ b/lib/less/visitors/extend-visitor.js
@@ -198,8 +198,7 @@ ProcessExtendsVisitor.prototype = {
             if (iterationCount > 100) {
                 var selectorOne = "{unable to calculate}";
                 var selectorTwo = "{unable to calculate}";
-                try
-                {
+                try {
                     selectorOne = extendsToAdd[0].selfSelectors[0].toCSS();
                     selectorTwo = extendsToAdd[0].selector.toCSS();
                 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "grunt-contrib-jasmine": "^0.8.2",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-uglify": "^0.8.0",
-    "grunt-jscs": "~1.5.0",
+    "grunt-jscs": "^1.6.0",
     "grunt-shell": "^1.1.1",
     "grunt-browserify": "~3.5.0",
     "jit-grunt": "^0.9.1",

--- a/test/browser/runner-global-vars-options.js
+++ b/test/browser/runner-global-vars-options.js
@@ -3,4 +3,5 @@ var less = {
     errorReporting: "console",
     globalVars: {
         "@global-var": "red"
-}};
+    }
+};

--- a/test/browser/runner-main-options.js
+++ b/test/browser/runner-main-options.js
@@ -4,15 +4,15 @@ var less = {
 };
 less.strictMath = true;
 less.functions = {
-  add: function(a, b) {
-      return new(less.tree.Dimension)(a.value + b.value);
-  },
-  increment: function(a) {
-      return new(less.tree.Dimension)(a.value + 1);
-  },
-  _color: function(str) {
-      if (str.value === "evil red") {
-          return new(less.tree.Color)("600");
-      }
-  }
+    add: function(a, b) {
+        return new(less.tree.Dimension)(a.value + b.value);
+    },
+    increment: function(a) {
+        return new(less.tree.Dimension)(a.value + 1);
+    },
+    _color: function(str) {
+        if (str.value === "evil red") {
+            return new(less.tree.Color)("600");
+        }
+    }
 };

--- a/test/plugins/visitor/index.js
+++ b/test/plugins/visitor/index.js
@@ -4,19 +4,17 @@
     };
 
     RemoveProperty.prototype = {
-    isReplacing: true,
-    run: function (root) {
-        return this._visitor.visit(root);
-    },
-    visitRule: function (ruleNode, visitArgs) {
-        if (ruleNode.name != '-some-aribitrary-property')
-        {
-            return ruleNode;
+        isReplacing: true,
+        run: function (root) {
+            return this._visitor.visit(root);
+        },
+        visitRule: function (ruleNode, visitArgs) {
+            if (ruleNode.name != '-some-aribitrary-property') {
+                return ruleNode;
+            } else {
+                return [];
+            }
         }
-        else {
-            return [];
-        }
-    }
     };
 
     exports.install = function(less, pluginManager) {


### PR DESCRIPTION
I did not modify `lib\less-rhino\index.js` indents though (just suppressed the corressponding errors for the file) as there're too many (mostly `//` at the start of line).