### PR TITLE
Fix floating point inaccuracies when using mix()

### DIFF
--- a/lib/less/functions/color.js
+++ b/lib/less/functions/color.js
@@ -259,6 +259,12 @@ colorFunctions = {
             color1.rgb[1] * w1 + color2.rgb[1] * w2,
             color1.rgb[2] * w1 + color2.rgb[2] * w2];
 
+        // Fix floating point inaccuracies by rounding to one decimal place.
+        // For example: 25.499999999999993 → 25.5
+        rgb = rgb.map(function (x) {
+            return Math.round(x * 10) / 10;
+        });
+
         var alpha = color1.alpha * p + color2.alpha * (1 - p);
 
         return new Color(rgb, alpha);

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -123,7 +123,7 @@
   shade: #686868;
   shade-full: #000000;
   shade-percent: #686868;
-  shade-negative: #868686;
+  shade-negative: #878787;
   fade-out: rgba(255, 0, 0, 0.95);
   fade-in: rgba(255, 0, 0, 0.95);
   fade-out-relative: rgba(255, 0, 0, 0.95);
@@ -136,6 +136,7 @@
   mix-0: #ffff00;
   mix-100: #ff0000;
   mix-weightless: #ff8000;
+  mix-floating-point: #ff1a1a;
   mixt: rgba(255, 0, 0, 0.5);
 }
 #built-in .is-a {

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -146,6 +146,7 @@
   mix-0: mix(#ff0000, #ffff00, 0);
   mix-100: mix(#ff0000, #ffff00, 100);
   mix-weightless: mix(#ff0000, #ffff00);
+  mix-floating-point: mix(#ffffff, #ff0000, 10);
   mixt: mix(#ff0000, transparent);
 
   .is-a {


### PR DESCRIPTION
`mix(#ffffff, #ff0000, 10)` currently outputs `#ff1919`. This got me wondering because Sass outputs `#ff1a1a` instead.

The issue is that [`mix()`](https://github.com/less/less.js/blob/v2.7.2/lib/less/functions/color.js#L239-L265) returns RGB values of `[ 255, 25.499999999999993, 25.499999999999993 ]` which get rounded down to `[ 255, 25, 25 ]`. To fix this, I round to one decimal place first, therefore returning `[ 255, 25.5, 25.5 ]` (which get rounded up).

I have implemented this correction directly in `mix()`, for now. However, it might make sense to move it to [`toHex()`](https://github.com/less/less.js/blob/v2.7.2/lib/less/tree/color.js#L38-L43). This would be similar to how Sass solves this issue (see [color.rb](https://github.com/sass/sass/blob/3.4.25/lib/sass/script/value/color.rb#L237) and [util.rb](https://github.com/sass/sass/blob/3.4.25/lib/sass/util.rb#L143-L153)).