### PR TITLE
Cache Phantomjs to mitigate connectivity issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,23 @@
 language: node_js
+cache:
+  directories:
+    - travis-phantomjs
 node_js:
   - "6"
   - "4"
   - "0.12"
   - "0.10"
+before_install:
+  # from https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-177592725
+  # and also from https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-200965782
+  - phantomjs --version
+  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
+  - phantomjs --version
+  # Clear cache and download new copy of PhantomJS if the current version doesn't match 2.1.1.
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis-phantomjs; mkdir -p $PWD/travis-phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://cnpmjs.org/mirrors/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs; fi"
+  - phantomjs --version  
 install:
   - npm install -g grunt-cli
   - npm install


### PR DESCRIPTION
Copied from https://github.com/Coursemology/coursemology2/pull/1183
But changed the URL to https://cnpmjs.org/mirrors/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2

related to #2898