### PR TITLE
Additional check to avoid evaluating an expression if it is a comment

### DIFF
--- a/lib/less/parser/parser.js
+++ b/lib/less/parser/parser.js
@@ -2321,6 +2321,11 @@ const Parser = function Parser(context, imports, fileInfo) {
                         continue;
                     }
                     e = this.addition() || this.entity();
+
+                    if (e instanceof tree.Comment) {
+                        e = null;
+                    }
+
                     if (e) {
                         entities.push(e);
                         // operations do not allow keyword "/" dimension (e.g. small/20px) so we support that here

--- a/test/less/errors/invalid-color-with-comment.less
+++ b/test/less/errors/invalid-color-with-comment.less
@@ -1,0 +1,1 @@
+.test {color: #fffff /* comment */ ;}

--- a/test/less/errors/invalid-color-with-comment.txt
+++ b/test/less/errors/invalid-color-with-comment.txt
@@ -1,0 +1,2 @@
+ParseError: Unrecognised input in {path}invalid-color-with-comment.less on line 1, column 36:
+1 .test {color: #fffff /* comment */ ;}


### PR DESCRIPTION
While investigating #3443, it was found that the evaluation of the expression became stuck in an infinite loop, filling up the `entities` array until Less runs out of memory. The cause appears to be the attempted evaluation of a comment as an entity, which should have been caught just beforehand but for some reason wasn't. Maybe an issue with cleaning up the loop variable?

A second check has now been added to the entity retrieval, since an entity can also be a comment. This fix removes the value from `e` if that is the case, preventing the infinite loop.