### PR TITLE
fix(#3294): use loadFileSync when loading plugins with syncImport: true

### DIFF
--- a/lib/less-node/plugin-loader.js
+++ b/lib/less-node/plugin-loader.js
@@ -30,6 +30,10 @@ class PluginLoader extends AbstractPluginLoader {
             context.prefixes = ['less-plugin-', ''];
         }
 
+        if (context.syncImport) {
+            return fileManager.loadFileSync(filename, basePath, context, environment);
+        }
+
         return new Promise((fulfill, reject) => {
             fileManager.loadFile(filename, basePath, context, environment).then(
                 data => {
@@ -45,7 +49,11 @@ class PluginLoader extends AbstractPluginLoader {
                 reject(err);
             });
         });
+    }
 
+    loadPluginSync(filename, basePath, context, environment, fileManager) {
+        context.syncImport = true;
+        return this.loadPlugin(filename, basePath, context, environment, fileManager);
     }
 }
 

--- a/lib/less/import-manager.js
+++ b/lib/less/import-manager.js
@@ -138,6 +138,7 @@ export default environment => {
                     }
                 }
             };
+            let loadedFile;
             let promise;
             const context = utils.clone(this.context);
 
@@ -147,19 +148,34 @@ export default environment => {
 
             if (importOptions.isPlugin) {
                 context.mime = 'application/javascript';
-                promise = pluginLoader.loadPlugin(path, currentFileInfo.currentDirectory, context, environment, fileManager);
+
+                if (context.syncImport) {
+                    loadedFile = pluginLoader.loadPluginSync(path, currentFileInfo.currentDirectory, context, environment, fileManager);
+                } else {
+                    promise = pluginLoader.loadPlugin(path, currentFileInfo.currentDirectory, context, environment, fileManager);
+                }
             }
             else {
-                promise = fileManager.loadFile(path, currentFileInfo.currentDirectory, context, environment,
-                    (err, loadedFile) => {
-                        if (err) {
-                            fileParsedFunc(err);
-                        } else {
-                            loadFileCallback(loadedFile);
-                        }
-                    });
+                if (context.syncImport) {
+                    loadedFile = fileManager.loadFileSync(path, currentFileInfo.currentDirectory, context, environment);
+                } else {
+                    promise = fileManager.loadFile(path, currentFileInfo.currentDirectory, context, environment,
+                        (err, loadedFile) => {
+                            if (err) {
+                                fileParsedFunc(err);
+                            } else {
+                                loadFileCallback(loadedFile);
+                            }
+                        });
+                }
             }
-            if (promise) {
+            if (loadedFile) {
+                if (!loadedFile.filename) {
+                    fileParsedFunc(loadedFile);
+                } else {
+                    loadFileCallback(loadedFile);
+                }
+            } else if (promise) {
                 promise.then(loadFileCallback, fileParsedFunc);
             }
         }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "errno": "^0.1.1",
     "graceful-fs": "^4.1.2",
     "image-size": "~0.5.0",
-    "make-dir":"^2.1.0",
+    "make-dir": "^2.1.0",
     "mime": "^1.4.1",
     "promise": "^7.1.1",
     "request": "^2.83.0",

--- a/test/css/import.css
+++ b/test/css/import.css
@@ -7,6 +7,7 @@
   color: red;
   width: 10px;
   height: 30%;
+  value: 3.141592653589793;
 }
 @media screen and (max-width: 600px) {
   body {

--- a/test/index.js
+++ b/test/index.js
@@ -72,6 +72,7 @@ testMap.forEach(function(args) {
     lessTester.runTestSet.apply(lessTester, args)
 });
 lessTester.testSyncronous({syncImport: true}, 'import');
+lessTester.testSyncronous({syncImport: true}, 'plugin');
 lessTester.testSyncronous({syncImport: true}, 'math/strict-legacy/css');
 lessTester.testNoOptions();
 lessTester.testJSImport();

--- a/test/less/import.less
+++ b/test/less/import.less
@@ -1,4 +1,6 @@
 /** comment at the top**/
+@plugin "./plugin/plugin-simple";
+
 @import url(/absolute/something.css) screen and (color) and (max-width: 600px);
 
 @import (optional) "file-does-not-exist.does-not-exist";
@@ -10,6 +12,7 @@
   .mixin;
   width: 10px;
   height: (@a + 10%);
+  value: pi-anon();
 }
 @import "import/import-test-e" screen and (max-width: 600px);
 


### PR DESCRIPTION
Currently the only way to compile Less code synchronously is by setting `syncImport: true`. But as described in #3294, it cannot work when it involves plugins. In fact `loadPlugin` didn't have a sync version. This PR added a `loadPluginSync` method to fix this problem.

---

~~PS. I didn't quite understand how tests work so tests are not included. Any help would be appreciated.~~

---

**Please note: compiled files are not included in this PR.**