### PR TITLE
Revised dependencies - switched all request presence with phin.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -126,7 +126,7 @@ module.exports = function (grunt) {
                     var pass = process.env.SAUCE_ACCESS_KEY;
 
                     git.short(function(hash) {
-                        require('phin')({
+                        require('phin').unpromisified({
                             method: 'PUT',
                             url: ['https://saucelabs.com/rest/v1', user, 'jobs', result.job_id].join('/'),
                             auth: { user: user, pass: pass },

--- a/lib/less-node/url-file-manager.js
+++ b/lib/less-node/url-file-manager.js
@@ -1,6 +1,6 @@
 var isUrlRe = /^(?:https?:)?\/\//i,
     url = require('url'),
-    request,
+    phin,
     PromiseConstructor,
     AbstractFileManager = require('../less/environment/abstract-file-manager.js'),
     logger = require('../less/logger');
@@ -19,12 +19,12 @@ UrlFileManager.prototype.loadFile = function(filename, currentDirectory, options
         PromiseConstructor = typeof Promise === 'undefined' ? require('promise') : Promise;
     }
     return new PromiseConstructor(function(fulfill, reject) {
-        if (request === undefined) {
-            try { request = require('request'); }
-            catch (e) { request = null; }
+        if (phin === undefined) {
+            try { phin = require('phin').unpromisified; }
+            catch (e) { phin = null; }
         }
-        if (!request) {
-            reject({ type: 'File', message: 'optional dependency \'request\' required to import over http(s)\n' });
+        if (!phin) {
+            reject({ type: 'File', message: 'optional dependency \'phin\' required to import over http(s)\n' });
             return;
         }
 
@@ -36,7 +36,9 @@ UrlFileManager.prototype.loadFile = function(filename, currentDirectory, options
             urlStr = urlObj.format();
         }
 
-        request.get({uri: urlStr, strictSSL: !options.insecure }, function (error, res, body) {
+        phin({url: urlStr}, function (error, res) {
+            var body = res.body
+
             if (error) {
                 reject({ type: 'File', message: 'resource \'' + urlStr + '\' gave this Error:\n  ' + error + '\n' });
                 return;

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "image-size": "~0.5.0",
     "mime": "^1.4.1",
     "mkdirp": "^0.5.0",
+    "phin": "^2.9.3",
     "promise": "^7.1.1",
-    "request": "^2.83.0",
     "source-map": "~0.6.0"
   },
   "devDependencies": {
@@ -72,7 +72,7 @@
     "performance-now": "^0.2.0",
     "phantomjs-polyfill-object-assign": "0.0.2",
     "phantomjs-prebuilt": "^2.1.16",
-    "phin": "^2.2.3",
+    "phin": "^2.9.3",
     "promise": "^7.1.1",
     "time-grunt": "^1.3.0",
     "uikit": "2.27.4"


### PR DESCRIPTION
Currently the [phin](https://github.com/ethanent/phin) library is used as part of the build process, and it's more lightweight than request. (This change was originally made in #3096.)

I think it'd be great to use phin in production at this point as it's proven to be stable for the build process, and it is less than 1% the size of request.

![image](https://user-images.githubusercontent.com/14060354/50660184-c5fe7280-0f53-11e9-98f4-9c20d0b4612a.png)