### PR TITLE
Reference inline comments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *~
 .#*
 .idea
+*.iml
 *.sublime-*
 
 # npm

--- a/lib/less/tree/expression.js
+++ b/lib/less/tree/expression.js
@@ -53,4 +53,9 @@ Expression.prototype.throwAwayComments = function () {
         return !(v instanceof Comment);
     });
 };
+Expression.prototype.markReferenced = function () {
+    this.value.forEach(function (value) {
+        if (value.markReferenced) { value.markReferenced(); }
+    });
+};
 module.exports = Expression;

--- a/lib/less/tree/rule.js
+++ b/lib/less/tree/rule.js
@@ -92,4 +92,22 @@ Rule.prototype.makeImportant = function () {
                           this.index, this.currentFileInfo, this.inline);
 };
 
+// Recursive marking for rules
+var mark = function(value) {
+    if (!Array.isArray(value)) {
+        if (value.markReferenced) {
+            value.markReferenced();
+        }
+    } else {
+        value.forEach(function (ar) {
+            mark(ar);
+        });
+    }
+};
+Rule.prototype.markReferenced = function () {
+    if (this.value) {
+        mark(this.value);
+    }
+};
+
 module.exports = Rule;

--- a/test/css/import-reference.css
+++ b/test/css/import-reference.css
@@ -59,7 +59,7 @@ div#id.class[a=1][b=2].class:not(1) {
   color: green;
 }
 .y {
-  pulled-in: yes;
+  pulled-in: yes /* inline comment survives */;
 }
 /* comment pulled in */
 .visible {

--- a/test/less/import/import-reference.less
+++ b/test/less/import/import-reference.less
@@ -37,7 +37,7 @@
 
 .zz {
   .y {
-    pulled-in: yes;
+    pulled-in: yes /* inline comment survives */;
   }
   /* comment pulled in */
 }


### PR DESCRIPTION
This pull fixes #2675.

As described in the issue, in-value comments are not currently preserved in when referenced. This patch adds reference marking to nodes below rules and expressions if markReferenced is available.
![](http://static4.fjcdn.com/thumbnails/comments/Germany+_c21cd83ea070204a95e981d633063e86.gif)

No changes in benchmark runtime outside of test noise levels.


