### PR TITLE
Resolve #3398 Add flag to disable sourcemap url annotation

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -10949,6 +10949,12 @@ function render() {
             // make the sourcemap filename point to the sourcemap relative to the css file output directory
             sourceMapOptions.sourceMapFilename = path.join(path.relative(outputDir, mapDir), path.basename(sourceMapOptions.sourceMapFullFilename));
         }
+        if (sourceMapOptions.sourceMapURL && sourceMapOptions.disableSourcemapAnnotation) {
+            console.error('You cannot provide flag --source-map-url with --source-map-no-annotation.')
+            console.error('Please remove one of those flags.')
+            process.exitcode = 1;
+            return;
+        }
     }
     if (sourceMapOptions.sourceMapBasepath === undefined) {
         sourceMapOptions.sourceMapBasepath = input ? path.dirname(input) : process.cwd();
@@ -11271,6 +11277,9 @@ function processPluginQueue() {
                 if (checkArgFunc(arg, match[2])) {
                     sourceMapOptions.sourceMapURL = match[2];
                 }
+                break;
+            case 'source-map-no-annotation':
+                sourceMapOptions.disableSourcemapAnnotation = true;
                 break;
             case 'rp':
             case 'rootpath':

--- a/lib/less-node/lessc-helper.js
+++ b/lib/less-node/lessc-helper.js
@@ -44,6 +44,7 @@ const lessc_helper = {
         console.log('  --source-map-inline          Puts the map (and any less files) as a base64 data uri into the output css file.');
         console.log('  --source-map-url=URL         Sets a custom URL to map file, for sourceMappingURL comment');
         console.log('                               in generated CSS file.');
+        console.log('  --source-map-no-annotation   Excludes the sourceMappingURL comment from the output css file.');
         console.log('  -rp, --rootpath=URL          Sets rootpath for url rewriting in relative imports and urls');
         console.log('                               Works with or without the relative-urls option.');
         console.log('  -ru=, --rewrite-urls=        Rewrites URLs to make them relative to the base less file.');

--- a/lib/less/source-map-builder.js
+++ b/lib/less/source-map-builder.js
@@ -17,7 +17,8 @@ export default (SourceMapOutput, environment) => {
                     sourceMapRootpath: this.options.sourceMapRootpath,
                     outputSourceFiles: this.options.outputSourceFiles,
                     sourceMapGenerator: this.options.sourceMapGenerator,
-                    sourceMapFileInline: this.options.sourceMapFileInline
+                    sourceMapFileInline: this.options.sourceMapFileInline,    
+                    disableSourcemapAnnotation: this.options.disableSourcemapAnnotation
                 });
 
             const css = sourceMapOutput.toCSS(options);
@@ -40,6 +41,10 @@ export default (SourceMapOutput, environment) => {
                     return '';
                 }
                 sourceMapURL = `data:application/json;base64,${environment.encodeBase64(this.sourceMap)}`;
+            }
+
+            if (this.options.disableSourcemapAnnotation) {
+                return '';
             }
 
             if (sourceMapURL) {

--- a/test/index.js
+++ b/test/index.js
@@ -56,6 +56,8 @@ var testMap = [
         }],
     [{math: 'strict', strictUnits: true, sourceMap: {sourceMapFileInline: true}},
         'sourcemaps-empty/', lessTester.testEmptySourcemap],
+    [{math: 'strict', strictUnits: true, sourceMap: {disableSourcemapAnnotation: true}},
+        'sourcemaps-disable-annotation/', lessTester.testSourcemapWithoutUrlAnnotation],
     [{globalVars: true, banner: '/**\n  * Test\n  */\n'}, 'globalVars/',
         null, null, null, function(name, type, baseFolder) { return path.join(baseFolder, name) + '.json'; }],
     [{modifyVars: true}, 'modifyVars/',

--- a/test/less/sourcemaps-disable-annotation/basic.less
+++ b/test/less/sourcemaps-disable-annotation/basic.less
@@ -1,0 +1,4 @@
+body {
+  /*# sourceMappingURL=this-should-be-ok.css.map */
+  color: white;
+}

--- a/test/sourcemaps-disable-annotation/basic.json
+++ b/test/sourcemaps-disable-annotation/basic.json
@@ -1,0 +1,1 @@
+{"version":3,"sources":["testweb/sourcemaps-disable-annotation/basic.less"],"names":[],"mappings":"AAAA;;EAEE,YAAA","file":"sourcemaps-disable-annotation/basic.css"}


### PR DESCRIPTION
**Small doubts** 
Shall I use positive form for the property? I mean using `appendSourcemapUrlAnnotation`, for example,  instead of `disableSourcemapAnnotation` sounds more straightforward for me. In other words, `disableSourcemapAnnotation: false/true` looks a little bit confusing.
`--source-map-no-annotation`, on the other hand, looks ok for me since it does not have true/false value with it.
