### PR TITLE
throw an error when argument to percentage is not a number

### DIFF
--- a/lib/less/functions/number.js
+++ b/lib/less/functions/number.js
@@ -71,6 +71,10 @@ functionRegistry.addMultiple({
         return new Dimension(Math.pow(x.value, y.value), x.unit);
     },
     percentage: function (n) {
+        if (typeof n !== "number") {
+            throw { type: "Argument", message: "argument must be a number" };
+        }
+        
         return new Dimension(n.value * 100, '%');
     }
 });


### PR DESCRIPTION
This is a bugfix to Issue #2553 . Added an error thrown if the arguments do not equal a number.