### PR TITLE
Updated mocha-headless-chrome version to v3.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - "14"
   - "12"
   - "10"
-  - "8"
 install:
   - npm install -g grunt-cli
   - travis_retry npm install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,7 @@
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "6"
-    - nodejs_version: "8"
+    - nodejs_version: "14"
     - nodejs_version: "10"
     - nodejs_version: "12"
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "less-plugin-clean-css": "^1.5.1",
     "minimist": "^1.2.0",
     "mocha": "^6.2.1",
-    "mocha-headless-chrome": "^2.0.3",
+    "mocha-headless-chrome": "^3.1.0",
     "mocha-teamcity-reporter": "^3.0.0",
     "performance-now": "^0.2.0",
     "phin": "^2.2.3",

--- a/test/browser/generator/generate.js
+++ b/test/browser/generator/generate.js
@@ -56,7 +56,7 @@ Object.entries(config).forEach(entry => {
         console.log(file)
         return runner({
             file,
-            timeout: 2000,
+            timeout: 3500,
             args: ['disable-web-security']
         })
     })

--- a/test/browser/generator/template.js
+++ b/test/browser/generator/template.js
@@ -44,7 +44,7 @@ module.exports = (stylesheets, helpers, spec, less) => {
         expect = chai.expect
         mocha.setup({
             ui: 'bdd',
-            timeout: 1500
+            timeout: 2500
         });
     </script>
     <script src="common.js"></script>


### PR DESCRIPTION
Updated mocha-headless-chrome to latest in package.json as the latest version
has support for aarch64 platform and also increased timeout value in "template.js" & "generate.js".
Removed nodejs version 6 and 8 and added version 14 in appveyor.yml & .travis.yml, as puppeteer doesn't support nodejs version 6 & 8.
