### PR TITLE
Cache parsed imports for faster and incremental build

### DIFF
--- a/lib/less/import-manager.js
+++ b/lib/less/import-manager.js
@@ -109,9 +109,21 @@ module.exports = function(environment) {
             } else if (importOptions.inline) {
                 fileParsedFunc(null, contents, resolvedFilename);
             } else {
-                new Parser(newEnv, importManager, newFileInfo).parse(contents, function (e, root) {
-                    fileParsedFunc(e, root, resolvedFilename);
-                });
+                var importsCache = require('./imports-cache');
+                var entry = importsCache.get(resolvedFilename);
+                if (entry && entry.root) {
+                    fileParsedFunc(null, entry.root, resolvedFilename);
+                }
+                else {
+                    new Parser(newEnv, importManager, newFileInfo).parse(contents, function (e, root) {
+
+                        importsCache.set(resolvedFilename, {
+                            contents: contents,
+                            root: root
+                        });
+                        fileParsedFunc(e, root, resolvedFilename);
+                    });
+                }
             }
         };
 

--- a/lib/less/imports-cache.js
+++ b/lib/less/imports-cache.js
@@ -1,0 +1,36 @@
+
+
+// When the cache is disabled, it will stay empty
+
+var cache = {};
+var enabled = false;
+
+module.exports = {
+
+    isEnabled: function() {
+       return enabled;
+    },
+    enable: function() {
+       enabled = true;
+    },
+    disable: function() {
+       enabled = false;
+       this.clean();
+    },
+    
+    set: function (key, value) {
+        if ( enabled ) {
+            cache[key] = value;
+        }
+    },
+    get: function (key) {
+        return cache[key];
+    },
+    remove: function(key) {
+        delete cache[key];
+    },
+    clean: function(key) {
+        cache = {};
+    }
+};
+

--- a/lib/less/index.js
+++ b/lib/less/index.js
@@ -17,6 +17,7 @@ module.exports = function(environment, fileManagers) {
         ParseTree: (ParseTree = require('./parse-tree')(SourceMapBuilder)),
         ImportManager: (ImportManager = require('./import-manager')(environment)),
         render: require("./render")(environment, ParseTree, ImportManager),
+        invalidateImportsCacheFile: require("./imports-cache").remove,
         parse: require("./parse")(environment, ParseTree, ImportManager),
         LessError: require('./less-error'),
         transformTree: require('./transform-tree'),

--- a/lib/less/render.js
+++ b/lib/less/render.js
@@ -1,11 +1,29 @@
 var PromiseConstructor;
 
+var importsCache = require('./imports-cache');
+
+
+
 module.exports = function(environment, ParseTree, ImportManager) {
     var render = function (input, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = {};
         }
+
+        // importsCache can be enabled or disabled per render phase
+        if ( options.withImportsCaching ) {
+           importsCache.enable();
+           // If you invalidate cache yourself, you will have to call 
+           // less.invalidateImportsCacheFile(filePath) everytime a less file is modified
+           if ( !options.withManualImportsCachingInvalidation ) {
+               importsCache.clean();
+           } 
+        } 
+        else {
+           importsCache.disable();
+        }
+
 
         if (!callback) {
             if (!PromiseConstructor) {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "less",
+  "name": "less-with-imports-caching",
   "version": "2.5.3",
   "description": "Leaner CSS",
   "homepage": "http://lesscss.org",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "less-with-imports-caching",
+  "name": "less",
   "version": "2.5.3",
   "description": "Leaner CSS",
   "homepage": "http://lesscss.org",


### PR DESCRIPTION
This is related to this discussion:
https://github.com/less/less.js/issues/2640

I propose an experimental option to use imports caching.

This is experimental because it is insecure regarding to `@import (multiple)`  according to @seven-phases-max 

However, for most less users, this setting will be enough secure to leverage better productivity in a development environment.
Because many don't use `@import (multiple)` it would be a bad to not benefits from these perf gains just for features we don't always use.

If the user does not use these options then nothing would change for him. I recommend only using this in a dev mode setting (why the option!)
# New render options

`render` can be called with options:
- withImportsCaching: true => Means that the caching will kick in

The cache, by default, will be empty at the beginning of a render, so that modified files between 2 renders will always be reloaded. However this simple trick divides the compilation time by 2 on my app and someone else too.
- withManualImportsCachingInvalidation: true => means that the client will manage himself the evictions from the cache
  With this additional option, the next compilations will be faster because the cache will already be filled, and compilation time is divided by 3.

However the user has to call `less.invalidateImportsCacheFile` himself everytime a less file change.

This could probably be simpler to use if less supported some kind of watch mode (like watchify for browserify)
# Exemple gulp integration

``` js
        gulp.watch('./src/**/*.less').on('change', function(file) {
            less.invalidateImportsCacheFile(file.path);
            gulp.run('styles');
        });
```

``` js
var isProd = process.env.NODE_ENV === 'production';

function compileLess() {
    return less({
        withImportsCaching: !isProd,
        withManualImportsCachingInvalidation: !isProd
    });
};


gulp.task('styles', function () {
    return gulp.src("./src/app.less")
        .on('error', handleErrors)
        .pipe(compileLess())
        .on('error', handleErrors)
        .pipe(gulp.dest('./build'))
        .on('error', handleErrors)
        .pipe(gulpif(!isProd, livereload()));
});
```
