### PR TITLE
Ignore undefined content in generating source maps

### DIFF
--- a/lib/less/source-map-output.js
+++ b/lib/less/source-map-output.js
@@ -69,6 +69,12 @@ module.exports = function (environment) {
                 // adjust the source
                 inputSource = inputSource.slice(this._contentsIgnoredCharsMap[fileInfo.filename]);
             }
+
+            // ignore empty content
+            if (inputSource === undefined) {
+                return;
+            }
+
             inputSource = inputSource.substring(0, index);
             sourceLines = inputSource.split('\n');
             sourceColumns = sourceLines[sourceLines.length - 1];


### PR DESCRIPTION
When building with angular-cli and lazy loaded modules, there are empty files with no content. This produces an unfortunately cryptic error message: "cannot call substring of undefined. File 'undefined', line 'undefined'"

After much investigation I found this to be the source of the issue. I don't really know root cause, but I think it has to do with webpack's module splitting. Maybe files in split modules aren't immediately available? At any rate, this fixes it and seems in line with behavior at the start of the file.