### PR TITLE
Change to less-browser for old android

### DIFF
--- a/lib/less-browser/utils.js
+++ b/lib/less-browser/utils.js
@@ -9,7 +9,7 @@ module.exports = {
     },
     addDataAttr: function(options, tag) {
         for (var opt in tag.dataset) {
-            if (tag.dataset.hasOwnProperty(opt)) {
+            if (typeof tag.dataset.hasOwnProperty === "function" && tag.dataset.hasOwnProperty(opt)) {
                 if (opt === "env" || opt === "dumpLineNumbers" || opt === "rootpath" || opt === "errorReporting") {
                     options[opt] = tag.dataset[opt];
                 } else {


### PR DESCRIPTION
Change to check if tag.dataset.hasOwnProperty is a function to prevent
errors in error reporting in apps that use web view in older versions of
android (pre-4.4).