### PR TITLE
fix: Use make-dir instead of mkdirp

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -10981,7 +10981,7 @@ function render() {
         if (!existsSync(dir)) {
             if (mkdirp === undefined) {
                 try {
-                    mkdirp = require('mkdirp');
+                    mkdirp = require('make-dir');
                 }
                 catch (e) {
                     mkdirp = null;

--- a/lib/lessc.js
+++ b/lib/lessc.js
@@ -135,7 +135,7 @@ function render() {
         const existsSync = fs.existsSync || path.existsSync;
         if (!existsSync(dir)) {
             if (mkdirp === undefined) {
-                try {mkdirp = require('mkdirp');}
+                try {mkdirp = require('make-dir');}
                 catch (e) { mkdirp = null; }
             }
             cmd = mkdirp && mkdirp.sync || fs.mkdirSync;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "errno": "^0.1.1",
     "graceful-fs": "^4.1.2",
     "image-size": "~0.5.0",
-    "make-dir":"^3.0.2",
+    "make-dir":"^2.1.0",
     "mime": "^1.4.1",
     "promise": "^7.1.1",
     "request": "^2.83.0",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "errno": "^0.1.1",
     "graceful-fs": "^4.1.2",
     "image-size": "~0.5.0",
+    "make-dir":"^3.0.2",
     "mime": "^1.4.1",
-    "mkdirp": "^0.5.0",
     "promise": "^7.1.1",
     "request": "^2.83.0",
     "source-map": "~0.6.0"


### PR DESCRIPTION
Closes #3487 

`minimist` has the vulnerability. By removing `mkdirp@0.x` (which is deprecated anyway) we get rid of `minimist`. 

Note that we already have to use an outdated version of `make-dir` since less supports node 6 (has reached end-of-life a year ago) while `make-dir@latest` only supports node 8 (which also reached end-of-life since end of last year).