### PR TITLE
Fixes #3430: Removed unnecessary 'important' from NamespaceValue.

### DIFF
--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -766,7 +766,6 @@ const Parser = function Parser(context, imports, fileInfo) {
             //
             variableCall: function (parsedName) {
                 let lookups;
-                let important;
                 const i = parserInput.i;
                 const inValue = !!parsedName;
                 let name = parsedName;
@@ -787,10 +786,6 @@ const Parser = function Parser(context, imports, fileInfo) {
                         name = name[1];
                     }
 
-                    if (lookups && parsers.important()) {
-                        important = true;
-                    }
-
                     const call = new tree.VariableCall(name, i, fileInfo);
                     if (!inValue && parsers.end()) {
                         parserInput.forget();
@@ -798,7 +793,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                     }
                     else {
                         parserInput.forget();
-                        return new tree.NamespaceValue(call, lookups, important, i, fileInfo);
+                        return new tree.NamespaceValue(call, lookups, i, fileInfo);
                     }
                 }
 
@@ -927,7 +922,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                             parserInput.forget();
                             const mixin = new(tree.mixin.Call)(elements, args, index, fileInfo, !lookups && important);
                             if (lookups) {
-                                return new tree.NamespaceValue(mixin, lookups, important);
+                                return new tree.NamespaceValue(mixin, lookups);
                             }
                             else {
                                 return mixin;

--- a/lib/less/tree/namespace-value.js
+++ b/lib/less/tree/namespace-value.js
@@ -4,12 +4,11 @@ import Ruleset from './ruleset';
 import Selector from './selector';
 
 class NamespaceValue extends Node {
-    constructor(ruleCall, lookups, important, index, fileInfo) {
+    constructor(ruleCall, lookups, index, fileInfo) {
         super();
 
         this.value = ruleCall;
         this.lookups = lookups;
-        this.important = important;
         this._index = index;
         this._fileInfo = fileInfo;
     }

--- a/test/css/namespacing/namespacing-3.css
+++ b/test/css/namespacing/namespacing-3.css
@@ -6,3 +6,18 @@
     color: white;
   }
 }
+.cell {
+  margin: 0 5px !important;
+}
+.class1 {
+  color: #33acfe !important;
+  margin: 20px !important;
+  padding: 20px !important;
+  width: 0 !important;
+}
+.class2 {
+  color: #efca44;
+  margin: 10px;
+  padding: 40px 10px;
+  width: 0 !important;
+}

--- a/test/less/namespacing/namespacing-3.less
+++ b/test/less/namespacing/namespacing-3.less
@@ -26,3 +26,26 @@
     color: @map[@colors][toolbar-foreground];
   }
 }
+
+// !important after map usage
+// https://github.com/less/less.js/issues/3430
+@margins: {
+    zero: 0;
+    ten: 10px;
+}
+.cell {
+  margin: @margins[zero] @margins[ten]/2 !important;
+}
+
+.mixin(@color: black; @margin: 10px; @padding: 20px) {
+  color: @color;
+  margin: @margin;
+  padding: @padding;
+  width: @margins[zero] !important
+}
+.class1 {
+  .mixin(@margin: 20px; @color: #33acfe) !important;
+}
+.class2 {
+  .mixin(#efca44; @padding: 40px 10px);
+}


### PR DESCRIPTION
!important keyword was being parsed inside VariableCall, which was unnecessary and leads to the bug. Instead, we can check/parse it along with the declaration parser.
Similar logic may apply to mixin-call but couldn't reproduce a bad case.