### PR TITLE
 fix: browser cache is always considered stale if .modifyVars wasn't set

### DIFF
--- a/lib/less-browser/cache.js
+++ b/lib/less-browser/cache.js
@@ -28,10 +28,13 @@ module.exports = function(window, options, logger) {
                 timestamp = cache && cache.getItem(path + ':timestamp'),
                 vars      = cache && cache.getItem(path + ':vars');
 
+            modifyVars = modifyVars || {};
+            vars = vars || "{}"; // if not set, treat as the JSON representation of an empty object
+
             if (timestamp && webInfo.lastModified &&
                 (new Date(webInfo.lastModified).valueOf() ===
                     new Date(timestamp).valueOf()) &&
-                ((!modifyVars && !vars) || JSON.stringify(modifyVars || {}) === vars)) {
+                JSON.stringify(modifyVars) === vars) {
                 // Use local copy
                 return css;
             }

--- a/lib/less-browser/cache.js
+++ b/lib/less-browser/cache.js
@@ -28,12 +28,10 @@ module.exports = function(window, options, logger) {
                 timestamp = cache && cache.getItem(path + ':timestamp'),
                 vars      = cache && cache.getItem(path + ':vars');
 
-            modifyVars = modifyVars || {};
-
             if (timestamp && webInfo.lastModified &&
                 (new Date(webInfo.lastModified).valueOf() ===
                     new Date(timestamp).valueOf()) &&
-                (!modifyVars && !vars || JSON.stringify(modifyVars) === vars)) {
+                ((!modifyVars && !vars) || JSON.stringify(modifyVars || {}) === vars)) {
                 // Use local copy
                 return css;
             }


### PR DESCRIPTION
The problem this fixes is the following: Assume `modifyVars` is not used, i.e. it's `null`.

In `cache.setCSS`, the `:vars` cache item is not set, because `modifyVars` is falsy in [this `if` statement](https://github.com/less/less.js/blob/566f42862e5191d360aff418dd81034615d1e704/lib/less-browser/cache.js#L17).

Therefore, in `cache.getCSS`, we're retrieving a [non-existent item from the cache](https://github.com/less/less.js/blob/566f42862e5191d360aff418dd81034615d1e704/lib/less-browser/cache.js#L29), and so `vars` is `null`.

But `modifyVars`, which is `null` at function call time, is them [defaulted](https://github.com/less/less.js/blob/566f42862e5191d360aff418dd81034615d1e704/lib/less-browser/cache.js#L31) to `{}`. In particular, in the [check whether the cache is up-to-date](https://github.com/less/less.js/blob/566f42862e5191d360aff418dd81034615d1e704/lib/less-browser/cache.js#L36), `modifyVars` is *never* falsy.

Thus `!modifyVars && !vars` is never truthy, and the up-to-date decision comes down to 
`JSON.stringify(modifyVars) === vars`, which is `"{}" === null` and thus false.

So the locally cached version is never used.
