### PR TITLE
Normalise the output file: path using the sourceMapBasepath

### DIFF
--- a/lib/less/source-map-output.js
+++ b/lib/less/source-map-output.js
@@ -106,7 +106,7 @@ module.exports = function (environment) {
     };
 
     SourceMapOutput.prototype.toCSS = function(context) {
-        this._sourceMapGenerator = new this._sourceMapGeneratorConstructor({ file: this._outputFilename, sourceRoot: null });
+        this._sourceMapGenerator = new this._sourceMapGeneratorConstructor({ file: this.normalizeFilename(this._outputFilename), sourceRoot: null });
 
         if (this._outputSourceFiles) {
             for (var filename in this._contentsMap) {


### PR DESCRIPTION
This allows source maps to be reproducible regardless of what path they're being built under