### PR TITLE
pinned request dep to v2.81.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mkdirp": "^0.5.0",
     "promise": "^7.1.1",
     "source-map": "^0.5.3",
-    "request": "^2.72.0"
+    "request": "2.81.0"
   },
   "devDependencies": {
     "diff": "^2.2.2",


### PR DESCRIPTION
See: https://github.com/less/less.js/issues/3104, 
        https://github.com/request/request/issues/2772

This PR pins the version of request to still support Node v0.12.x or greater.