### PR TITLE
Undefined source map should result in an empty map file. 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -449,6 +449,9 @@ module.exports = function (grunt) {
     // Run all tests
     grunt.registerTask('test', testTasks);
 
+    // Run all tests
+    grunt.registerTask('quicktest', testTasks.slice(0, testTasks.length -1));
+
     // generate a good test environment for testing sourcemaps
     grunt.registerTask('sourcemap-test', [
         'clean:sourcemap-test',

--- a/bin/lessc
+++ b/bin/lessc
@@ -353,6 +353,7 @@ function printUsage() {
 
     if (!sourceMapFileInline) {
         var writeSourceMap = function(output, onDone) {
+            output = output || "";
             var filename = sourceMapOptions.sourceMapFullFilename;
             ensureDirectory(filename);
             fs.writeFile(filename, output, 'utf8', function (err) {


### PR DESCRIPTION
Undefined source map should result in an empty map file. Should fix #2430