### PR TITLE
Fix import path for plugins

### DIFF
--- a/lib/less-node/index.js
+++ b/lib/less-node/index.js
@@ -17,7 +17,7 @@ less.UrlFileManager = UrlFileManager;
 // Set up options
 less.options = require('../less/default-options')();
 less.options.paths = [
-    path.join(process.cwd(), "node_modules")
+    path.join(path.resolve(__dirname, "../../../../"), "node_modules")
 ];
 
 // provide image-size functionality


### PR DESCRIPTION
#3181 Less shouldn't search for plugins in process.cwd(), but in same node_modules folder like less is installed. 