### PR TITLE
Fix floating point inaccuracies when converting to RGB

### DIFF
--- a/lib/less/tree/color.js
+++ b/lib/less/tree/color.js
@@ -35,9 +35,9 @@ function clamp(v, max) {
     return Math.min(Math.max(v, 0), max);
 }
 
-function toHex(v) {
+function toHex(v, context) {
     return '#' + v.map(function (c) {
-        c = clamp(Math.round(c), 255);
+        c = clamp(Node.round(context, c), 255);
         return (c < 16 ? '0' : '') + c.toString(16);
     }).join('');
 }
@@ -73,12 +73,12 @@ Color.prototype.toCSS = function (context, doNotCompress) {
     alpha = this.fround(context, this.alpha);
     if (alpha < 1) {
         return "rgba(" + this.rgb.map(function (c) {
-            return clamp(Math.round(c), 255);
+            return clamp(Node.round(context, c), 255);
         }).concat(clamp(alpha, 1))
             .join(',' + (compress ? '' : ' ')) + ")";
     }
 
-    color = this.toRGB();
+    color = this.toRGB(context);
 
     if (compress) {
         var splitcolor = color.split('');
@@ -106,8 +106,8 @@ Color.prototype.operate = function (context, op, other) {
     }
     return new Color(rgb, alpha);
 };
-Color.prototype.toRGB = function () {
-    return toHex(this.rgb);
+Color.prototype.toRGB = function (context) {
+    return toHex(this.rgb, context);
 };
 Color.prototype.toHSL = function () {
     var r = this.rgb[0] / 255,

--- a/lib/less/tree/color.js
+++ b/lib/less/tree/color.js
@@ -70,7 +70,7 @@ Color.prototype.toCSS = function (context, doNotCompress) {
     // is via `rgba`. Otherwise, we use the hex representation,
     // which has better compatibility with older browsers.
     // Values are capped between `0` and `255`, rounded and zero-padded.
-    alpha = this.fround(context, this.alpha);
+    alpha = Node.fround(context, this.alpha);
     if (alpha < 1) {
         return "rgba(" + this.rgb.map(function (c) {
             return clamp(Node.round(context, c), 255);

--- a/lib/less/tree/dimension.js
+++ b/lib/less/tree/dimension.js
@@ -32,7 +32,7 @@ Dimension.prototype.genCSS = function (context, output) {
         throw new Error("Multiple units in dimension. Correct the units or use the unit function. Bad unit: " + this.unit.toString());
     }
 
-    var value = this.fround(context, this.value),
+    var value = Node.fround(context, this.value),
         strValue = String(value);
 
     if (value !== 0 && value < 0.000001 && value > -0.000001) {

--- a/lib/less/tree/node.js
+++ b/lib/less/tree/node.js
@@ -79,7 +79,7 @@ Node.round = function(context, value) {
 
     return Math.round(value);
 };
-Node.prototype.fround = function(context, value) {
+Node.fround = function(context, value) {
     var precision = context && context.numPrecision;
     // add "epsilon" to ensure numbers like 1.000000005 (represented as 1.000000004999...) are properly rounded:
     return (precision) ? Number((value + 2e-16).toFixed(precision)) : value;

--- a/lib/less/tree/node.js
+++ b/lib/less/tree/node.js
@@ -61,6 +61,24 @@ Node.prototype._operate = function (context, op, a, b) {
         case '/': return a / b;
     }
 };
+// Based on Sass’s implementation.
+// See https://github.com/sass/sass/blob/3.5.1/lib/sass/util.rb#L132-L142.
+Node.round = function(context, value) {
+    var precision = context && context.numPrecision;
+
+    if (precision) {
+        var precisionFactor = Math.pow(10, precision);
+        var epsilon = 1 / (precisionFactor * 10);
+
+        // If the number is within epsilon of .5, round up.
+        // For example: 25.499999999999993 → 26.
+        if ((value % 1) - 0.5 > epsilon * -1) {
+            return Math.ceil(value);
+        }
+    }
+
+    return Math.round(value);
+};
 Node.prototype.fround = function(context, value) {
     var precision = context && context.numPrecision;
     // add "epsilon" to ensure numbers like 1.000000005 (represented as 1.000000004999...) are properly rounded:

--- a/test/css/functions.css
+++ b/test/css/functions.css
@@ -136,6 +136,7 @@
   mix-0: #ffff00;
   mix-100: #ff0000;
   mix-weightless: #ff8000;
+  mix-floating-point: #ff1a1a;
   mixt: rgba(255, 0, 0, 0.5);
 }
 #built-in .is-a {

--- a/test/less/functions.less
+++ b/test/less/functions.less
@@ -146,6 +146,7 @@
   mix-0: mix(#ff0000, #ffff00, 0);
   mix-100: mix(#ff0000, #ffff00, 100);
   mix-weightless: mix(#ff0000, #ffff00);
+  mix-floating-point: mix(#ffffff, #ff0000, 10);
   mixt: mix(#ff0000, transparent);
 
   .is-a {


### PR DESCRIPTION
This is a (hopefully) better approach to fixing floating point inaccuracies than #3083.

It is now based on Sass’s implementation which [rounds up if the number is within epsilon of X.5](https://github.com/sass/sass/blob/3.5.1/lib/sass/util.rb#L138-L140) ([epsilon being one tenth of the numeric precision](https://github.com/sass/sass/blob/3.5.1/lib/sass/script/value/number.rb#L59)).

I have not implemented support for negative numbers since RGB values are clamped to 0–255 anyway.