### PR TITLE
FireLess: font-family property are not surrounded by quotes.

### DIFF
--- a/lib/less/tree/debug-info.js
+++ b/lib/less/tree/debug-info.js
@@ -25,14 +25,14 @@ debugInfo.asMediaQuery = function(ctx) {
     if (!/^[a-z]+:\/\//i.test(filenameWithProtocol)) {
         filenameWithProtocol = 'file://' + filenameWithProtocol;
     }
-    return '@media -sass-debug-info{filename{font-family:' +
+    return '@media -sass-debug-info{filename{font-family:"' +
         filenameWithProtocol.replace(/([.:\/\\])/g, function (a) {
             if (a == '\\') {
                 a = '\/';
             }
             return '\\' + a;
         }) +
-        '}line{font-family:\\00003' + ctx.debugInfo.lineNumber + '}}\n';
+        '";}line{font-family:"\\00003' + ctx.debugInfo.lineNumber + '";}}\n';
 };
 
 module.exports = debugInfo;

--- a/test/css/debug/linenumbers-all.css
+++ b/test/css/debug/linenumbers-all.css
@@ -1,49 +1,49 @@
 @charset "UTF-8";
 /* line 1, {pathimport}test.less */
-@media -sass-debug-info{filename{font-family:file\:\/\/{pathimportesc}test\.less}line{font-family:\000031}}
+@media -sass-debug-info{filename{font-family:"file\:\/\/{pathimportesc}test\.less";}line{font-family:"\000031";}}
 /* @charset "ISO-8859-1"; */
 
 /* line 23, {pathimport}test.less */
-@media -sass-debug-info{filename{font-family:file\:\/\/{pathimportesc}test\.less}line{font-family:\0000323}}
+@media -sass-debug-info{filename{font-family:"file\:\/\/{pathimportesc}test\.less";}line{font-family:"\0000323";}}
 .tst3 {
   color: grey;
 }
 /* line 15, {path}linenumbers.less */
-@media -sass-debug-info{filename{font-family:file\:\/\/{pathesc}linenumbers\.less}line{font-family:\0000315}}
+@media -sass-debug-info{filename{font-family:"file\:\/\/{pathesc}linenumbers\.less";}line{font-family:"\0000315";}}
 .test1 {
   color: black;
 }
 /* line 6, {path}linenumbers.less */
-@media -sass-debug-info{filename{font-family:file\:\/\/{pathesc}linenumbers\.less}line{font-family:\000036}}
+@media -sass-debug-info{filename{font-family:"file\:\/\/{pathesc}linenumbers\.less";}line{font-family:"\000036";}}
 .test2 {
   color: red;
 }
 @media all {
   /* line 5, {pathimport}test.less */
-  @media -sass-debug-info{filename{font-family:file\:\/\/{pathimportesc}test\.less}line{font-family:\000035}}
+  @media -sass-debug-info{filename{font-family:"file\:\/\/{pathimportesc}test\.less";}line{font-family:"\000035";}}
   .tst {
     color: black;
   }
 }
 @media all and screen {
   /* line 7, {pathimport}test.less */
-  @media -sass-debug-info{filename{font-family:file\:\/\/{pathimportesc}test\.less}line{font-family:\000037}}
+  @media -sass-debug-info{filename{font-family:"file\:\/\/{pathimportesc}test\.less";}line{font-family:"\000037";}}
   .tst {
     color: red;
   }
   /* line 9, {pathimport}test.less */
-  @media -sass-debug-info{filename{font-family:file\:\/\/{pathimportesc}test\.less}line{font-family:\000039}}
+  @media -sass-debug-info{filename{font-family:"file\:\/\/{pathimportesc}test\.less";}line{font-family:"\000039";}}
   .tst .tst3 {
     color: white;
   }
 }
 /* line 18, {pathimport}test.less */
-@media -sass-debug-info{filename{font-family:file\:\/\/{pathimportesc}test\.less}line{font-family:\0000318}}
+@media -sass-debug-info{filename{font-family:"file\:\/\/{pathimportesc}test\.less";}line{font-family:"\0000318";}}
 .tst2 {
   color: white;
 }
 /* line 27, {path}linenumbers.less */
-@media -sass-debug-info{filename{font-family:file\:\/\/{pathesc}linenumbers\.less}line{font-family:\0000327}}
+@media -sass-debug-info{filename{font-family:"file\:\/\/{pathesc}linenumbers\.less";}line{font-family:"\0000327";}}
 .test {
   color: red;
   width: 2;

--- a/test/css/debug/linenumbers-mediaquery.css
+++ b/test/css/debug/linenumbers-mediaquery.css
@@ -1,40 +1,40 @@
 @charset "UTF-8";
-@media -sass-debug-info{filename{font-family:file\:\/\/{pathimportesc}test\.less}line{font-family:\000031}}
+@media -sass-debug-info{filename{font-family:"file\:\/\/{pathimportesc}test\.less";}line{font-family:"\000031";}}
 /* @charset "ISO-8859-1"; */
 
-@media -sass-debug-info{filename{font-family:file\:\/\/{pathimportesc}test\.less}line{font-family:\0000323}}
+@media -sass-debug-info{filename{font-family:"file\:\/\/{pathimportesc}test\.less";}line{font-family:"\0000323";}}
 .tst3 {
   color: grey;
 }
-@media -sass-debug-info{filename{font-family:file\:\/\/{pathesc}linenumbers\.less}line{font-family:\0000315}}
+@media -sass-debug-info{filename{font-family:"file\:\/\/{pathesc}linenumbers\.less";}line{font-family:"\0000315";}}
 .test1 {
   color: black;
 }
-@media -sass-debug-info{filename{font-family:file\:\/\/{pathesc}linenumbers\.less}line{font-family:\000036}}
+@media -sass-debug-info{filename{font-family:"file\:\/\/{pathesc}linenumbers\.less";}line{font-family:"\000036";}}
 .test2 {
   color: red;
 }
 @media all {
-  @media -sass-debug-info{filename{font-family:file\:\/\/{pathimportesc}test\.less}line{font-family:\000035}}
+  @media -sass-debug-info{filename{font-family:"file\:\/\/{pathimportesc}test\.less";}line{font-family:"\000035";}}
   .tst {
     color: black;
   }
 }
 @media all and screen {
-  @media -sass-debug-info{filename{font-family:file\:\/\/{pathimportesc}test\.less}line{font-family:\000037}}
+  @media -sass-debug-info{filename{font-family:"file\:\/\/{pathimportesc}test\.less";}line{font-family:"\000037";}}
   .tst {
     color: red;
   }
-  @media -sass-debug-info{filename{font-family:file\:\/\/{pathimportesc}test\.less}line{font-family:\000039}}
+  @media -sass-debug-info{filename{font-family:"file\:\/\/{pathimportesc}test\.less";}line{font-family:"\000039";}}
   .tst .tst3 {
     color: white;
   }
 }
-@media -sass-debug-info{filename{font-family:file\:\/\/{pathimportesc}test\.less}line{font-family:\0000318}}
+@media -sass-debug-info{filename{font-family:"file\:\/\/{pathimportesc}test\.less";}line{font-family:"\0000318";}}
 .tst2 {
   color: white;
 }
-@media -sass-debug-info{filename{font-family:file\:\/\/{pathesc}linenumbers\.less}line{font-family:\0000327}}
+@media -sass-debug-info{filename{font-family:"file\:\/\/{pathesc}linenumbers\.less";}line{font-family:"\0000327";}}
 .test {
   color: red;
   width: 2;


### PR DESCRIPTION
Refer to http://bassjobsen.weblogs.fm/fireless-less-v2/, in order to support [FireLess](https://addons.mozilla.org/en-us/firefox/addon/fireless/) we now need to add following JS for live bugfix less.js:

    <link type=”text/css” href=”bootstrap3/bootstrap/less/bootstrap.less” rel=”stylesheet/less”>
    <script>
    function FireLessProcessor(options) {};
    FireLessProcessor.prototype = {
    process: function (css) {
    css = css.replace(/(@media -sass-debug-info\{)(.*)(\}\n)/g,function(m1,m2,m3,m4){
    m3 = m3.replace(‘file\\:\\/\\/file\\:\\/\\/’,’file\\:\\/\\/’);
    m3 = m3.replace(‘file\\:\\/\\/http\\:\\/\\/’,’http\\:\\/\\/’);
    m3 = m3.replace(‘file\\:\\/\\/https\\:\\/\\/’,’https\\:\\/\\/’);
    m3 = m3.replace(/(font-family:)([^}]+)(})/g, function(r1,r2,r3,r4){
    return r2 + ‘”‘ + r3 + ‘”;’ + r4;
    });

    return m2 + m3 + m4;
    });
    return css;
    }
    };
    var FireLess = {
    install: function(less,pluginManager) {
    pluginManager.addPostProcessor(new FireLessProcessor());
    }
    };

    var less = {
    env: “development”,
    dumpLineNumbers: “mediaquery”,
    plugins: [FireLess]
    };
    </script>
    <script src=”//cdnjs.cloudflare.com/ajax/libs/less.js/2.2.0/less.min.js”></script>

Where the key point as below:

    m3 = m3.replace(/(font-family:)([^}]+)(})/g, function(r1,r2,r3,r4){
    return r2 + ‘”‘ + r3 + ‘”;’ + r4;
    });

So this pull request solve above suggested bugfix from original source `lib/less/tree/debug-info.js`, and update corresponding test cases, too.

Confirm generated result works with OS X 10.10.3 + FF 37.0.1 + FireLESS 1.1 
 