### PR TITLE
add `moduleUrl` option

### DIFF
--- a/lib/less/contexts.js
+++ b/lib/less/contexts.js
@@ -48,6 +48,7 @@ var evalCopyProperties = [
     'strictUnits',    // whether units need to evaluate correctly
     'sourceMap',      // whether to output a source map
     'importMultiple', // whether we are currently importing multiple copies
+    'moduleUrl',      // whether urls are in module syntax (./relative, module/item)
     'urlArgs',        // whether to add args into url tokens
     'javascriptEnabled',// option - whether JavaScript is enabled. if undefined, defaults to true
     'pluginManager',  // Used as the plugin manager for the session
@@ -79,7 +80,19 @@ contexts.Eval.prototype.isMathOn = function () {
 };
 
 contexts.Eval.prototype.isPathRelative = function (path) {
-    return !/^(?:[a-z-]+:|\/|#)/i.test(path);
+    if (this.moduleUrl) {
+        return /^(?:\.\.?\/)/.test(path);
+    } else {
+        return !/^(?:[a-z-]+:|\/|#)/i.test(path);
+    }
+};
+
+contexts.Eval.prototype.combinePath = function (rootpath, path) {
+    if (this.moduleUrl) {
+        return "./" + rootpath + path;
+    } else {
+        return rootpath + path;
+    }
 };
 
 contexts.Eval.prototype.normalizePath = function( path ) {
@@ -92,9 +105,16 @@ contexts.Eval.prototype.normalizePath = function( path ) {
         segment = segments.pop();
         switch( segment ) {
             case ".":
+                // Keep leading "./" seqment in module url mode
+                if (this.moduleUrl && path.length === 0) {
+                    path.push( segment );
+                }
                 break;
             case "..":
                 if ((path.length === 0) || (path[path.length - 1] === "..")) {
+                    path.push( segment );
+                } else if (path[path.length - 1] === ".") {
+                    path.pop();
                     path.push( segment );
                 } else {
                     path.pop();

--- a/lib/less/tree/url.js
+++ b/lib/less/tree/url.js
@@ -30,7 +30,7 @@ URL.prototype.eval = function (context) {
             if (!val.quote) {
                 rootpath = rootpath.replace(/[\(\)'"\s]/g, function(match) { return "\\" + match; });
             }
-            val.value = rootpath + val.value;
+            val.value = context.combinePath(rootpath, val.value);
         }
 
         val.value = context.normalizePath(val.value);

--- a/test/css/module-url/module-url.css
+++ b/test/css/module-url/module-url.css
@@ -1,0 +1,19 @@
+#imported-file {
+  background-url: url(./folder/relative/path);
+  background-url: url(./relative/path);
+  background-url: url(../relative/path);
+  background-url: url(module/path);
+}
+#correct-normalize {
+  background-url: url(./relative/path);
+  background-url: url("./relative/path");
+  background-url: url('./relative/path');
+  background-url: url(../relative/path);
+  background-url: url("../relative/path");
+  background-url: url('../relative/path');
+  background-url: url(./path);
+  background-url: url(.);
+  background-url: url(module);
+  background-url: url(module/path);
+  background-url: url(module/relative/path);
+}

--- a/test/css/url-args/urls.css
+++ b/test/css/url-args/urls.css
@@ -54,3 +54,8 @@
   background-image: url(data:image/x-png,f9difSSFIIGFIFJD1f982FSDKAA9==);
   background-image: url(' data:image/x-png,f9difSSFIIGFIFJD1f982FSDKAA9==');
 }
+#normalize-urls {
+  background-image: url(normal?424242);
+  background-image: url(relative?424242);
+  background-image: url("relative?424242");
+}

--- a/test/index.js
+++ b/test/index.js
@@ -46,6 +46,7 @@ lessTester.runTestSet({globalVars: true, banner: "/**\n  * Test\n  */\n"}, "glob
 lessTester.runTestSet({modifyVars: true}, "modifyVars/",
     null, null, null, function(name, type, baseFolder) { return path.join(baseFolder, name) + '.json'; });
 lessTester.runTestSet({urlArgs: '424242'}, "url-args/");
+lessTester.runTestSet({moduleUrl: true, relativeUrls: true}, "module-url/");
 lessTester.runTestSet({paths: ['test/data/', 'test/less/import/']}, "include-path/");
 lessTester.runTestSet({paths: 'test/data/'}, "include-path-string/");
 lessTester.runTestSet({plugin: 'test/plugins/postprocess/'}, "postProcessorPlugin/");

--- a/test/less/module-url/folder/file.less
+++ b/test/less/module-url/folder/file.less
@@ -1,0 +1,6 @@
+#imported-file {
+  background-url: url(./relative/path);
+  background-url: url(../relative/path);
+  background-url: url(../../relative/path);
+  background-url: url(module/path);
+}

--- a/test/less/module-url/module-url.less
+++ b/test/less/module-url/module-url.less
@@ -1,0 +1,15 @@
+@import "./folder/file.less";
+
+#correct-normalize {
+  background-url: url(./relative/path);
+  background-url: url("./relative/path");
+  background-url: url('./relative/path');
+  background-url: url(../relative/path);
+  background-url: url("../relative/path");
+  background-url: url('../relative/path');
+  background-url: url(./relative/../path);
+  background-url: url(./relative/../path/..);
+  background-url: url(module);
+  background-url: url(module/path);
+  background-url: url(module/path/../relative/path);
+}

--- a/test/less/url-args/urls.less
+++ b/test/less/url-args/urls.less
@@ -61,3 +61,9 @@
   background-image: url( data:image/x-png,f9difSSFIIGFIFJD1f982FSDKAA9==);
   background-image: url( ' data:image/x-png,f9difSSFIIGFIFJD1f982FSDKAA9==');
 }
+
+#normalize-urls {
+  background-image: url(normal);
+  background-image: url(./relative);
+  background-image: url("./relative");
+}


### PR DESCRIPTION
This PR adds an option which allows to switch the mode for `relativeUrls`.

By default `url(./file)` is emitted as `url(file)` and `url(module/path)` is emitted as `url(folder/module/path)` when imported from another file in `folder`.

With `moduleUrl = true` `url(./file)` is emitted as `url(./file)` and `url(module/path)` is emitted as `url(module/path)` even when imported from another file.

Why? [CSS Modules](https://github.com/css-modules/css-modules) use CommonJs-like `url(...)`s.
