### PR TITLE
Allow custom @-rules to execute custom functions

### DIFF
--- a/lib/less/functions/function-caller.js
+++ b/lib/less/functions/function-caller.js
@@ -17,13 +17,13 @@ functionCaller.prototype.call = function(args) {
     // https://github.com/less/less.js/issues/2477
     if (Array.isArray(args)) {
         args = args.filter(function (item) {
-            if (item.type === "Comment") {
+            if (item && item.type && item.type === "Comment") {
                 return false;
             }
             return true;
         })
         .map(function(item) {
-            if (item.type === "Expression") {
+            if (item && item.type && item.type === "Expression") {
                 var subNodes = item.value.filter(function (item) {
                     if (item.type === "Comment") {
                         return false;

--- a/lib/less/tree/directive.js
+++ b/lib/less/tree/directive.js
@@ -1,6 +1,7 @@
 var Node = require("./node"),
     Selector = require("./selector"),
-    Ruleset = require("./ruleset");
+    Ruleset = require("./ruleset"),
+    FunctionCaller = require("../functions/function-caller");
 
 var Directive = function (name, value, rules, index, currentFileInfo, debugInfo, isRooted, visibilityInfo) {
     var i;
@@ -57,7 +58,8 @@ Directive.prototype.genCSS = function (context, output) {
     }
 };
 Directive.prototype.eval = function (context) {
-    var mediaPathBackup, mediaBlocksBackup, value = this.value, rules = this.rules;
+    var mediaPathBackup, mediaBlocksBackup, value = this.value, rules = this.rules,
+        result, funcCaller = new FunctionCaller(this.name, context, this.index, this.currentFileInfo);
 
     //media stored inside other directive should not bubble over it
     //backpup media bubbling information
@@ -75,6 +77,24 @@ Directive.prototype.eval = function (context) {
         rules = [rules[0].eval(context)];
         rules[0].root = true;
     }
+
+    if (funcCaller.isValid()) {
+        try {
+            result = funcCaller.call([this.name, value ? value.value : value, rules ? rules[0] : rules]);
+        } catch (e) {
+            throw { type: e.type || "Runtime",
+                    message: "error evaluating custom directive `" + this.name + "`" +
+                             (e.message ? ': ' + e.message : ''),
+                    index: this.index, filename: this.currentFileInfo.filename };
+        }
+
+        if (result != null) {
+            result.index = this.index;
+            result.currentFileInfo = this.currentFileInfo;
+            return result;
+        }
+    }
+
     //restore media bubbling information
     context.mediaPath = mediaPathBackup;
     context.mediaBlocks = mediaBlocksBackup;

--- a/test/css/plugin.css
+++ b/test/css/plugin.css
@@ -47,3 +47,7 @@
   prop: value;
 }
 @arbitrary value after ();
+@new-directive success;
+test {
+  foo: bar;
+}

--- a/test/less/plugin.less
+++ b/test/less/plugin.less
@@ -90,4 +90,12 @@
 test-directive("@charset"; '"utf-8"');
 test-directive("@arbitrary"; "value after ()");
 
+@plugin "./plugin/plugin-custom-directives";
+
+@make-directive new-directive;
+@eval-rules test {
+  foo: bar;
+}
+
+
 

--- a/test/less/plugin/plugin-custom-directives.js
+++ b/test/less/plugin/plugin-custom-directives.js
@@ -1,0 +1,9 @@
+
+functions.addMultiple({
+    "@make-directive" : function(name, value, rules) {
+        return new tree.Directive('@' + value, new tree.Anonymous('success'));
+    },
+    "@eval-rules" : function(name, value, rules) {
+        return new tree.Ruleset([ new tree.Selector([new tree.Element("", value)]) ], rules.rules);
+    }
+});


### PR DESCRIPTION
This is a small but powerful extension to custom functions per the discussion here: https://github.com/less/less-meta/issues/10. Like regular functions, it allows you to intercept at-rules and see if there's a match in the function registry for that directive (at-rule). And like functions, if there is no match, it allows the directive to pass through as-is.

This allows you to do powerful stuff like:
```
@plugin "fancy-defaults";
@config defaults {
  first: true;
  second: false;
}

//fancy-defaults.js
functions.addMultiple({
    "@config" : function(name, value, rules) { 
        // process the rules and do fancy stuff with them
        // really you can do whatever you want, and return a node or not, just like functions
        return true;
    }
});
```