### PR TITLE
Keep shorthand color form the same way as named colors are kept.

### DIFF
--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -489,7 +489,7 @@ var Parser = function Parser(context, imports, fileInfo) {
                         if (!colorCandidateString.match(/^[A-Fa-f0-9]+$/)) { // verify if candidate consists only of allowed HEX characters
                             error("Invalid HEX color code");
                         }
-                        return new(tree.Color)(rgb[1]);
+                        return new(tree.Color)(rgb[1], undefined, '#' + colorCandidateString);
                     }
                 },
 

--- a/lib/less/tree/color.js
+++ b/lib/less/tree/color.js
@@ -4,7 +4,7 @@ var Node = require("./node"),
 //
 // RGB Colors - #ff0014, #eee
 //
-var Color = function (rgb, a) {
+var Color = function (rgb, a, originalForm) {
     //
     // The end goal here, is to parse the arguments
     // into an integer triplet, such as `128, 255, 0`
@@ -23,6 +23,9 @@ var Color = function (rgb, a) {
         });
     }
     this.alpha = typeof a === 'number' ? a : 1;
+    if (typeof originalForm !== 'undefined') {
+        this.value = originalForm;
+    }
 };
 
 Color.prototype = new Node();

--- a/test/css/comments2.css
+++ b/test/css/comments2.css
@@ -2,7 +2,7 @@
   /* Safari and Chrome */
 }
 .bg {
-  background-image: linear-gradient(#333333 /*{comment}*/, #111111);
+  background-image: linear-gradient(#333 /*{comment}*/, #111);
 }
 #planadvisor,
 .first,

--- a/test/css/compression/compression.css
+++ b/test/css/compression/compression.css
@@ -1,3 +1,3 @@
-#colours{color1:#fea;color2:#fea;color3:rgba(255,238,170,0.1);string:"#ffeeaa";/*! but not this type
+#colours{color1:#fea;color2:#ffeeaa;color3:rgba(255,238,170,0.1);string:"#fea";/*! but not this type
       Note preserved whitespace
   */}dimensions{val:.1px;val:0;val:4cm;val:.2;val:5;angles-must-have-unit:0deg;durations-must-have-unit:0s;length-doesnt-have-unit:0;width:auto\9}@page{marks:none;@top-left-corner{vertical-align:top}@top-left{vertical-align:top}}.shadow^.dom,body^^.shadow{display:done}

--- a/test/css/extract-and-length.css
+++ b/test/css/extract-and-length.css
@@ -1,6 +1,6 @@
 .multiunit {
   length: 6;
-  extract: abc "abc" 1 1px 1% #112233;
+  extract: abc "abc" 1 1px 1% #123;
 }
 .incorrect-index {
   v1: extract(a b c, 5);

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -4,7 +4,7 @@
   height: undefined("self");
   border-width: 5;
   variable: 11;
-  background: linear-gradient(#000000, #ffffff);
+  background: linear-gradient(#000, #fff);
 }
 #built-in {
   escaped: -Some::weird(#thing, y);
@@ -60,7 +60,7 @@
   replace-single-quoted: 'foo-2';
   replace-escaped-string: bar-2;
   replace-keyword: baz-2;
-  replace-with-color: "#113355#1133557";
+  replace-with-color: "#135#1357";
   replace-with-number: "2em07";
   format: "rgb(32, 128, 64)";
   format-string: "hello world";
@@ -68,7 +68,7 @@
   format-url-encode: "red is %23ff0000";
   format-single-quoted: 'hello single world';
   format-escaped-string: hello escaped world;
-  format-color-as-string: "#112233";
+  format-color-as-string: "#123";
   format-number-as-string: "4px";
   eformat: rgb(32, 128, 64);
   unitless: 12;

--- a/test/css/mixins-args.css
+++ b/test/css/mixins-args.css
@@ -34,7 +34,7 @@
 }
 body {
   padding: 30px;
-  color: #ff0000;
+  color: #f00;
 }
 .scope-mix {
   width: 8;

--- a/test/css/scope.css
+++ b/test/css/scope.css
@@ -1,5 +1,5 @@
 .tiny-scope {
-  color: #998899;
+  color: #989;
 }
 .scope1 {
   color: blue;

--- a/test/css/strings.css
+++ b/test/css/strings.css
@@ -28,7 +28,7 @@
 #interpolation {
   url: "http://lesscss.org/dev/image.jpg";
   url2: "http://lesscss.org/image-256.jpg";
-  url3: "http://lesscss.org#445566";
+  url3: "http://lesscss.org#456";
   url4: "http://lesscss.org/hello";
   url5: "http://lesscss.org/54.4px";
 }

--- a/test/css/url-args/urls.css
+++ b/test/css/url-args/urls.css
@@ -5,7 +5,7 @@
 #shorthands {
   background: url("http://www.lesscss.org/spec.html?424242") no-repeat 0 4px;
   background: url("img.jpg?424242") center / 100px;
-  background: #ffffff url(image.png?424242) center / 1px 100px repeat-x scroll content-box padding-box;
+  background: #fff url(image.png?424242) center / 1px 100px repeat-x scroll content-box padding-box;
 }
 #misc {
   background-image: url(images/image.jpg?424242);

--- a/test/css/urls.css
+++ b/test/css/urls.css
@@ -12,7 +12,7 @@
 #shorthands {
   background: url("http://www.lesscss.org/spec.html") no-repeat 0 4px;
   background: url("img.jpg") center / 100px;
-  background: #ffffff url(image.png) center / 1px 100px repeat-x scroll content-box padding-box;
+  background: #fff url(image.png) center / 1px 100px repeat-x scroll content-box padding-box;
 }
 #misc {
   background-image: url(images/image.jpg);

--- a/test/css/variables.css
+++ b/test/css/variables.css
@@ -3,7 +3,7 @@
 }
 .variables {
   height: 24px;
-  color: #888888;
+  color: #888;
   font-family: "Trebuchet MS", Verdana, sans-serif;
   quotes: "~" "~";
 }
@@ -16,10 +16,10 @@
 .values {
   minus-one: -1;
   font-family: 'Trebuchet', 'Trebuchet', 'Trebuchet';
-  color: #888888 !important;
-  same-color: #888888 !important;
-  same-again: #888888 !important;
-  multi-important: #888888 #888888, 'Trebuchet' !important;
+  color: #888 !important;
+  same-color: #888 !important;
+  same-again: #888 !important;
+  multi-important: #888 #888, 'Trebuchet' !important;
   multi: something 'A', B, C, 'Trebuchet';
 }
 .variable-names .quoted {


### PR DESCRIPTION
Keep shorthand color form the same way as named colors are kept. Fixes #2481 - Interpolated selectors and three letters long id selectors.