### PR TITLE
Guard expressions regression in 2.6.0 (#2798)

### DIFF
--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -1640,12 +1640,44 @@ var Parser = function Parser(context, imports, fileInfo) {
                 }
             },
             parenthesisCondition: function () {
+                function tryConditionFollowedByParenthesis(me) {
+                    var body;
+                    parserInput.save();
+                    body = me.condition();
+                    if (!body) {
+                        parserInput.restore();
+                        return ;
+                    }
+                    if (!parserInput.$char(')')) {
+                        parserInput.restore();
+                        return ;
+                    }
+                    parserInput.forget();
+                    return body;
+                }
+
                 var body;
+                parserInput.save();
                 if (!parserInput.$str("(")) {
+                    parserInput.restore();
                     return ;
                 }
-                body = this.condition() || this.atomicCondition();
-                expectChar(')');
+                body = tryConditionFollowedByParenthesis(this);
+                if (body) {
+                    parserInput.forget();
+                    return body;
+                }
+
+                body = this.atomicCondition();
+                if (!body) {
+                    parserInput.restore();
+                    return ;
+                }
+                if (!parserInput.$char(')')) {
+                    parserInput.restore("expected ')' got '" + parserInput.currentChar() + "'");
+                    return ;
+                }
+                parserInput.forget();
                 return body;
             },
             atomicCondition: function () {

--- a/test/css/no-strict-math/mixins-guards.css
+++ b/test/css/no-strict-math/mixins-guards.css
@@ -1,0 +1,12 @@
+.test-2798 {
+  regression: fixed;
+}
+.conditions-parser-1 {
+  only-atomic: ok;
+}
+.conditions-parser-2 {
+  only-atomic-with-nested-parenthesis: ok;
+}
+.conditions-parser-3 {
+  only-atomic-nested-parenthesis-on-right: ok;
+}

--- a/test/less/no-strict-math/mixins-guards.less
+++ b/test/less/no-strict-math/mixins-guards.less
@@ -1,0 +1,25 @@
+// https://github.com/less/less.js/issues/2798
+.test-2798 when ((8+4) < 13) { 
+  regression: fixed; 
+}
+.test-2798 when ((8+6) < 13) { 
+  regression: should not be visible; 
+}
+.conditions-parser-1 when (8+4 < 13) {
+  only-atomic: ok;
+}
+.conditions-parser-1 when (8+6 < 13) {
+  only-atomic: should not be visible;
+}
+.conditions-parser-2 when (8+(5-1) < 13) {
+  only-atomic-with-nested-parenthesis: ok;
+}
+.conditions-parser-2 when (8+(15-1) < 13) {
+  only-atomic-with-nested-parenthesis: should not be visible;
+}
+.conditions-parser-3 when (8 < (13+1)) {
+  only-atomic-nested-parenthesis-on-right: ok;
+}
+.conditions-parser-3 when (8 < (3+1)) {
+  only-atomic-nested-parenthesis-on-right: should not be visible;
+}


### PR DESCRIPTION
This fixes #2798 - left part of inequality could not be enclosed in parenthesis. 

