### PR TITLE
`inline` and `less` imports of the same name = race condition

### DIFF
--- a/lib/less/import-manager.js
+++ b/lib/less/import-manager.js
@@ -51,7 +51,10 @@ module.exports = function(environment) {
                 callback(null, {rules:[]}, false, null);
             }
             else {
-                if (!importManager.files[fullPath]) {
+                // Inline imports aren't cached here.
+                // If we start to cache them, please make sure they won't conflict with non-inline imports of the
+                // same name as they used to do before this comment and the condition below have been added.
+                if (!importManager.files[fullPath] && !importOptions.inline) {
                     importManager.files[fullPath] = { root: root, options: importOptions };
                 } 
                 if (e && !importManager.error) { importManager.error = e; }


### PR DESCRIPTION
Stumbled upon this working on https://github.com/webpack-contrib/less-loader/pull/242.
See an instance of the mentioned race condition here: https://ci.appveyor.com/project/webpack-contrib/less-loader/build/1.0.46/job/mbywf90cimqkjee5

It happens when processing files like this:
```less
@import (less) "some/css.css";
@import (inline) "some/css.css";
```