### PR TITLE
make --depends generate no CSS output

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -383,7 +383,9 @@ function printUsage() {
     };
 
     var writeOutput = function(output, result, onSuccess) {
-        if (output) {
+        if (options.depends) {
+            onSuccess();
+        } else if (output) {
             ensureDirectory(output);
             fs.writeFile(output, result.css, {encoding: 'utf8'}, function (err) {
                 if (err) {


### PR DESCRIPTION
I'm using `lessc` with Qt/C++ and up until recently I've just been regenerating the stylesheets, but I thought that this could be faster.

I dug around and found the `depends` flag and it sped up my build process 0 to :100: real quick.

The only downside is that when lessc is invoked twice, it will generate output twice.  I actually only need the dependencies with no output, and then at a later stage during `make`, the actual output.  I see here (https://github.com/less/less.js/issues/2476) that it's a nice to have feature, so here it is.

The new option is `-Mn` for short or `--depends-no-output`.  It will exercise the same code path as `depends` but skip the output stage if `depends_no_output` is `true`.