### PR TITLE
use instanceof operator instead of class comparison optimization

### DIFF
--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -55,7 +55,7 @@ var Parser = function Parser(context, imports, fileInfo) {
 
     function expect(arg, msg, index) {
         // some older browsers return typeof 'function' for RegExp
-        var result = (Object.prototype.toString.call(arg) === '[object Function]') ? arg.call(parsers) : parserInput.$re(arg);
+        var result = (arg instanceof Function || Object.prototype.toString.call(arg) === '[object Function]') ? arg.call(parsers) : parserInput.$re(arg);
         if (result) {
             return result;
         }


### PR DESCRIPTION
It is significantly faster to use instanceof operator for type checking instead of class comparison (jsperf test:http://jsperf.com/functiontype ). The optimization is to put instanceof check at first place.