### PR TITLE
Fixes #3147 #2715

### DIFF
--- a/lib/less/parser/parser-input.js
+++ b/lib/less/parser/parser-input.js
@@ -145,14 +145,15 @@ module.exports = function() {
         return tok;
     };
 
-    parserInput.$quoted = function() {
+    parserInput.$quoted = function(loc) {
+        var pos = loc || parserInput.i,
+            startChar = input.charAt(pos);
 
-        var startChar = input.charAt(parserInput.i);
         if (startChar !== "'" && startChar !== '"') {
             return;
         }
         var length = input.length,
-            currentPosition = parserInput.i;
+            currentPosition = pos;
 
         for (var i = 1; i + currentPosition < length; i++) {
             var nextChar = input.charAt(i + currentPosition);
@@ -165,13 +166,91 @@ module.exports = function() {
                     break;
                 case startChar:
                     var str = input.substr(currentPosition, i + 1);
-                    skipWhitespace(i + 1);
+                    if (!loc) {
+                        skipWhitespace(i + 1);
+                    }
                     return str;
                 default:
             }
         }
         return null;
     };
+
+    /**
+     * Permissive parsing. Ignores everything except matching {} [] () and quotes
+     * until matching token (outside of blocks)
+     */
+    parserInput.$parseUntil = function(tok) {
+        var str = '',
+            blockDepth = 0,
+            blockStack = [],
+            length = input.length,
+            startPos = parserInput.i,
+            i = parserInput.i,
+            loop = true,
+            testChar;
+
+        if (typeof tok === 'string') {
+            testChar = function(char) {
+                return char === tok;
+            }
+        } else {
+            testChar = function(char) {
+                return tok.test(char);
+            }
+        }
+
+        do {
+            var nextChar = input.charAt(i);
+            if (blockDepth === 0 && testChar(nextChar)) {
+                str = input.substr(startPos, i - startPos);
+                skipWhitespace(i - startPos);
+                loop = false
+            } else {
+                switch (nextChar) {
+                    case "'":
+                    case '"':
+                        str = parserInput.$quoted(i);
+                        if (str) {
+                            i += str.length - 1;
+                        }
+                        else {
+                            str = null;
+                            loop = false;
+                        }
+                        break;
+                    case "{":
+                        blockStack.push("}");
+                        blockDepth++;
+                        break;
+                    case "(":
+                        blockStack.push(")");
+                        blockDepth++;
+                        break;
+                    case "[":
+                        blockStack.push("]");
+                        blockDepth++;
+                        break;
+                    case "}":
+                    case ")":
+                    case "]":
+                        if (nextChar === blockStack.pop()) {
+                            blockDepth--;
+                        } else {
+                            str = null;
+                            loop = false;
+                        }
+                }
+                i++;
+                if (i > length) {
+                    str = null;
+                    loop = false;
+                }
+            }
+        } while (loop);
+
+        return str ? str : null;
+    }
 
     parserInput.autoCommentAbsorb = true;
     parserInput.commentStore = [];

--- a/lib/less/parser/parser-input.js
+++ b/lib/less/parser/parser-input.js
@@ -215,7 +215,8 @@ module.exports = function() {
                             i += str.length - 1;
                         }
                         else {
-                            str = null;
+                            skipWhitespace(i - startPos);
+                            str = nextChar;
                             loop = false;
                         }
                         break;
@@ -234,10 +235,13 @@ module.exports = function() {
                     case "}":
                     case ")":
                     case "]":
-                        if (nextChar === blockStack.pop()) {
+                        var expected = blockStack.pop();
+                        if (nextChar === expected) {
                             blockDepth--;
                         } else {
-                            str = null;
+                            // move the parser to the error and return expected
+                            skipWhitespace(i - startPos);
+                            str = expected;
                             loop = false;
                         }
                 }

--- a/lib/less/parser/parser-input.js
+++ b/lib/less/parser/parser-input.js
@@ -201,8 +201,8 @@ module.exports = function() {
         }
 
         do {
-            var nextChar = input.charAt(i);
-            if (blockDepth === 0 && testChar(nextChar)) {
+            var prevChar, nextChar = input.charAt(i);
+            if (blockDepth === 0 && testChar(nextChar) && (nextChar !== '{' || prevChar !== '@')) {
                 str = input.substr(startPos, i - startPos);
                 skipWhitespace(i - startPos);
                 loop = false
@@ -251,6 +251,7 @@ module.exports = function() {
                     loop = false;
                 }
             }
+            prevChar = nextChar;
         } while (loop);
 
         return str ? str : null;

--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -1621,7 +1621,7 @@ var Parser = function Parser(context, imports, fileInfo) {
                             error(name + " rule is missing block or ending semi-colon");
                         }
                     } else {
-                        value = new(tree.Anonymous)(value.trim());
+                        value = new(tree.Quoted)('"', value.trim(), true, index, fileInfo);
                     }
                 }
 

--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -1292,7 +1292,12 @@ var Parser = function Parser(context, imports, fileInfo) {
 
                         // Try to store values as anonymous
                         // If we need the value later we'll re-parse it in ruleset.parseValue
-                        value = this.anonymousValue();
+                        if (name[0].value && name[0].value.slice(0, 2) === '--') {
+                            value = this.customPropertyValue();
+                        }
+                        else {
+                            value = this.anonymousValue();
+                        }
                         if (value) {
                             parserInput.forget();
                             // anonymous values absorb the end ';' which is required for them to work
@@ -1322,6 +1327,13 @@ var Parser = function Parser(context, imports, fileInfo) {
                 var match = parserInput.$re(/^([^@\$+\/'"*`(;{}-]*);/);
                 if (match) {
                     return new(tree.Anonymous)(match[1], index);
+                }
+            },
+            customPropertyValue: function () {
+                var index = parserInput.i,
+                    value = parserInput.$parseUntil(';');
+                if (value && parserInput.$char(';')) {
+                    return new(tree.Anonymous)(value, index);
                 }
             },
 
@@ -1595,10 +1607,14 @@ var Parser = function Parser(context, imports, fileInfo) {
                         error("expected " + name + " expression");
                     }
                 } else if (hasUnknown) {
-                    value = (parserInput.$re(/^[^{;]+/) || '').trim();
-                    hasBlock = (parserInput.currentChar() == '{');
-                    if (value) {
-                        value = new(tree.Anonymous)(value);
+                    value = parserInput.$parseUntil(/^[{;]/);
+                    hasBlock = (parserInput.currentChar() === '{');
+                    if (!value) {
+                        if (!hasBlock && parserInput.currentChar() !== ';') {
+                            error(name + " rules is missing block or ending semi-colon");
+                        }
+                    } else {
+                        value = new(tree.Anonymous)(value.trim());
                     }
                 }
 

--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -1336,9 +1336,11 @@ var Parser = function Parser(context, imports, fileInfo) {
                     if (/^[\}\)\]'"]/.test(value)) {
                         error("Expected '" + value + "'", "Parse");
                     }
-                    if (parserInput.$char(';')) {
-                        return new(tree.Anonymous)(value, index);
-                    }
+                    /**
+                     * Treat custom properties like a quoted value,
+                     * for variable interpolation
+                     */
+                    return new(tree.Quoted)("'", value, true, index, fileInfo);
                 }
             },
 

--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -1332,8 +1332,13 @@ var Parser = function Parser(context, imports, fileInfo) {
             customPropertyValue: function () {
                 var index = parserInput.i,
                     value = parserInput.$parseUntil(';');
-                if (value && parserInput.$char(';')) {
-                    return new(tree.Anonymous)(value, index);
+                if (value) {
+                    if (/^[\}\)\]'"]/.test(value)) {
+                        error("Expected '" + value + "'", "Parse");
+                    }
+                    if (parserInput.$char(';')) {
+                        return new(tree.Anonymous)(value, index);
+                    }
                 }
             },
 
@@ -1611,7 +1616,7 @@ var Parser = function Parser(context, imports, fileInfo) {
                     hasBlock = (parserInput.currentChar() === '{');
                     if (!value) {
                         if (!hasBlock && parserInput.currentChar() !== ';') {
-                            error(name + " rules is missing block or ending semi-colon");
+                            error(name + " rule is missing block or ending semi-colon");
                         }
                     } else {
                         value = new(tree.Anonymous)(value.trim());

--- a/test/css/permissive-parse.css
+++ b/test/css/permissive-parse.css
@@ -9,3 +9,6 @@
     even other stuff;
   };
 }
+.var {
+  --fortran: read (*, *, iostat=1) radius, height;
+}

--- a/test/css/permissive-parse.css
+++ b/test/css/permissive-parse.css
@@ -1,0 +1,11 @@
+@-moz-document regexp("(\d{0,15})") {
+  a {
+    color: red;
+  }
+}
+.custom-property {
+  --this: () => {
+    basically anything until final semi-colon;
+    even other stuff;
+  };
+}

--- a/test/less/errors/at-rules-unmatching-block.less
+++ b/test/less/errors/at-rules-unmatching-block.less
@@ -1,0 +1,4 @@
+
+@unknown url( {
+    50% {width: 20px;}
+}

--- a/test/less/errors/at-rules-unmatching-block.txt
+++ b/test/less/errors/at-rules-unmatching-block.txt
@@ -1,0 +1,4 @@
+SyntaxError: @unknown rule is missing block or ending semi-colon in {path}at-rules-unmatching-block.less on line 2, column 10:
+1 
+2 @unknown url( {
+3     50% {width: 20px;}

--- a/test/less/errors/custom-property-unmatched-block-1.less
+++ b/test/less/errors/custom-property-unmatched-block-1.less
@@ -1,0 +1,6 @@
+.custom {
+  --custom: ({
+    this;
+    is-unmatched: [
+  })
+}

--- a/test/less/errors/custom-property-unmatched-block-1.txt
+++ b/test/less/errors/custom-property-unmatched-block-1.txt
@@ -1,0 +1,4 @@
+ParseError: Expected ']' in {path}custom-property-unmatched-block-1.less on line 5, column 3:
+4     is-unmatched: [
+5   })
+6 }

--- a/test/less/errors/custom-property-unmatched-block-2.less
+++ b/test/less/errors/custom-property-unmatched-block-2.less
@@ -1,0 +1,6 @@
+.custom {
+  --custom: {{
+    this;
+    is-unmatched: [
+  }}
+}

--- a/test/less/errors/custom-property-unmatched-block-2.txt
+++ b/test/less/errors/custom-property-unmatched-block-2.txt
@@ -1,0 +1,4 @@
+ParseError: Expected ']' in {path}custom-property-unmatched-block-2.less on line 5, column 3:
+4     is-unmatched: [
+5   }}
+6 }

--- a/test/less/errors/custom-property-unmatched-block-3.less
+++ b/test/less/errors/custom-property-unmatched-block-3.less
@@ -1,0 +1,6 @@
+.custom {
+  --custom: {{
+    this;
+    is-unmatched: "
+  }}
+}

--- a/test/less/errors/custom-property-unmatched-block-3.txt
+++ b/test/less/errors/custom-property-unmatched-block-3.txt
@@ -1,0 +1,4 @@
+ParseError: Expected '"' in {path}custom-property-unmatched-block-3.less on line 4, column 19:
+3     this;
+4     is-unmatched: "
+5   }}

--- a/test/less/permissive-parse.less
+++ b/test/less/permissive-parse.less
@@ -1,0 +1,12 @@
+@-moz-document regexp("(\d{0,15})") {
+	a {
+		color: red;
+	}
+}
+
+.custom-property {
+  --this: () => {
+    basically anything until final semi-colon;
+    even other stuff;
+  };
+}

--- a/test/less/permissive-parse.less
+++ b/test/less/permissive-parse.less
@@ -1,4 +1,6 @@
-@-moz-document regexp("(\d{0,15})") {
+@function-name: regexp;
+@d-value: 15;
+@-moz-document @{function-name}("(\d{0,@{d-value}})") {
 	a {
 		color: red;
 	}

--- a/test/less/permissive-parse.less
+++ b/test/less/permissive-parse.less
@@ -10,3 +10,8 @@
     even other stuff;
   };
 }
+
+@iostat: 1;
+.var {
+  --fortran: read (*, *, iostat=@{iostat}) radius, height;
+}


### PR DESCRIPTION
* Adds permissive parsing for at-rules and custom properties
* Fixes #3147 #2715

Custom property values and unknown at-rule entities are essentially treated as quoted escaped values, meaning you can write:
```less
@function-name: regexp;
@d-value: 15;
@-moz-document @{function-name}("(\d{0,@{d-value}})") {
	a {
		color: red;
	}
}
@iostat: 1;
.var {
  --fortran: read (*, *, iostat=@{iostat}) radius, height;
}
```

The only rule with permissive parsing is that you have matching `{}()[]"'`, and I've added error tests for those. Each block ignores anything except its closing block, and only the top-most block is looking for a final parsing token(s).