### PR TITLE
Mime update

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "errno": "^0.1.1",
     "graceful-fs": "^4.1.2",
     "image-size": "~0.5.0",
-    "mime": "^1.2.11",
+    "mime": "^1.4.1",
     "mkdirp": "^0.5.0",
     "promise": "^7.1.1",
     "source-map": "^0.5.3"


### PR DESCRIPTION
The version of mime that is referenced is listed on Node Security for having a RegEx-DoS:
- https://nodesecurity.io/advisories/535
- https://github.com/broofa/node-mime/issues/167

This PR updates the optional dependency to use the `1.x` version that does not have this vulnerabiltiy (`1.4.1`).
