### PR TITLE
Skip missing optional imports

### DIFF
--- a/lib/less/visitors/import-visitor.js
+++ b/lib/less/visitors/import-visitor.js
@@ -104,6 +104,7 @@ ImportVisitor.prototype = {
         var importVisitor = this,
             inlineCSS = importNode.options.inline,
             isPlugin = importNode.options.plugin,
+            isOptional = importNode.options.optional,
             duplicateImport = importedAtRoot || fullPath in importVisitor.recursionDetector;
 
         if (!context.importMultiple) {
@@ -118,6 +119,10 @@ ImportVisitor.prototype = {
                     return false;
                 };
             }
+        }
+
+        if (!fullPath && isOptional) {
+            importNode.skip = true;
         }
 
         if (root) {


### PR DESCRIPTION
Currently LESSC fails if you have an optional import, the import is missing, and source maps are enabled (#2599).

This changes the import visitor to skip the import if it's optional AND missing.