### PR TITLE
Less Importer: Throw some notice when a file is skipped

### DIFF
--- a/lib/less/import-manager.js
+++ b/lib/less/import-manager.js
@@ -2,7 +2,8 @@ var contexts = require("./contexts"),
     Parser = require('./parser/parser'),
     LessError = require('./less-error'),
     utils = require('./utils'),
-    PromiseConstructor = typeof Promise === 'undefined' ? require('promise') : Promise;
+    PromiseConstructor = typeof Promise === 'undefined' ? require('promise') : Promise,
+    logger = require('./logger');
 
 module.exports = function(environment) {
 
@@ -28,7 +29,7 @@ module.exports = function(environment) {
         this.queue = [];        // Files which haven't been imported yet
         this.files = {};        // Holds the imported parse trees.
     };
-    
+
     /**
      * Add an import to be imported
      * @param path - the raw path
@@ -49,11 +50,12 @@ module.exports = function(environment) {
             var importedEqualsRoot = fullPath === importManager.rootFilename;
             if (importOptions.optional && e) {
                 callback(null, {rules:[]}, false, null);
+                logger.info("The file " + fullPath + " was skipped because it was not found and the import was marked optional.");
             }
             else {
                 if (!importManager.files[fullPath]) {
                     importManager.files[fullPath] = { root: root, options: importOptions };
-                } 
+                }
                 if (e && !importManager.error) { importManager.error = e; }
                 callback(e, root, importedEqualsRoot, fullPath);
             }
@@ -118,10 +120,10 @@ module.exports = function(environment) {
             } else if (importOptions.inline) {
                 fileParsedFunc(null, contents, resolvedFilename);
             } else {
-                
+
                 // import (multiple) parse trees apparently get altered and can't be cached.
                 // TODO: investigate why this is
-                if (importManager.files[resolvedFilename] 
+                if (importManager.files[resolvedFilename]
                     && !importManager.files[resolvedFilename].options.multiple
                     && !importOptions.multiple) {
 
@@ -144,7 +146,7 @@ module.exports = function(environment) {
             promise = pluginLoader.loadPlugin(path, currentFileInfo.currentDirectory, context, environment, fileManager);
         }
         else {
-            promise = fileManager.loadFile(path, currentFileInfo.currentDirectory, context, environment, 
+            promise = fileManager.loadFile(path, currentFileInfo.currentDirectory, context, environment,
                 function(err, loadedFile) {
                     if (err) {
                         fileParsedFunc(err);


### PR DESCRIPTION
This is handy when you're trying to scour your logs to figure out why a file was not being included. :)