### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,7 @@
     "type": "git",
     "url": "https://github.com/less/less.js.git"
   },
-  "licenses": [
-    {
-      "type": "Apache v2",
-      "url": "https://github.com/less/less.js/blob/master/LICENSE"
-    }
-  ],
+  "license": "Apache-2.0",
   "bin": {
     "lessc": "./bin/lessc"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/