### PR TITLE
bin/lessc: Make sure path.dirname gets passed strings

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -316,8 +316,8 @@ function printUsage() {
     }
 
     if (sourceMapOptions.sourceMapRootpath === undefined) {
-        var pathToMap = path.dirname(sourceMapFileInline ? output : sourceMapOptions.sourceMapFullFilename),
-            pathToInput = path.dirname(sourceMapOptions.sourceMapInputFilename);
+        var pathToMap = path.dirname(sourceMapFileInline ? output : sourceMapOptions.sourceMapFullFilename || '.'),
+            pathToInput = path.dirname(sourceMapOptions.sourceMapInputFilename || '.');
         sourceMapOptions.sourceMapRootpath = path.relative(pathToMap, pathToInput);
     }
 


### PR DESCRIPTION
Since nodejs/node@08085c49b6e, which will be part of Node.js v6.0, functions from the `path` core module (like `dirname`) will require the input to be a string.

Because `.sourceMapFullFilename` and `.sourceMapInputFilename` in bin/lessc may be `undefined`, default to passing `'.'` to `path.dirname` instead. (In Node ≤ v5.x, `path.dirname(undefined) === '.'`.)

Disclosure: I basically don’t know anything about less internals. What I know is that this fixes my build; there’s a good chance that there is a more appropriate solution for this problem. I also have no idea where a test for this particular problem would go, but since this issue can be reproduced by simply running `lessc <input>`, I don’t know if that’s even necessary.

Also, [this line](https://github.com/less/less.js/blob/ce4a7bc0e9468f9cda0b9f8f2132475111f6165b/bin/lessc#L48) suppresses all uncaught exceptions, which made debugging kinda hard. Again, I don’t know whether that’s the best way for less, but I’d suggest adding an explicit handler via `process.on('uncaughtException', …)`.