### PR TITLE
Adds range() function for lists

### DIFF
--- a/lib/less/functions/list.js
+++ b/lib/less/functions/list.js
@@ -1,5 +1,6 @@
 var Dimension = require('../tree/dimension'),
     Declaration = require('../tree/declaration'),
+    Expression = require('../tree/expression'),
     Ruleset = require('../tree/ruleset'),
     Selector = require('../tree/selector'),
     Element = require('../tree/element'),
@@ -25,6 +26,34 @@ functionRegistry.addMultiple({
     },
     length: function(values) {
         return new Dimension(getItemsFromNode(values).length);
+    },
+    /**
+     * Creates a Less list of incremental values.
+     * Modeled after Lodash's range function, also exists natively in PHP
+     * 
+     * @param {Dimension} [start=1]
+     * @param {Dimension} end  - e.g. 10 or 10px - unit is added to output
+     * @param {Dimension} [step=1] 
+     */
+    range: function(start, end, step) {
+        var from, to, stepValue = 1, list = [];
+        if (end) {
+            to = end;
+            from = start.value;
+            if (step) {
+                stepValue = step.value;
+            }
+        }
+        else {
+            from = 1;
+            to = start;
+        }
+
+        for (var i = from; i <= to.value; i += stepValue) {
+            list.push(new Dimension(i, to.unit));
+        }
+
+        return new Expression(list);
     },
     each: function(list, rs) {
         var i = 0, rules = [], newRules, iterator;

--- a/test/css/functions-each.css
+++ b/test/css/functions-each.css
@@ -40,6 +40,30 @@
   val2: 2;
   val3: 4;
 }
+.column-list {
+  list: 1 2 3 4;
+}
+.col-1 {
+  width: 25%;
+}
+.col-2 {
+  width: 25%;
+}
+.col-3 {
+  width: 25%;
+}
+.col-4 {
+  width: 25%;
+}
+.row-1 {
+  width: 10px;
+}
+.row-2 {
+  width: 20px;
+}
+.row-3 {
+  width: 30px;
+}
 .box {
   -less-log: a;
   -less-log: b;

--- a/test/less/functions-each.less
+++ b/test/less/functions-each.less
@@ -73,6 +73,23 @@ each(@selectors, {
   });
 }
 
+@columns: range(4);
+.column-list {
+  list: @columns;
+}
+
+each(@columns, .(@val) {
+  .col-@{val} {
+    width: (100% / length(@columns));
+  }
+});
+
+each(range(10px, 30px, 10px), .(@val, @index) {
+  .row-@{index} {
+    width: @val;
+  }
+});
+
 @list: a b c d;
 .box {
   each(@list, {


### PR DESCRIPTION
While attempting to upgrade a Bootstrap Less port to use `each()` (https://github.com/seanCodes/bootstrap-less-port/pull/12), I saw that there were still some gaps for porting Sass to Less code. Specifically, when looping X number of times based on a variable value. (This has been discussed in numerous issues, including as early as #249 and #2270.)

This PR fills a major gap by adding a very modest list-generating `range()` function modelled after Lodash / PHP / others. Coupled with `each()` it provides a native replacement for a Sass `@for` loop (along with letting you generate range lists for any other general purpose). This solves `for` loops without the syntactic burden of adding a new paradigm. It simply creates and populates a list in a declarative way.

Like Lodash, the function signature is: 

#### `range([start=1], end, [step=1])`

Start and step are optional (with step requiring a start). Also, this adopts Less behavior of unit casting. That is, the "end" value's unit is applied to the output units. (Also, consistent with Less, lists are 1-based, so unlike Lodash, the default start value is `1`.)

Meaning:
```less
@list: range(10px, 30px, 10); // equivalent to writing 10px 20px 30px
```

Coupled with `each()`, this constructs `for`-style incremental loops.
```less
@columns: range(4);  // 1 2 3 4

each(@columns, .(@val) {
  .col-@{val} {
    width: (100% / length(@columns));
  }
});
```
Outputs:
```css
.col-1 {
  width: 25%;
}
.col-2 {
  width: 25%;
}
.col-3 {
  width: 25%;
}
.col-4 {
  width: 25%;
}
```