### PR TITLE
chore(recondition): replace dependency request with native-request

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -470,7 +470,7 @@ var UrlFileManager = /** @class */ (function (_super) {
         return new Promise(function (fulfill, reject) {
             if (request === undefined) {
                 try {
-                    request = require('request');
+                    request = require('native-request');
                 }
                 catch (e) {
                     request = null;
@@ -7006,7 +7006,7 @@ var Parser = function Parser(context, imports, fileInfo) {
                     function f(parse, stop) {
                         return {
                             parse: parse,
-                            stop: stop // when true - stop after parse() and return its result, 
+                            stop: stop // when true - stop after parse() and return its result,
                             // otherwise continue for plain args
                         };
                     }

--- a/lib/less-node/url-file-manager.js
+++ b/lib/less-node/url-file-manager.js
@@ -12,11 +12,11 @@ class UrlFileManager extends AbstractFileManager {
     loadFile(filename, currentDirectory, options, environment) {
         return new Promise((fulfill, reject) => {
             if (request === undefined) {
-                try { request = require('request'); }
+                try { request = require('native-request'); }
                 catch (e) { request = null; }
             }
             if (!request) {
-                reject({ type: 'File', message: 'optional dependency \'request\' required to import over http(s)\n' });
+                reject({ type: 'File', message: 'optional dependency \'native-request\' required to import over http(s)\n' });
                 return;
             }
 

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "errno": "^0.1.1",
     "graceful-fs": "^4.1.2",
     "image-size": "~0.5.0",
-    "make-dir":"^2.1.0",
+    "make-dir": "^2.1.0",
     "mime": "^1.4.1",
+    "native-request": "^1.0.5",
     "promise": "^7.1.1",
-    "request": "^2.83.0",
     "source-map": "~0.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR replaces the [deprecated](https://github.com/request/request/issues/3142) request library with a [compatible alternative](https://www.npmjs.com/package/native-request).