### PR TITLE
Import file with dots in file name

### DIFF
--- a/lib/less-browser/file-manager.js
+++ b/lib/less-browser/file-manager.js
@@ -12,6 +12,20 @@ class FileManager extends AbstractFileManager {
         return true;
     }
 
+    getPossibleFileExtensions(path, ext) {
+        if (this.isPathWithExtension(path, ext)) {
+            return [''];
+        }
+
+        // if file doesn't have dot in name it require extention
+        if (path.indexOf(".") === -1) {
+            return [ext];
+        }
+
+        // path has dots in name it might be with or without extention (like .css)
+        return [ext, ''];
+    }
+
     join(basePath, laterPath) {
         if (!basePath) {
             return laterPath;
@@ -57,6 +71,29 @@ class FileManager extends AbstractFileManager {
         }
     }
 
+    tryToLoad(href) {
+        return new Promise((resolve, reject) => {
+            if (options.useFileCache && fileCache[href]) {
+                try {
+                    const lessText = fileCache[href];
+                    return resolve({ contents: lessText, filename: href, webInfo: { lastModified: new Date() }});
+                } catch (e) {
+                    return reject({ filename: href, message: `Error loading file ${href} error was ${e.message}` });
+                }
+            }
+
+            this.doXHR(href, options.mime, function doXHRCallback(data, lastModified) {
+                // per file cache
+                fileCache[href] = data;
+
+                // Use remote copy (re-parse)
+                resolve({ contents: data, filename: href, webInfo: { lastModified }});
+            }, function doXHRError(status, url) {
+                reject({ type: 'File', message: `'${url}' wasn't found (${status})`, href });
+            });
+        });
+    }
+
     supports() {
         return true;
     }
@@ -73,7 +110,7 @@ class FileManager extends AbstractFileManager {
             filename = currentDirectory + filename;
         }
 
-        filename = options.ext ? this.tryAppendExtension(filename, options.ext) : filename;
+        const extensions = this.getPossibleFileExtensions(filename, options.ext || '');
 
         options = options || {};
 
@@ -81,28 +118,12 @@ class FileManager extends AbstractFileManager {
         // some context variables for imports
         const hrefParts = this.extractUrlParts(filename, window.location.href);
         const href      = hrefParts.url;
-        const self      = this;
-        
-        return new Promise((resolve, reject) => {
-            if (options.useFileCache && fileCache[href]) {
-                try {
-                    const lessText = fileCache[href];
-                    return resolve({ contents: lessText, filename: href, webInfo: { lastModified: new Date() }});
-                } catch (e) {
-                    return reject({ filename: href, message: `Error loading file ${href} error was ${e.message}` });
-                }
-            }
+        const hrefs     = extensions.map(ext => this.tryAppendExtension(href, ext))
 
-            self.doXHR(href, options.mime, function doXHRCallback(data, lastModified) {
-                // per file cache
-                fileCache[href] = data;
-
-                // Use remote copy (re-parse)
-                resolve({ contents: data, filename: href, webInfo: { lastModified }});
-            }, function doXHRError(status, url) {
-                reject({ type: 'File', message: `'${url}' wasn't found (${status})`, href });
-            });
-        });
+        return hrefs.reduce(
+            (prev, href) => prev.catch(() => this.tryToLoad(href)),
+            this.tryToLoad(hrefs.shift())
+        );
     }
 }
 

--- a/lib/less-node/file-manager.js
+++ b/lib/less-node/file-manager.js
@@ -17,6 +17,14 @@ class FileManager extends AbstractFileManager {
         return true;
     }
 
+    getPossibleFileExtensions(path, ext) {
+        if (this.isPathWithExtension(path, ext)) {
+            return [''];
+        }
+
+        return ['', ext];
+    }
+
     loadFile(filename, currentDirectory, options, environment, callback) {
         let fullFilename;
         const isAbsoluteFilename = this.isPathAbsolute(filename);
@@ -37,7 +45,8 @@ class FileManager extends AbstractFileManager {
         if (!isAbsoluteFilename && paths.indexOf('.') === -1) { paths.push('.'); }
 
         const prefixes = options.prefixes || [''];
-        const extensions = self.tryAppendExtension(filename, options.ext) === filename ? [''] : ['', options.ext];
+
+        const extensions = this.getPossibleFileExtensions(filename, options.ext);
         const fileParts = this.extractUrlParts(filename);
 
         if (options.syncImport) {

--- a/lib/less-node/file-manager.js
+++ b/lib/less-node/file-manager.js
@@ -37,6 +37,7 @@ class FileManager extends AbstractFileManager {
         if (!isAbsoluteFilename && paths.indexOf('.') === -1) { paths.push('.'); }
 
         const prefixes = options.prefixes || [''];
+        const extensions = self.tryAppendExtension(filename, options.ext) === filename ? [''] : ['', options.ext];
         const fileParts = this.extractUrlParts(filename);
 
         if (options.syncImport) {
@@ -69,93 +70,76 @@ class FileManager extends AbstractFileManager {
                 if (i < paths.length) {
                     (function tryPrefix(j) {
                         if (j < prefixes.length) {
-                            isNodeModule = false;
-                            fullFilename = fileParts.rawPath + prefixes[j] + fileParts.filename;
+                            (function tryExtension(k) {
+                                if (k < extensions.length) {
+                                    isNodeModule = false;
+                                    fullFilename = fileParts.rawPath + prefixes[j] + fileParts.filename + extensions[k];
 
-                            if (paths[i]) {
-                                fullFilename = path.join(paths[i], fullFilename);
-                            }
+                                    if (paths[i]) {
+                                        fullFilename = path.join(paths[i], fullFilename);
+                                    }
 
-                            if (!explicit && paths[i] === '.') {
-                                try {
-                                    fullFilename = require.resolve(fullFilename);
-                                    isNodeModule = true;
-                                }
-                                catch (e) {
-                                    filenamesTried.push(npmPrefix + fullFilename);
-                                    tryWithExtension();
-                                }
-                            }
-                            else {
-                                tryWithExtension();
-                            }
-
-                            function tryWithExtension() {
-                                const extFilename = options.ext ? self.tryAppendExtension(fullFilename, options.ext) : fullFilename;
-
-                                if (extFilename !== fullFilename && !explicit && paths[i] === '.') {
-                                    try {
-                                        fullFilename = require.resolve(extFilename);
-                                        isNodeModule = true;
-                                    }
-                                    catch (e) {
-                                        filenamesTried.push(npmPrefix + extFilename);
-                                        fullFilename = extFilename;
-                                    }
-                                }
-                                else {
-                                    fullFilename = extFilename;
-                                }
-                            }
-
-                            let modified = false;
-
-                            if (self.contents[fullFilename]) {
-                                try {
-                                    var stat = fs.statSync.apply(this, [fullFilename]);
-                                    if (stat.mtime.getTime() === self.contents[fullFilename].mtime.getTime()) {
-                                        fulfill({ contents: self.contents[fullFilename].data, filename: fullFilename});
-                                    }
-                                    else {
-                                        modified = true;
-                                    }
-                                }
-                                catch (e) {
-                                    modified = true;
-                                }
-                            }
-                            if (modified || !self.contents[fullFilename]) {
-                                const readFileArgs = [fullFilename];
-                                if (!options.rawBuffer) {
-                                    readFileArgs.push('utf-8');
-                                }
-                                if (options.syncImport) {
-                                    try {
-                                        const data = fs.readFileSync.apply(this, readFileArgs);
-                                        var stat = fs.statSync.apply(this, [fullFilename]);
-                                        self.contents[fullFilename] = { data, mtime: stat.mtime };
-                                        fulfill({ contents: data, filename: fullFilename});
-                                    }
-                                    catch (e) {
-                                        filenamesTried.push(isNodeModule ? npmPrefix + fullFilename : fullFilename);
-                                        return tryPrefix(j + 1);
-                                    }
-                                }
-                                else {
-                                    readFileArgs.push(function(e, data) {
-                                        if (e) {
-                                            filenamesTried.push(isNodeModule ? npmPrefix + fullFilename : fullFilename);
-                                            return tryPrefix(j + 1);
+                                    if (!explicit && paths[i] === '.') {
+                                        try {
+                                            fullFilename = require.resolve(fullFilename);
+                                            isNodeModule = true;
                                         }
-                                        const stat = fs.statSync.apply(this, [fullFilename]);
-                                        self.contents[fullFilename] = { data, mtime: stat.mtime };      
-                                        fulfill({ contents: data, filename: fullFilename});
-                                    });
-                                    fs.readFile.apply(this, readFileArgs);
+                                        catch (e) {
+                                            filenamesTried.push(npmPrefix + fullFilename);
+                                        }
+                                    }
+
+                                    let modified = false;
+
+                                    if (self.contents[fullFilename]) {
+                                        try {
+                                            var stat = fs.statSync.apply(this, [fullFilename]);
+                                            if (stat.mtime.getTime() === self.contents[fullFilename].mtime.getTime()) {
+                                                fulfill({ contents: self.contents[fullFilename].data, filename: fullFilename});
+                                            }
+                                            else {
+                                                modified = true;
+                                            }
+                                        }
+                                        catch (e) {
+                                            modified = true;
+                                        }
+                                    }
+                                    if (modified || !self.contents[fullFilename]) {
+                                        const readFileArgs = [fullFilename];
+                                        if (!options.rawBuffer) {
+                                            readFileArgs.push('utf-8');
+                                        }
+                                        if (options.syncImport) {
+                                            try {
+                                                const data = fs.readFileSync.apply(this, readFileArgs);
+                                                var stat = fs.statSync.apply(this, [fullFilename]);
+                                                self.contents[fullFilename] = { data, mtime: stat.mtime };
+                                                fulfill({ contents: data, filename: fullFilename});
+                                            }
+                                            catch (e) {
+                                                filenamesTried.push(isNodeModule ? npmPrefix + fullFilename : fullFilename);
+                                                return tryExtension(k + 1);
+                                            }
+                                        }
+                                        else {
+                                            readFileArgs.push(function(e, data) {
+                                                if (e) {
+                                                    filenamesTried.push(isNodeModule ? npmPrefix + fullFilename : fullFilename);
+                                                    return tryExtension(k + 1);
+                                                }
+                                                const stat = fs.statSync.apply(this, [fullFilename]);
+                                                self.contents[fullFilename] = { data, mtime: stat.mtime };      
+                                                fulfill({ contents: data, filename: fullFilename});
+                                            });
+                                            fs.readFile.apply(this, readFileArgs);
+                                        }
+                                    }
                                 }
-
-                            }
-
+                                else {
+                                    tryPrefix(j + 1)
+                                }
+                            })(0);
                         }
                         else {
                             tryPathIndex(i + 1);

--- a/lib/less/environment/abstract-file-manager.js
+++ b/lib/less/environment/abstract-file-manager.js
@@ -15,7 +15,12 @@ class AbstractFileManager {
     }
 
     tryAppendExtension(path, ext) {
-        return /(\.[a-z]*$)|([\?;].*)$/.test(path) ? path : path + ext;
+        let extPos = path.lastIndexOf(ext);
+        if (extPos === -1 || extPos !== path.length - ext.length) {
+            return path + ext;
+        }
+
+        return path;
     }
 
     tryAppendLessExtension(path) {

--- a/lib/less/environment/abstract-file-manager.js
+++ b/lib/less/environment/abstract-file-manager.js
@@ -14,13 +14,17 @@ class AbstractFileManager {
         return filename.slice(0, j + 1);
     }
 
-    tryAppendExtension(path, ext) {
+    isPathWithExtension(path, ext) {
         let extPos = path.lastIndexOf(ext);
-        if (extPos === -1 || extPos !== path.length - ext.length) {
-            return path + ext;
+        return extPos !== -1 && extPos === path.length - ext.length
+    }
+
+    tryAppendExtension(path, ext) {
+        if (this.isPathWithExtension(path, ext)) {
+            return path;
         }
 
-        return path;
+        return path + ext;
     }
 
     tryAppendLessExtension(path) {

--- a/test/css/import-once.css
+++ b/test/css/import-once.css
@@ -1,6 +1,9 @@
 #import {
   color: red;
 }
+.test-d > h1 {
+  height: 20px;
+}
 body {
   width: 100%;
 }

--- a/test/less/import-once.less
+++ b/test/less/import-once.less
@@ -1,5 +1,7 @@
 @import "import/import-once-test-c";
 @import "import/import-once-test-c";
+@import "import/import.once.test.d";
+@import "import/import.once.test.d.less";
 @import "import/import-once-test-c.less";
 @import "import/deeper/import-once-test-a";
 @import (multiple) "import/import-test-f.less";

--- a/test/less/import/import.once.test.d.less
+++ b/test/less/import/import.once.test.d.less
@@ -1,0 +1,3 @@
+.test-d > h1 {
+  height: 20px;
+}


### PR DESCRIPTION
Fixes #3288
This PR consist of three parts: importing files in node, importing files in browser, and unit test.
Fix described in issue isn't full because if file has dots in name it doesn't mean that we shouldn't add extension. That's why we should try to load file with and without extension.

As an example:
1) hello.css - this file has extension and we shouldn't add .less at the end.
2) hello.world - this file doesn't have extension and we probably should add .less at the end.

Thanks a lot. 