### PR TITLE
Fix AST to include text for single line comments

### DIFF
--- a/lib/less/parser/parser-input.js
+++ b/lib/less/parser/parser-input.js
@@ -40,7 +40,7 @@ module.exports = function() {
                         nextNewLine = endIndex;
                     }
                     parserInput.i = nextNewLine;
-                    comment.text = inp.substr(comment.i, parserInput.i - comment.i);
+                    comment.text = inp.substr(comment.index, parserInput.i - comment.index);
                     parserInput.commentStore.push(comment);
                     continue;
                 } else if (nextChar === '*') {


### PR DESCRIPTION
The AST didn't include the contents of single line comments because of a tyop in a property name.

I used

```
function lessAST(filename, options) {
    options = options || {};
    options.filename = path.resolve(filename);
    return new Promise(function (res, rej) {
        fs.readFile(filename, 'utf8', function (err, data) {
            if (err) {
                rej(err);
            } else {
                res(data);
            }
        });
    }).then(function (data) {
        return new Promise(function (res, rej) {
            less.parse(data, options, function (err, tree) {
                if (err) {
                    rej(err);
                } else {
                    res(tree);
                }
            });
        });
    });
}
lessAST(filename).then(function (tree) {
  fs.writeFile('tmp.json', JSON.stringify(tree, null, 2));
});
```

to view the AST locally. I haven't yet written any tests for this particular case.