### PR TITLE
Added 'request' as optional dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "mime": "^1.2.11",
     "mkdirp": "^0.5.0",
     "promise": "^7.1.1",
-    "source-map": "^0.5.3"
+    "source-map": "^0.5.3",
+    "request": "^2.72.0"
   },
   "devDependencies": {
     "diff": "^2.2.2",


### PR DESCRIPTION
Compiling following less code:

``` less
@import (less) url(http://example.com/somefile.less);
```

Will fail with if npm 'request' package is not installed:

```
FileError: optional dependency 'request' required to import over http(s)
```
