### PR TITLE
Add "grunt-cli" package to "devDependencies" at package.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ We only accept issues that are bug reports or feature requests. Bugs must be iso
 1. **Search for existing issues.** We get a lot of duplicate issues, and you'd help us out a lot by first checking if someone else has reported the same issue. Moreover, the issue may have already been resolved with a fix available.
 2. **Create an isolated and reproducible test case.** Be sure the problem exists in Less.js's code with [reduced test cases](http://css-tricks.com/reduced-test-cases/) that should be included in each bug report.
 3. **Test with the latest version**. We get a lot of issues that could be resolved by updating your version of Less.js.
-3. **Include an example with source.** E.g. You can use [less2css.org](http://less2css.org/) to create a short test case. 
+3. **Include an example with source.** E.g. You can use [less2css.org](http://less2css.org/) to create a short test case.
 4. **Share as much information as possible.** Include operating system and version. Describe how you use Less. If you use it in the browser, please include browser and version, and the version of Less.js you're using. Let us know if you're using the command line (`lessc`) or an external tool. And try to include steps to reproduce the bug.
 5. If you have a solution or suggestion for how to fix the bug you're reporting, please include it, or make a pull request - don't assume the maintainers know how to fix it just because you do.
 
@@ -35,7 +35,7 @@ _Pull requests are encouraged!_
 * Start by adding a feature request to get feedback and see how your idea is received.
 * If your pull request solves an existing issue, but it's different in some way, _please create a new issue_ and make sure to discuss it with the core contributors. Otherwise you risk your hard work being rejected.
 * Do not change the **./dist/** folder, we do this when releasing
-* _Please add tests_ for your work. Tests are invoked using `grunt test` command. It will run both node.js tests and browser ([PhantomJS](http://phantomjs.org/)) tests.
+* _Please add tests_ for your work. Tests are invoked using `npm test` command. It will run both node.js tests and browser ([PhantomJS](http://phantomjs.org/)) tests.
 
 ### Coding Standards
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "node": ">=0.12"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "grunt": "grunt"
   },
   "optionalDependencies": {
     "errno": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "diff": "^2.2.2",
     "grunt": "~0.4.5",
     "grunt-browserify": "^5.0.0",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-connect": "^1.0.2",


### PR DESCRIPTION
So contibutors don't have to install grunt globally to run tests which is a good tone.
