### PR TITLE
- Fixed currentFileInfo propagation to Definition nodes

### DIFF
--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -1149,7 +1149,7 @@ const Parser = function Parser(context, imports, fileInfo) {
 
                         if (ruleset) {
                             parserInput.forget();
-                            return new(tree.mixin.Definition)(name, params, ruleset, cond, variadic);
+                            return new(tree.mixin.Definition)(name, params, ruleset, cond, variadic, undefined, undefined, fileInfo);
                         } else {
                             parserInput.restore();
                         }
@@ -1465,7 +1465,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                 if (blockRuleset) {
                     parserInput.forget();
                     if (params) {
-                        return new tree.mixin.Definition(null, params, blockRuleset, null, variadic);
+                        return new tree.mixin.Definition(null, params, blockRuleset, null, variadic, undefined, undefined, fileInfo);
                     }
                     return new tree.DetachedRuleset(blockRuleset);
                 }
@@ -2065,7 +2065,7 @@ const Parser = function Parser(context, imports, fileInfo) {
 
                         m.parensInOp = true;
                         a.parensInOp = true;
-                        operation = new(tree.Operation)(op, [operation || m, a], isSpaced);
+                        operation = new(tree.Operation)(op, [operation || m, a], isSpaced, fileInfo);
                         isSpaced = parserInput.isWhitespace(-1);
                     }
                     return operation || m;
@@ -2092,7 +2092,7 @@ const Parser = function Parser(context, imports, fileInfo) {
 
                         m.parensInOp = true;
                         a.parensInOp = true;
-                        operation = new(tree.Operation)(op, [operation || m, a], isSpaced);
+                        operation = new(tree.Operation)(op, [operation || m, a], isSpaced, fileInfo);
                         isSpaced = parserInput.isWhitespace(-1);
                     }
                     return operation || m;
@@ -2295,7 +2295,7 @@ const Parser = function Parser(context, imports, fileInfo) {
 
                 if (negate) {
                     o.parensInOp = true;
-                    o = new(tree.Negative)(o);
+                    o = new(tree.Negative)(o, fileInfo);
                 }
 
                 return o;

--- a/lib/less/tree/mixin-definition.js
+++ b/lib/less/tree/mixin-definition.js
@@ -8,7 +8,7 @@ import contexts from '../contexts';
 import * as utils from '../utils';
 
 class Definition extends Ruleset {
-    constructor(name, params, rules, condition, variadic, frames, visibilityInfo) {
+    constructor(name, params, rules, condition, variadic, frames, visibilityInfo, currentFileInfo) {
         super();
 
         this.name = name || 'anonymous mixin';
@@ -18,6 +18,7 @@ class Definition extends Ruleset {
         this.variadic = variadic;
         this.arity = params.length;
         this.rules = rules;
+        this._fileInfo = currentFileInfo;
         this._lookups = {};
         const optionalParameters = [];
         this.required = params.reduce((count, p) => {
@@ -76,7 +77,7 @@ class Definition extends Ruleset {
                     for (j = 0; j < params.length; j++) {
                         if (!evaldArguments[j] && name === params[j].name) {
                             evaldArguments[j] = arg.value.eval(context);
-                            frame.prependRule(new Declaration(name, arg.value.eval(context)));
+                            frame.prependRule(new Declaration(name, arg.value.eval(context), false, false, undefined, this.currentFileInfo));
                             isNamedFound = true;
                             break;
                         }
@@ -103,7 +104,7 @@ class Definition extends Ruleset {
                     for (j = argIndex; j < argsLength; j++) {
                         varargs.push(args[j].value.eval(context));
                     }
-                    frame.prependRule(new Declaration(name, new Expression(varargs).eval(context)));
+                    frame.prependRule(new Declaration(name, new Expression(varargs).eval(context), false, false, undefined, this.currentFileInfo));
                 } else {
                     val = arg && arg.value;
                     if (val) {
@@ -121,7 +122,7 @@ class Definition extends Ruleset {
                         throw { type: 'Runtime', message: `wrong number of arguments for ${this.name} (${argsLength} for ${this.arity})` };
                     }
 
-                    frame.prependRule(new Declaration(name, val));
+                    frame.prependRule(new Declaration(name, val, false, false, undefined, this.currentFileInfo));
                     evaldArguments[i] = val;
                 }
             }
@@ -150,7 +151,8 @@ class Definition extends Ruleset {
     }
 
     eval(context) {
-        return new Definition(this.name, this.params, this.rules, this.condition, this.variadic, this.frames || utils.copyArray(context.frames));
+        return new Definition(this.name, this.params, this.rules, this.condition, 
+            this.variadic, this.frames || utils.copyArray(context.frames), undefined, this.currentFileInfo);
     }
 
     evalCall(context, args, important) {
@@ -160,7 +162,7 @@ class Definition extends Ruleset {
         let rules;
         let ruleset;
 
-        frame.prependRule(new Declaration('@arguments', new Expression(_arguments).eval(context)));
+        frame.prependRule(new Declaration('@arguments', new Expression(_arguments).eval(context), false, false, undefined, this.currentFileInfo));
 
         rules = utils.copyArray(this.rules);
 

--- a/lib/less/tree/negative.js
+++ b/lib/less/tree/negative.js
@@ -3,10 +3,11 @@ import Operation from './operation';
 import Dimension from './dimension';
 
 class Negative extends Node {
-    constructor(node) {
+    constructor(node, currentFileInfo) {
         super();
 
         this.value = node;
+        this._fileInfo = currentFileInfo;
     }
 
     genCSS(context, output) {
@@ -16,7 +17,7 @@ class Negative extends Node {
 
     eval(context) {
         if (context.isMathOn()) {
-            return (new Operation('*', [new Dimension(-1), this.value])).eval(context);
+            return (new Operation('*', [new Dimension(-1), this.value], this.currentFileInfo)).eval(context);
         }
         return new Negative(this.value.eval(context));
     }

--- a/lib/less/tree/node.js
+++ b/lib/less/tree/node.js
@@ -6,12 +6,11 @@ class Node {
         this.rootNode = null;
         this.parsed = null;
 
-        const self = this;
         Object.defineProperty(this, 'currentFileInfo', {
-            get: function() { return self.fileInfo(); }
+            get: function() { return this.fileInfo(); }
         });
         Object.defineProperty(this, 'index', {
-            get: function() { return self.getIndex(); }
+            get: function() { return this.getIndex(); }
         });
 
     }

--- a/lib/less/tree/operation.js
+++ b/lib/less/tree/operation.js
@@ -6,12 +6,13 @@ const MATH = Constants.Math;
 
 
 class Operation extends Node {
-    constructor(op, operands, isSpaced) {
+    constructor(op, operands, isSpaced, currentFileInfo) {
         super();
 
         this.op = op.trim();
         this.operands = operands;
         this.isSpaced = isSpaced;
+        this._fileInfo = currentFileInfo;
     }
 
     accept(visitor) {


### PR DESCRIPTION
Currently a LESS plugin is not able to access the `currentFileInfo` property for all nodes.
With this (partial) fix I tried to propagate the file info data to additional node types.
However to be 100% correct the task would require a slight refactoring of the node constructors, since the `currentFileInfo` object is passed to selected nodes as last/middle argument.

In addition, the current implementation of the `currentFileInfo` property in `node.js` is not correct, since it accesses to a captured 'this' and it returns the wrong default value if called in inherited prototypes. The getter/setter functions are guaranteed to be called with a correct `this` value.

Thanks, 
-L