### PR TITLE
Increased timeout value in "generate.js"

### DIFF
--- a/test/browser/generator/generate.js
+++ b/test/browser/generator/generate.js
@@ -56,7 +56,7 @@ Object.entries(config).forEach(entry => {
         console.log(file)
         return runner({
             file,
-            timeout: 2000,
+            timeout: 3500,
             args: ['disable-web-security']
         })
     })


### PR DESCRIPTION
Hi,
One test case was failing on "aarch64" platform due to timeout issue, so increasing it from 2000ms to 3500ms. Please refer:
https://github.com/less/less.js/issues/3240#issuecomment-621993800 
Please have a look.
Thanks.