### PR TITLE
Fixes #3195 - already-parsed node can't re-parse

### DIFF
--- a/lib/less/tree/ruleset.js
+++ b/lib/less/tree/ruleset.js
@@ -297,21 +297,25 @@ Ruleset.prototype.parseValue = function(toParse) {
     var self = this;
     function transformDeclaration(decl) {
         if (decl.value instanceof Anonymous && !decl.parsed) {
-            this.parse.parseNode(
-                decl.value.value, 
-                ["value", "important"], 
-                decl.value.getIndex(), 
-                decl.fileInfo(), 
-                function(err, result) {
-                    if (err) {
-                        decl.parsed = true;
-                    }
-                    if (result) {
-                        decl.value = result[0];
-                        decl.important = result[1] || '';
-                        decl.parsed = true;
-                    }
-                });
+            if (typeof decl.value.value === "string") {
+                this.parse.parseNode(
+                    decl.value.value,
+                    ["value", "important"], 
+                    decl.value.getIndex(), 
+                    decl.fileInfo(), 
+                    function(err, result) {
+                        if (err) {
+                            decl.parsed = true;
+                        }
+                        if (result) {
+                            decl.value = result[0];
+                            decl.important = result[1] || '';
+                            decl.parsed = true;
+                        }
+                    });
+            } else {
+                decl.parsed = true;
+            }
 
             return decl;
         }

--- a/test/less/extract-and-length.less
+++ b/test/less/extract-and-length.less
@@ -1,4 +1,17 @@
 
+// test late parsing
+@cols: 1, 2;
+
+.a(@i: length(@cols)) when (@i > 0) {
+  @divider: e(extract(@cols, @i));
+}
+.a;
+
+.b(@j: 1) when (@j < length(@cols)) {
+  @divider: e(extract(@cols, @j));
+}
+.b;
+
 // simple array/list:
 
 .multiunit {


### PR DESCRIPTION
Looks like I introduced a bug with the late parsing feature, where a value parsed as a number was trying to get re-parsed when referenced and would cause string parsing failures. Fixes #3195.