### PR TITLE
CI Build Fixes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,31 @@
 language: node_js
+cache:
+  directories:
+    - travis-phantomjs
 node_js:
   - "6"
   - "4"
   - "0.12"
   - "0.10"
+before_install:
+  # from https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-177592725
+  # and also from https://github.com/travis-ci/travis-ci/issues/3225#issuecomment-200965782
+  - phantomjs --version
+  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
+  - phantomjs --version
+  # Clear cache and download new copy of PhantomJS if the current version doesn't match 2.1.1.
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis-phantomjs; mkdir -p $PWD/travis-phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs; fi"
+  - phantomjs --version
 install:
   - npm install -g grunt-cli
-  - npm install
+  # node 0.10 & 0.12 have race condition issues when running custom install scripts
+  # this can cause phantomjs-prebuilt install script to fail with the error:
+  # <Cannot find module 'boom'>
+  # Seems related to: https://github.com/npm/npm/issues/8152
+  # using <travis_retry> solves this.
+  - travis_retry npm install
 env:
   global:
     - PHANTOMJS_CDNURL=http://cnpmjs.org/downloads

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,14 @@ install:
   - npm -g install npm@2
   - set PATH=%APPDATA%\npm;%PATH%
   - npm -v
-  # Typical npm stuff.
-  - npm install
+
+  # node 0.10 & 0.12 have race condition issues when running custom install scripts
+  # this can cause phantomjs-prebuilt install script to fail with the error:
+  # <Cannot find module 'boom'>
+  # Seems related to: https://github.com/npm/npm/issues/8152
+  # using <appveyor_retry> solves this.
+  - appveyor-retry call npm install
+
   # Grunt-specific stuff.
   - npm install -g grunt-cli
 


### PR DESCRIPTION
 CI Build Fixes.

In Short:
* Enable Travis Cache to mitigate phantomjs download issues.
* Enable Travis & appveyor <retry> functionality to avoid race condition on CI builds
  and old node.js version (0.10/0.12)

Details:

Using <https://bitbucket.org/ariya/phantomjs/downloads/>
to download phantom (on travis)  instead of <http://cnpmjs.org/downloads>
because Travis downloads from http://cnpmjs.org/downloads are horribly slow (30k/s)
and seem courrpt most of the time (smells like throttling)

Travis caching is by branch + build env (node version).
But it has a fallback to using the cache from the default branch
so it should help even with pull requests (which are new branches).

Secondly using **travis_retry** and **appveyor_retry** for **npm install**
to workaround race condition on with npm install and older versions of node.

mitigates #2898