### PR TITLE
Move optionalDependencies to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "test": "grunt test"
   },
-  "optionalDependencies": {
+  "dependencies": {
     "errno": "^0.1.1",
     "graceful-fs": "^3.0.5",
     "image-size": "~0.3.5",


### PR DESCRIPTION
Like `source-map` is not the optional dependency on Node.js,
should use `dependencies` instead of `optionalDependencies`.
