### PR TITLE
Fail when image-size functions are used in browser-less.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -170,7 +170,7 @@ module.exports = function (grunt) {
                 }
             },
             errors: {
-                src: ['test/less/errors/*.less', '!test/less/errors/javascript-error.less'],
+                src: ['test/less/errors/*.less', '!test/less/errors/javascript-error.less', 'test/browser/less/errors/*.less'],
                 options: {
                     timeout: 20000,
                     helpers: 'test/browser/runner-errors-options.js',

--- a/lib/less-browser/image-size.js
+++ b/lib/less-browser/image-size.js
@@ -1,0 +1,28 @@
+module.exports = function() {
+
+    var functionRegistry = require("./../less/functions/function-registry");
+
+    function imageSize() {
+        throw {
+            type: "Runtime",
+            message: "Image size functions are not supported in browser version of less"
+        };
+    }
+
+    var imageFunctions = {
+        "image-size": function(filePathNode) {
+            imageSize(this, filePathNode);
+            return -1;
+        },
+        "image-width": function(filePathNode) {
+            imageSize(this, filePathNode);
+            return -1;
+        },
+        "image-height": function(filePathNode) {
+            imageSize(this, filePathNode);
+            return -1;
+        }
+    };
+
+    functionRegistry.addMultiple(imageFunctions);
+};

--- a/lib/less-browser/index.js
+++ b/lib/less-browser/index.js
@@ -8,6 +8,7 @@ var addDataAttr = require("./utils").addDataAttr,
 module.exports = function(window, options) {
     var document = window.document;
     var less = require('../less')();
+
     //module.exports = less;
     less.options = options;
     var environment = less.environment,
@@ -19,6 +20,7 @@ module.exports = function(window, options) {
     require("./log-listener")(less, options);
     var errors = require("./error-reporting")(window, less, options);
     var cache = less.cache = options.cache || require("./cache")(window, options, less.logger);
+    require('./image-size')(less.environment);
 
     //Setup user functions
     if (options.functions) {

--- a/test/browser/less/errors/image-height-error.less
+++ b/test/browser/less/errors/image-height-error.less
@@ -1,0 +1,3 @@
+.test-height{
+  height: image-height("../data/image.jpg")
+}

--- a/test/browser/less/errors/image-height-error.txt
+++ b/test/browser/less/errors/image-height-error.txt
@@ -1,0 +1,4 @@
+RuntimeError: error evaluating function `image-height`: Image size functions are not supported in browser version of less in image-height-error.less on line 2, column 11:
+1 .test-height{
+2   height: image-height("../data/image.jpg")
+3 }

--- a/test/browser/less/errors/image-size-error.less
+++ b/test/browser/less/errors/image-size-error.less
@@ -1,0 +1,3 @@
+.test-size{
+  size: image-size("../data/image.jpg")
+}

--- a/test/browser/less/errors/image-size-error.txt
+++ b/test/browser/less/errors/image-size-error.txt
@@ -1,0 +1,4 @@
+RuntimeError: error evaluating function `image-size`: Image size functions are not supported in browser version of less in image-size-error.less on line 2, column 9:
+1 .test-size{
+2   size: image-size("../data/image.jpg")
+3 }

--- a/test/browser/less/errors/image-width-error.less
+++ b/test/browser/less/errors/image-width-error.less
@@ -1,0 +1,3 @@
+.test-width{
+  width: image-width("../data/image.jpg")
+}

--- a/test/browser/less/errors/image-width-error.txt
+++ b/test/browser/less/errors/image-width-error.txt
@@ -1,0 +1,4 @@
+RuntimeError: error evaluating function `image-width`: Image size functions are not supported in browser version of less in image-width-error.less on line 2, column 10:
+1 .test-width{
+2   width: image-width("../data/image.jpg")
+3 }


### PR DESCRIPTION
Throw a proper exception instead of failing to undefined error when using image-size functions in browser version of less.

Resolves #2737