### PR TITLE
Fix `Ruleset.prototype.find` failing for certain frames

### DIFF
--- a/lib/less/tree/ruleset.js
+++ b/lib/less/tree/ruleset.js
@@ -255,7 +255,7 @@ Ruleset.prototype.variable = function (name) {
     return this.variables()[name];
 };
 Ruleset.prototype.rulesets = function () {
-    if (!this.rules) { return null; }
+    if (!this.rules) { return []; }
 
     var filtRules = [], rules = this.rules, cnt = rules.length,
         i, rule;


### PR DESCRIPTION
Some frames may have no `rules` and `Ruleset.prototype.find` fails with those at https://github.com/less/less.js/blob/v2.5.0/lib/less/tree/ruleset.js#L287 because of `null.forEach`.
I suppose this can affect only programmatic usage of `find` (e.g. within a plugin or so, I stepped into this with a "mixin definition default parameter values" frame).