### PR TITLE
Download PhantomJS from CDN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "4.2.0"
-  - "4.0.0"
+  - "6"
+  - "4"
   - "0.12"
   - "0.10"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,12 @@ node_js:
   - "4.0.0"
   - "0.12"
   - "0.10"
-before_install:
-  - mkdir travis-phantomjs
-  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
 install:
   - npm install -g grunt-cli
   - npm install
 env:
   global:
+    - PHANTOMJS_CDNURL=http://cnpmjs.org/downloads
     - secure: TrNVruWYaUK5ALga1y7wRY+MLjWJECUSCsBmKW5EUmIevOUxqHWu7M89FANKxstEeFRRAGH3QJbloRxnzIgh0U0ah5npE9XA1bYXGO5khoXeIyk7pNRfjIo8aEnJH1Vp8vWA6J6ovxdJ7lCFKEGvGKxGde50knVl7KFVVULlX2U=
     - secure: Rzh+CEI7YRvvVkOruPE8Z0dkU0s13V6b6cpqbN72vxbJl/Jm5PUZkjTFJdkWJrW3ErhCKX6EC7XdGvrclqEA9WAqKzrecqCJYqTnw4MwqiAj6F9wqE/BqhoWg4xPxm0MK/7eJMvLCgjNpe+gc1CaeFJZkLSNWn6nOFke+vVlf9Q=
 sudo: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ environment:
     - nodejs_version: "0.10"
     - nodejs_version: "0.12"
     - nodejs_version: "4"
+    - nodejs_version: "6"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "diff": "^2.2.2",
-    "grunt": "^1.0.1",
+    "grunt": "~0.4.5",
     "grunt-browserify": "^5.0.0",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-concat": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "grunt-saucelabs": "^8.6.2",
     "grunt-shell": "^1.3.0",
     "jit-grunt": "^0.10.0",
+    "phantomjs-prebuilt": "^2.1.7",
     "time-grunt": "^1.3.0"
   },
   "keywords": [


### PR DESCRIPTION
Addresses #2898.  Instead of attempting a manual download of
PhantomJS, use the npm package phantomjs-prebuilt and the
environment variable `PHANTOMJS_CDNURL` as suggested in
the comment at https://github.com/ariya/phantomjs/issues/13953#issuecomment-200862297.