### PR TITLE
Fix error reporting of lessc executable

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -40,18 +40,20 @@ var silent = false,
     plugins: plugins
 };
 var sourceMapOptions = {};
-var continueProcessing = true,
-    currentErrorcode;
 
-// calling process.exit does not flush stdout always
-// so use this to set the exit code
-process.on('exit', function() { process.reallyExit(currentErrorcode); });
+var exitWithError = function(msg) {
+    console.error(msg);
+    process.exit(1);
+};
+
+var exitWithLog = function(msg) {
+    console.log(msg);
+    process.exit(0);
+};
 
 var checkArgFunc = function(arg, option) {
     if (!option) {
-        console.error(arg + " option requires a parameter");
-        continueProcessing = false;
-        currentErrorcode = 1;
+        exitWithError(arg + " option requires a parameter");
         return false;
     }
     return true;
@@ -60,9 +62,7 @@ var checkArgFunc = function(arg, option) {
 var checkBooleanArg = function(arg) {
     var onOff = /^((on|t|true|y|yes)|(off|f|false|n|no))$/i.exec(arg);
     if (!onOff) {
-        console.error(" unable to parse " + arg + " as a boolean. use one of on/t/true/y/yes/off/f/false/n/no");
-        continueProcessing = false;
-        currentErrorcode = 1;
+        exitWithError(" unable to parse " + arg + " as a boolean. use one of on/t/true/y/yes/off/f/false/n/no");
         return false;
     }
     return Boolean(onOff[2]);
@@ -78,8 +78,11 @@ var sourceMapFileInline = false;
 function printUsage() {
     less.lesscHelper.printUsage();
     pluginLoader.printUsage(plugins);
-    continueProcessing = false;
 }
+
+process.on("unhandledRejection", function(reason) {
+    exitWithError(reason);
+});
 
 // self executing function so we can return
 (function() {
@@ -102,8 +105,7 @@ function printUsage() {
         switch (arg) {
             case 'v':
             case 'version':
-                console.log("lessc " + less.version.join('.') + " (Less Compiler) [JavaScript]");
-                continueProcessing = false;
+                exitWithLog("lessc " + less.version.join('.') + " (Less Compiler) [JavaScript]");
                 break;
             case 'verbose':
                 verbose = true;
@@ -250,9 +252,8 @@ function printUsage() {
                 if (plugin) {
                     plugins.push(plugin);
                 } else {
-                    console.error("Unable to load plugin " + name +
+                    exitWithError("Unable to load plugin " + name +
                         " please make sure that it is installed under or at the same level as less");
-                    currentErrorcode = 1;
                 }
                 break;
             default:
@@ -260,18 +261,13 @@ function printUsage() {
                 if (plugin) {
                     plugins.push(plugin);
                 } else {
-                    console.error("Unable to interpret argument " + arg +
+                    exitWithError("Unable to interpret argument " + arg +
                         " - if it is a plugin (less-plugin-" + arg + "), make sure that it is installed under or at" +
                         " the same level as less");
-                    currentErrorcode = 1;
                 }
                 break;
         }
     });
-
-    if (!continueProcessing) {
-        return;
-    }
 
     var input = args[1];
     if (input && input != '-') {
@@ -325,7 +321,7 @@ function printUsage() {
         console.error("lessc: no input files");
         console.error("");
         printUsage();
-        currentErrorcode = 1;
+        process.exit(1);
         return;
     }
 
@@ -420,8 +416,7 @@ function printUsage() {
 
     var parseLessFile = function (e, data) {
         if (e) {
-            console.error("lessc: " + e.message);
-            currentErrorcode = 1;
+            exitWithError("lessc: " + e.message);
             return;
         }
 
@@ -468,7 +463,7 @@ function printUsage() {
             },
             function(err) {
                 less.writeError(err, options);
-                currentErrorcode = 1;
+                process.exit(1);
             });
     };
 


### PR DESCRIPTION
This commit replaces the old control flow of exiting the process when an error occurred which swallowed the error in some situations (https://github.com/less/less.js/issues/2881). Additionally, it also adds a listener for "unhandledRejection" to also catch errors caused by rejected promises.

I'm calling `process.exit()` directly because I cannot reproduce that `calling process.exit does not flush stdout always` (has been added some time ago with 2d8ede3436ba28e96b20e2719de573fa9ea998f0).

~~I've also added a small "padding" around the error message which looks nicer in the terminal (inspired by mocha):~~ EDIT: Has been removed after discussion

![bildschirmfoto 2016-04-27 um 19 40 39](https://cloud.githubusercontent.com/assets/781746/14862826/654e71ce-0cb3-11e6-9c4b-c3bf03c34550.jpg)
![bildschirmfoto 2016-04-27 um 19 49 40](https://cloud.githubusercontent.com/assets/781746/14862831/67cbb826-0cb3-11e6-9aca-db0f5c3b07b5.jpg)
