### PR TITLE
browser: Copy a Content-Security-Policy nonce attribute from <link>

### DIFF
--- a/lib/less-browser/browser.js
+++ b/lib/less-browser/browser.js
@@ -17,6 +17,9 @@ module.exports = {
         if (sheet.media) {
             styleNode.setAttribute('media', sheet.media);
         }
+        if (sheet.hasAttribute && sheet.hasAttribute('nonce')) {
+            styleNode.setAttribute('nonce', sheet.getAttribute('nonce'));
+        }
         styleNode.id = id;
 
         if (!styleNode.styleSheet) {


### PR DESCRIPTION
When a nonce attribute is in use by Content-Security-Policy
copy the attribute from the &lt;link> tag to the &lt;style> tag.
This allows the Content-Security-Policy to accept the &lt;style>
tag that's been created by the in-browser less.

The goal is for developers to be running with Content-Security-Policy
set to enforcing. This ensures that developers find bugs related to
the policy. But at the same time still having less process stylesheets
in the browser during development.
