### PR TITLE
Properly exit calc mode after use

### DIFF
--- a/lib/less/contexts.js
+++ b/lib/less/contexts.js
@@ -84,7 +84,7 @@ contexts.Eval = class {
 
     exitCalc() {
         this.calcStack.pop();
-        if (!this.calcStack) {
+        if (!this.calcStack.length) {
             this.inCalc = false;
         }
     }

--- a/test/css/calc.css
+++ b/test/css/calc.css
@@ -17,3 +17,12 @@
 .c {
   height: calc(100% - ((10px * 3) + (10px * 2)));
 }
+.correctly-exit-calc-mode h2 {
+  width: 10px;
+}
+.correctly-exit-calc-mode div {
+  width: calc(100px * 2);
+}
+.correctly-exit-calc-mode h1 {
+  color: white;
+}

--- a/test/less/calc.less
+++ b/test/less/calc.less
@@ -28,3 +28,19 @@
   @v: 10px;
   height: calc(100% - ((@v * 3) + (@v * 2)));
 }
+
+.correctly-exit-calc-mode {
+    @a: 10;
+    h2 { width: unit(@a, px); }
+
+    div { width: calc(100px * 2); }
+
+    .mk-map() {
+        text: white;
+        background: black;
+    }
+
+    @p: .mk-map();
+
+    h1 { color: @p[text]; }
+}

--- a/test/sourcemaps/custom-props.json
+++ b/test/sourcemaps/custom-props.json
@@ -1,1 +1,1 @@
-{"version":3,"sources":["testweb/sourcemaps/custom-props.less"],"names":[],"mappings":"AAEA;EACC,uBAHO,UAGP;EACA,OAAO,eAAP;EACA,gCAAA","file":"sourcemaps/custom-props.css"}
+{"version":3,"sources":["testweb/sourcemaps/custom-props.less"],"names":[],"mappings":"AAEA;EACC,uBAHO,UAGP;EACA,OAAO,eAAP;EACA,sBALO,UAKP","file":"sourcemaps/custom-props.css"}


### PR DESCRIPTION
In issue #3393, it was found that Less does not properly exit out of calc mode after using it. This causes subsequent variables to be incorrectly evaluated, which results in errors. The code checks if the calculation stack is empty by checking `!this.calcStack`, but this does not evaluate to false. This was changed to checking if `this.calcStack.length` is 0, which does evaluate to false.

**Note**: The changes introduced by this PR also caused changes in the sourcemap test output, which is why I modified that as well. I'm not sure if this is right or wrong.