### PR TITLE
- Fixed replacer when visitor returns array of nodes

### DIFF
--- a/lib/less/visitors/visitor.js
+++ b/lib/less/visitors/visitor.js
@@ -80,8 +80,16 @@ class Visitor {
             }
         }
 
-        if (visitArgs.visitDeeper && node && node.accept) {
-            node.accept(this);
+        if (visitArgs.visitDeeper && node) {
+            if (node.length) {
+                for (var i = 0, cnt = node.length; i < cnt; i++) {
+                    if (node[i].accept) {
+                        node[i].accept(this);
+                    }
+                }
+            } else if (node.accept) {
+                node.accept(this);
+            }
         }
 
         if (funcOut != _noop) {


### PR DESCRIPTION
When a visitor hook returns an array of nodes for replacement, the accept calls are not made.
Returning an array of node when the plugin implementation `isReplacing` is set seems to be correctly supported in the `visitArray` function implementation.
-L