### PR TITLE
Fix relative sourcemap paths.

### DIFF
--- a/lib/less/source-map-output.js
+++ b/lib/less/source-map-output.js
@@ -57,14 +57,11 @@ module.exports = function (environment) {
     };
 
     SourceMapOutput.prototype.normalizeFilename = function(filename) {
-        filename = filename.replace(/\\/g, '/');
+        var path = require('path');
+        var basePath = this._sourceMapBasepath || process.cwd();
 
-        if (this._sourceMapBasepath && filename.indexOf(this._sourceMapBasepath) === 0) {
-            filename = filename.substring(this._sourceMapBasepath.length);
-            if (filename.charAt(0) === '\\' || filename.charAt(0) === '/') {
-                filename = filename.substring(1);
-            }
-        }
+        filename = path.relative(basePath, filename).replace(/\\/g, '/');
+
         return (this._sourceMapRootpath || "") + filename;
     };
 


### PR DESCRIPTION
This is modelled after Browserify's sourcemap generation.

In theory, `path.relative` could be replaced with a call to `pathDiff` on the environment's fileManager.
I couldn't find an obvious way to get the current directory from the environment, which made it difficult to get a fileManager.

Fixes #1741, #2822, #2864.
Sourcemaps were test in-browser and the file structure was as would be expected.
