### PR TITLE
Allow unknown non-{}-block at-rules

### DIFF
--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -1291,12 +1291,10 @@ var Parser = function Parser(context, imports, fileInfo) {
                             } else if (e) {
                                 nodes.push(new(tree.Paren)(e));
                             } else {
-                                parserInput.restore("badly formed media feature definition");
-                                return null;
+                                error("badly formed media feature definition");
                             }
                         } else {
-                            parserInput.restore("Missing closing ')'");
-                            return null;
+                            error("Missing closing ')'", "Parse");
                         }
                     }
                 } while (e);
@@ -1341,8 +1339,7 @@ var Parser = function Parser(context, imports, fileInfo) {
                     rules = this.block();
 
                     if (!rules) {
-                        parserInput.restore("media definitions require block statements after any features");
-                        return;
+                        error("media definitions require block statements after any features");
                     }
 
                     parserInput.forget();
@@ -1420,33 +1417,6 @@ var Parser = function Parser(context, imports, fileInfo) {
                 }
 
                 switch(nonVendorSpecificName) {
-                    /*
-                    case "@font-face":
-                    case "@viewport":
-                    case "@top-left":
-                    case "@top-left-corner":
-                    case "@top-center":
-                    case "@top-right":
-                    case "@top-right-corner":
-                    case "@bottom-left":
-                    case "@bottom-left-corner":
-                    case "@bottom-center":
-                    case "@bottom-right":
-                    case "@bottom-right-corner":
-                    case "@left-top":
-                    case "@left-middle":
-                    case "@left-bottom":
-                    case "@right-top":
-                    case "@right-middle":
-                    case "@right-bottom":
-                        hasBlock = true;
-                        isRooted = true;
-                        break;
-                    */
-                    case "@counter-style":
-                        hasIdentifier = true;
-                        hasBlock = true;
-                        break;
                     case "@charset":
                         hasIdentifier = true;
                         hasBlock = false;
@@ -1456,16 +1426,16 @@ var Parser = function Parser(context, imports, fileInfo) {
                         hasBlock = false;
                         break;
                     case "@keyframes":
+                    case "@counter-style":
                         hasIdentifier = true;
-                        break;
-                    case "@host":
-                    case "@page":
-                        hasUnknown = true;
                         break;
                     case "@document":
                     case "@supports":
                         hasUnknown = true;
                         isRooted = false;
+                        break;
+                    default:
+                        hasUnknown = true;
                         break;
                 }
 
@@ -1483,6 +1453,7 @@ var Parser = function Parser(context, imports, fileInfo) {
                     }
                 } else if (hasUnknown) {
                     value = (parserInput.$re(/^[^{;]+/) || '').trim();
+                    hasBlock = (parserInput.currentChar() == '{');
                     if (value) {
                         value = new(tree.Anonymous)(value);
                     }

--- a/test/css/css-3.css
+++ b/test/css/css-3.css
@@ -149,3 +149,9 @@ body ^^ .shadow {
 }
 @-ms-viewport {
 }
+@unknown foo 42 (bar) {
+  x {
+    y: z;
+  }
+}
+@unknown foo 43;

--- a/test/less/css-3.less
+++ b/test/less/css-3.less
@@ -144,11 +144,19 @@ body ^^ .shadow {
 #issue2066 {
   background: url('/images/icon-team.svg') 0 0 / contain;
 }
+
 @counter-style triangle {
   system: cyclic;
   symbols: ‣;
   suffix: " ";
 }
+
 @-ms-viewport{
-//width: auto !important;
+  // width: auto !important;
 }
+
+@unknown foo 42 (bar) {
+    x {y: z}    
+}
+
+@unknown foo 43;

--- a/test/less/errors/parse-error-media-no-block-1.txt
+++ b/test/less/errors/parse-error-media-no-block-1.txt
@@ -1,3 +1,3 @@
-ParseError: media definitions require block statements after any features in {path}parse-error-media-no-block-1.less on line 1, column 24:
+SyntaxError: media definitions require block statements after any features in {path}parse-error-media-no-block-1.less on line 1, column 24:
 1 @media (extra: bracket)) {
 2   body {

--- a/test/less/errors/parse-error-media-no-block-2.txt
+++ b/test/less/errors/parse-error-media-no-block-2.txt
@@ -1,2 +1,2 @@
-ParseError: media definitions require block statements after any features in {path}parse-error-media-no-block-2.less on line 1, column 7:
+SyntaxError: media definitions require block statements after any features in {path}parse-error-media-no-block-2.less on line 1, column 7:
 1 @media

--- a/test/less/errors/parse-error-media-no-block-3.txt
+++ b/test/less/errors/parse-error-media-no-block-3.txt
@@ -1,3 +1,3 @@
-ParseError: media definitions require block statements after any features in {path}parse-error-media-no-block-3.less on line 4, column 4:
+SyntaxError: media definitions require block statements after any features in {path}parse-error-media-no-block-3.less on line 4, column 4:
 3     font-size: 5000px;
 4   }


### PR DESCRIPTION
Fixes #2770.

---

This does *not* fix #2639 (i.e. non-block directives do not bubble).
(I suppose enabling bubbling for all unknown at-rules by default would be fine, so I was thinking of doing this in this PR too. But since I don't quite understand the bubbling implementation itself and can't perform any deeper debugging I guess I'll leave this modification for someone else (after all it's a bit beyond #2770 scope anyway and more a subject of #2639)).