### PR TITLE
Fix for #2558

### DIFF
--- a/lib/less/tree/mixin-definition.js
+++ b/lib/less/tree/mixin-definition.js
@@ -152,7 +152,7 @@ Definition.prototype.matchCondition = function (args, context) {
         new contexts.Eval(context,
             [this.evalParams(context, /* the parameter variables*/
                 new contexts.Eval(context, this.frames ? this.frames.concat(context.frames) : context.frames), args, [])]
-            .concat(this.frames) // the parent namespace/mixin frames
+            .concat(this.frames || []) // the parent namespace/mixin frames
             .concat(context.frames)))) { // the current environment frames
         return false;
     }

--- a/lib/less/tree/ruleset.js
+++ b/lib/less/tree/ruleset.js
@@ -255,7 +255,7 @@ Ruleset.prototype.variable = function (name) {
     return this.variables()[name];
 };
 Ruleset.prototype.rulesets = function () {
-    if (!this.rules) { return null; }
+    if (!this.rules) { return []; }
 
     var filtRules = [], rules = this.rules, cnt = rules.length,
         i, rule;

--- a/test/less/mixins-guards.less
+++ b/test/less/mixins-guards.less
@@ -269,3 +269,12 @@
 #guarded-deeper {
   #top > #deeper > .mixin(1);
 }
+
+// namespaced & guarded mixin in root
+// outputs nothing but should pass:
+
+@guarded-mixin-for-root: true;
+#ns {
+    .guarded-mixin-for-root() when (@guarded-mixin-for-root) {}
+}
+#ns > .guarded-mixin-for-root();


### PR DESCRIPTION
Fixes undefined guard variables when a namespaced mixin is invoked in global scope (#2558).