### PR TITLE
switch to unicode escape sequences for compatibility with strict mode

### DIFF
--- a/lib/less-node/lessc-helper.js
+++ b/lib/less-node/lessc-helper.js
@@ -15,8 +15,8 @@ var lessc_helper = {
             'red'       : [31, 39],
             'grey'      : [90, 39]
         };
-        return '\033[' + styles[style][0] + 'm' + str +
-               '\033[' + styles[style][1] + 'm';
+        return '\u001B[' + styles[style][0] + 'm' + str +
+               '\u001B[' + styles[style][1] + 'm';
     },
 
     //Print command line options


### PR DESCRIPTION
Presently, when requiring `less` for pragmatic usage with strict mode enabled, a syntax error is thrown because of use of octal escape sequences which are disabled in ES5 strict mode.

```sh
> node --use_strict
> var less = require('less');
/home/awal/dev/someProject/node_modules/less/lib/less-node/lessc-helper.js:19
               '\033[' + styles[style][1] + 'm';
                 ^^
```

This patch replaces them with the more universal unicode escape sequences, which fixes the above issue. I wasn't able to find any other places where strict-mode would throw at runtime, but I'd be happy to fix them as I find them and submit additional PRs if the feedback for this one is positive.

I realize this is not a priority and might not even be worth fixing for some, but our current setup enforces strict mode. It'd be great if this could be landed within less.js :)