### PR TITLE
Add -MF -MP and -MT in line with gcc dependency tracking.

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -141,6 +141,13 @@ function render() {
         return;
     }
 
+    if (options.depends) {
+        if (!output && (!options.dependsFile || !options.dependsTarget)) {
+            console.error("option --depends requires an output path to be specified, or --depends-file and --depends-target");
+            process.exit(1);
+        }
+    }
+
     var ensureDirectory = function (filepath) {
         var dir = path.dirname(filepath),
             cmd,
@@ -154,15 +161,6 @@ function render() {
             cmd(dir);
         }
     };
-
-    if (options.depends) {
-        if (!outputbase) {
-            console.error("option --depends requires an output path to be specified");
-            process.exitCode = 1;
-            return;
-        }
-        process.stdout.write(outputbase + ": ");
-    }
 
     if (!sourceMapFileInline) {
         var writeSourceMap = function(output, onDone) {
@@ -196,6 +194,14 @@ function render() {
         }
     };
 
+    var logError = function(err) {
+        if (errno && errno.errno[err.errno]) {
+            console.error("Error: " + errno.errno[err.errno].description);
+        } else {
+            console.error("Error: " + err.code + " " + err.message);
+        }
+    }
+
     var writeOutput = function(output, result, onSuccess) {
         if (options.noCss) {
             onSuccess();
@@ -203,14 +209,8 @@ function render() {
             ensureDirectory(output);
             fs.writeFile(output, result.css, {encoding: 'utf8'}, function (err) {
                 if (err) {
-                    var description = "Error: ";
-                    if (errno && errno.errno[err.errno]) {
-                        description += errno.errno[err.errno].description;
-                    } else {
-                        description += err.code + " " + err.message;
-                    }
                     console.error('lessc: failed to create file ' + output);
-                    console.error(description);
+                    logError(err);
                     process.exitCode = 1;
                 } else {
                     less.logger.info('lessc: wrote ' + output);
@@ -223,13 +223,56 @@ function render() {
         }
     };
 
-    var logDependencies = function(options, result) {
-        if (options.depends) {
-            var depends = "";
-            for (var i = 0; i < result.imports.length; i++) {
-                depends += result.imports[i] + " ";
+
+    var writeDependencies = function(stream, options, dependencies) {
+        var target = options.dependsTarget || output;
+
+        stream.write(target);
+        stream.write(':');
+        if (input) {
+            stream.write(' ');
+            stream.write(input);
+        }
+
+        for (var i = 0; i < dependencies.length; i++) {
+            stream.write(' ');
+            stream.write(dependencies[i]);
+        }
+        stream.write('\n');
+
+        if (options.dependsPhony) {
+            for (var i = 0; i < dependencies.length; i++) {
+                stream.write(dependencies[i]);
+                stream.write(':\n');
             }
-            console.log(depends);
+        }
+    }
+
+    var logDependencies = function(options, result, onSuccess) {
+        if (!options.depends) {
+            return;
+        }
+
+        if (!options.dependsFile) {
+            writeDependencies(process.stdout, options, result.imports);
+            if (onSuccess) {
+                onSuccess();
+            }
+        } else {
+            var stream = fs.createWriteStream(options.dependsFile);
+            stream.on('error', function (error) {
+                console.error('lessc: failed to create file ' + options.dependsFile);
+                logError(error);
+                stream.close();
+                process.exitCode = 1;
+            });
+            stream.on('open', function() {
+                writeDependencies(stream, options, result.imports);
+                stream.end();
+                if (onSuccess) {
+                    onSuccess();
+                }
+            });
         }
     };
 
@@ -391,6 +434,25 @@ function processPluginQueue() {
             case 'M':
             case 'depends':
                 options.depends = true;
+                break;
+            case 'MP':
+            case 'depends-phony':
+                options.depends      = true;
+                options.dependsPhony = true;
+                break;
+            case 'MT':
+            case 'depends-target':
+                if (checkArgFunc(arg, match[2])) {
+                    options.depends       = true;
+                    options.dependsTarget = match[2];
+                }
+                break;
+            case 'MF':
+            case 'depends-file':
+                if (checkArgFunc(arg, match[2])) {
+                    options.depends      = true;
+                    options.dependsFile  = match[2];
+                }
                 break;
             case 'no-css':
                 options.noCss = true;

--- a/bin/lessc
+++ b/bin/lessc
@@ -197,7 +197,7 @@ function render() {
     };
 
     var writeOutput = function(output, result, onSuccess) {
-        if (options.depends) {
+        if (options.noCss) {
             onSuccess();
         } else if (output) {
             ensureDirectory(output);
@@ -217,7 +217,7 @@ function render() {
                     onSuccess();
                 }
             });
-        } else if (!options.depends) {
+        } else {
             process.stdout.write(result.css);
             onSuccess();
         }
@@ -391,6 +391,9 @@ function processPluginQueue() {
             case 'M':
             case 'depends':
                 options.depends = true;
+                break;
+            case 'no-css':
+                options.noCss = true;
                 break;
             case 'max-line-len':
                 if (checkArgFunc(arg, match[2])) {

--- a/lib/less-node/lessc-helper.js
+++ b/lib/less-node/lessc-helper.js
@@ -29,6 +29,10 @@ var lessc_helper = {
         console.log("  -h, --help                   Prints help (this message) and exit.");
         console.log("  --include-path=PATHS         Sets include paths. Separated by `:'. `;' also supported on windows.");
         console.log("  -M, --depends                Outputs a makefile import dependency list to stdout.");
+        console.log("  -MP --depends-phony          Adds phony targets for imported files in the generated dependencies.");
+        console.log("                               This avoids errors from make if imports are deleted. Implies --depends.");
+        console.log("  -MT --depends-target         Changes the target of the generated make dependencies. Implies --depends.");
+        console.log("  -MF --depends-file           Writes the makefile depdencies to a file instead of stdout. Implies --depends.");
         console.log("  --no-css                     Disables normal CSS output (for example to generate --depends only).");
         console.log("  --no-color                   Disables colorized output.");
         console.log("  --ie-compat                  Enables IE8 compatibility checks.");

--- a/lib/less-node/lessc-helper.js
+++ b/lib/less-node/lessc-helper.js
@@ -29,6 +29,7 @@ var lessc_helper = {
         console.log("  -h, --help                   Prints help (this message) and exit.");
         console.log("  --include-path=PATHS         Sets include paths. Separated by `:'. `;' also supported on windows.");
         console.log("  -M, --depends                Outputs a makefile import dependency list to stdout.");
+        console.log("  --no-css                     Disables normal CSS output (for example to generate --depends only).");
         console.log("  --no-color                   Disables colorized output.");
         console.log("  --ie-compat                  Enables IE8 compatibility checks.");
         console.log("  --js                         Enables inline JavaScript in less files");

--- a/lib/less/default-options.js
+++ b/lib/less/default-options.js
@@ -4,6 +4,9 @@ module.exports = function() {
         /* Outputs a makefile import dependency list to stdout. */
         depends: false,
 
+        /* Suppress regular CSS output. */
+        noCss: false,
+
         /* Compress using less built-in compression. 
          * This does an okay job but does not utilise all the tricks of 
          * dedicated css compression. */

--- a/lib/less/default-options.js
+++ b/lib/less/default-options.js
@@ -4,6 +4,15 @@ module.exports = function() {
         /* Outputs a makefile import dependency list to stdout. */
         depends: false,
 
+        /* Outputs phony targets for dependencies, like gcc -MP. */
+        dependsPhony: false,
+
+        /* Set the target of the rule in the generated dependencies, null means real output. */
+        dependsTarget: null,
+
+        /* Write generated dependency information to a file instead of stdout. */
+        dependsFile: null,
+
         /* Suppress regular CSS output. */
         noCss: false,
 


### PR DESCRIPTION
This PR does a few things:
* Make the change in #2830 optional by adding a `--no-css` flag. By default `--depends` now outputs CSS again. This flag also has the benefit that you can now use `lessc` as a syntax/import checker without generating *any* output (css or dependencies).
* Add the main source file as a dependency for the output file (#2476) in the generated dependency information.
* Add `-MP --depends-phony`, `-MT --depends-target`, `-MF --depends-file` in line with gcc flags (all of these imply `-M`). These flags allow much more efficient integration with `make`.

`-MP` or `--depends-phony` adds phony rules for all dependencies. This prevents `make` from generating errors when a dependency is deleted.

Someone also wrote a blog article on post-processing the dependency information to achieve the same result using a pipe of `sed`, `tr` and `sed` [1]. Personally I've been using an `awk` script so far. I hope that shows that there is actual demand for this feature.

[1] https://www.thumbtack.com/engineering/makefiles-for-less-and-css/

Example output:
```
$ lessc /tmp/test.less /tmp/test.css  -MP 
/tmp/test.css: /tmp/test.less /tmp/foo.less
/tmp/foo.less:
``` 

`-MT` or `--depends-target` overwrite the target of the main rule in the dependency file. This can be useful when the output of lessc is later moved, or if the generated CSS output goes to stdout. Example output:
```
$ lessc /tmp/test.less /tmp/test.css  -MT=foo.css
foo.css: /tmp/test.less /tmp/foo.less
/tmp/foo.less:
``` 

`-MF` or `--depends-file` writes the dependecy information to a file instead of stdout. Together with `-MT` this enables dependency tracking even when CSS output goes to stdout.