### PR TITLE
Allow less imports of paths like 'dir/css'

### DIFF
--- a/lib/less/tree/import.js
+++ b/lib/less/tree/import.js
@@ -29,7 +29,7 @@ var Import = function (path, features, options, index, currentFileInfo, visibili
         this.css = !this.options.less || this.options.inline;
     } else {
         var pathValue = this.getPath();
-        if (pathValue && /[#\.\&\?\/]css([\?;].*)?$/.test(pathValue)) {
+        if (pathValue && /[#\.\&\?]css([\?;].*)?$/.test(pathValue)) {
             this.css = true;
         }
     }

--- a/test/css/import.css
+++ b/test/css/import.css
@@ -1,6 +1,5 @@
 @charset "UTF-8";
 /** comment at the top**/
-@import url(http://fonts.googleapis.com/css?family=Open+Sans);
 @import url(/absolute/something.css) screen and (color) and (max-width: 600px);
 @import url("//ha.com/file.css") (min-width: 100px);
 #import-test {

--- a/test/less/import.less
+++ b/test/less/import.less
@@ -1,6 +1,4 @@
 /** comment at the top**/
-@import url(http://fonts.googleapis.com/css?family=Open+Sans);
-
 @import url(/absolute/something.css) screen and (color) and (max-width: 600px);
 
 @import (optional) "file-does-not-exist.does-not-exist";


### PR DESCRIPTION
Right now, an import like `@import "directory/css";` is interpreted as a CSS import, because the path contains `/css`.

Based on https://github.com/less/less.js/issues/2364#issuecomment-68601978, it seems that the intent is to create a CSS import if the word `css` appears as a _URL parameter_. But appearing after a forward slash doesn't indicate a URL parameter; it just indicates a path.

An alternative would be to parse the import path using [url.parse](https://nodejs.org/docs/latest/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost) and to look for `css` in the query string or the hash. Please let me know what solution you'd prefer, and I'll adjust as needed.

Refs https://github.com/less/less.js/issues/2364
