### PR TITLE
Update request to v2.88.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mime": "^1.4.1",
     "mkdirp": "^0.5.0",
     "promise": "^7.1.1",
-    "request": "^2.83.0",
+    "request": "^2.88.0",
     "source-map": "~0.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
request v2.83 uses hawk package (which has been moved to @hapi/hawk) this causes  warning during package installation.

The latest version of request does not have the dependency