### PR TITLE
Temporary workaround to make appveyor-retry work with npm

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - set PATH=%APPDATA%\npm;%PATH%
   - npm -v
   # Typical npm stuff.
-  - npm install
+  - appveyor-retry call npm install
   # Grunt-specific stuff.
   - npm install -g grunt-cli
 


### PR DESCRIPTION
Problem is that appveyor-retry is actually cmd and npm is cmd too. So you need to add "call" after appveyor-retry. Please remove this workaround when https://github.com/appveyor/ci/issues/950fixed.