### PR TITLE
Fix invalid extraction of the host part from URL

### DIFF
--- a/lib/less/environment/abstract-file-manager.js
+++ b/lib/less/environment/abstract-file-manager.js
@@ -73,7 +73,7 @@ abstractFileManager.prototype.extractUrlParts = function extractUrlParts(url, ba
     // urlParts[4] = filename
     // urlParts[5] = parameters
 
-    var urlPartsRegex = /^((?:[a-z-]+:)?\/+?(?:[^\/\?#]*\/)|([\/\\]))?((?:[^\/\\\?#]*[\/\\])*)([^\/\\\?#]*)([#\?].*)?$/i,
+    var urlPartsRegex = /^((?:[a-z-]+:)?\/{2}(?:[^\/\?#]*\/)|([\/\\]))?((?:[^\/\\\?#]*[\/\\])*)([^\/\\\?#]*)([#\?].*)?$/i,
         urlParts = url.match(urlPartsRegex),
         returner = {}, directories = [], i, baseUrlParts;
 


### PR DESCRIPTION
In `extractUrlParts` method of `environment/abstract-file-manager` module there is an error in regular expression. Due to an this error occurs incorrect extraction of the host part from URL.

For example, we have URL - `/Content/less/`. Due to an error we get the host part equals to `/Content/`, but it should be `/`.