### PR TITLE
Do not pollute window object in less-browser bootstrap

### DIFF
--- a/lib/less-browser/bootstrap.js
+++ b/lib/less-browser/bootstrap.js
@@ -13,7 +13,7 @@ require('promise/polyfill');
 var options = require('../less/default-options')();
 
 if (window.less) {
-    for (key in window.less) {
+    for (var key in window.less) {
         if (window.less.hasOwnProperty(key)) {
             options[key] = window.less[key];
         }


### PR DESCRIPTION
The `key` variable in `bootstrap.js` is not properly declared, which causes it to be added to the global `window` object.

![image](https://user-images.githubusercontent.com/4691710/51058687-8ff66980-15b7-11e9-884c-15568dba3528.png)

This PR declares the `key` variable as `var`