### PR TITLE
Fixes an errant semicolon in test

### DIFF
--- a/test/less/errors/mixed-mixin-definition-args-2.less
+++ b/test/less/errors/mixed-mixin-definition-args-2.less
@@ -2,5 +2,5 @@
     will: fail;
 }
 .mixin-test {
-    .mixin(@a: 5, @b: 6; @c: 7);
+    .mixin(@a: 5, @b: 6, @c: 7);
 }


### PR DESCRIPTION
I found a typo in this test, that semicolon should be a comma.