### PR TITLE
Use the correct mime type when loading a plugin

### DIFF
--- a/lib/less/import-manager.js
+++ b/lib/less/import-manager.js
@@ -146,6 +146,7 @@ module.exports = function(environment) {
         }
 
         if (importOptions.isPlugin) {
+            context.mime = 'application/javascript';
             promise = pluginLoader.loadPlugin(path, currentFileInfo.currentDirectory, context, environment, fileManager);
         }
         else {


### PR DESCRIPTION
This one fixes #3336

The `context` object is cloned, so this is safe to modify. It's also being modified in line 145 to append the extension.