### PR TITLE
Fix #3576 import redirects. Replace native-request with needle.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@less/root",
-  "version": "3.12.2",
+  "version": "3.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/less/package-lock.json
+++ b/packages/less/package-lock.json
@@ -2761,7 +2761,6 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -3593,6 +3592,12 @@
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
 		},
+		"lodash.set": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+			"dev": true
+		},
 		"log-symbols": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -3921,8 +3926,7 @@
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"mute-stream": {
 			"version": "0.0.8",
@@ -3949,17 +3953,33 @@
 				"to-regex": "^3.0.1"
 			}
 		},
-		"native-request": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/native-request/-/native-request-1.0.5.tgz",
-			"integrity": "sha512-7wU3DvBGAJQxWuMR3F62zrhB7hxNj2DdlC/eBVrCgavc6+ZpFZOqS/PsR7QyUPLMkFk0GvvzoeeOAZGLLnObnA==",
-			"optional": true
-		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
+		},
+		"needle": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
+			"integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
+			"optional": true,
+			"requires": {
+				"debug": "^3.2.6",
+				"iconv-lite": "^0.4.4",
+				"sax": "^1.2.4"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.7",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+					"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+					"optional": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
+			}
 		},
 		"negotiator": {
 			"version": "0.6.2",
@@ -3972,6 +3992,18 @@
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
+		},
+		"nock": {
+			"version": "13.0.5",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-13.0.5.tgz",
+			"integrity": "sha512-1ILZl0zfFm2G4TIeJFW0iHknxr2NyA+aGCMTjDVUsBY4CkMRispF1pfIYkTRdAR/3Bg+UzdEuK0B6HczMQZcCg==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.1.0",
+				"json-stringify-safe": "^5.0.1",
+				"lodash.set": "^4.3.2",
+				"propagate": "^2.0.0"
+			}
 		},
 		"node-environment-flags": {
 			"version": "1.0.5",
@@ -4670,6 +4702,12 @@
 				"asap": "~2.0.3"
 			}
 		},
+		"propagate": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+			"integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+			"dev": true
+		},
 		"proxy-from-env": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -5088,8 +5126,7 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sauce-tunnel": {
 			"version": "2.5.0",
@@ -5152,6 +5189,12 @@
 			"requires": {
 				"https-proxy-agent": "^2.2.1"
 			}
+		},
+		"sax": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"optional": true
 		},
 		"semver": {
 			"version": "6.3.0",

--- a/packages/less/package-lock.json
+++ b/packages/less/package-lock.json
@@ -3592,12 +3592,6 @@
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
 		},
-		"lodash.set": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
-			"dev": true
-		},
 		"log-symbols": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -3994,14 +3988,15 @@
 			"dev": true
 		},
 		"nock": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-13.0.5.tgz",
-			"integrity": "sha512-1ILZl0zfFm2G4TIeJFW0iHknxr2NyA+aGCMTjDVUsBY4CkMRispF1pfIYkTRdAR/3Bg+UzdEuK0B6HczMQZcCg==",
+			"version": "11.9.1",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-11.9.1.tgz",
+			"integrity": "sha512-U5wPctaY4/ar2JJ5Jg4wJxlbBfayxgKbiAeGh+a1kk6Pwnc2ZEuKviLyDSG6t0uXl56q7AALIxoM6FJrBSsVXA==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.0",
 				"json-stringify-safe": "^5.0.1",
-				"lodash.set": "^4.3.2",
+				"lodash": "^4.17.13",
+				"mkdirp": "^0.5.0",
 				"propagate": "^2.0.0"
 			}
 		},

--- a/packages/less/package.json
+++ b/packages/less/package.json
@@ -82,7 +82,7 @@
 		"mocha": "^6.2.1",
 		"mocha-headless-chrome": "^2.0.3",
 		"mocha-teamcity-reporter": "^3.0.0",
-		"nock": "^13.0.5",
+		"nock": "^11.8.2",
 		"npm-run-all": "^4.1.5",
 		"performance-now": "^0.2.0",
 		"phin": "^2.2.3",

--- a/packages/less/package.json
+++ b/packages/less/package.json
@@ -50,7 +50,7 @@
 		"image-size": "~0.5.0",
 		"make-dir": "^2.1.0",
 		"mime": "^1.4.1",
-		"native-request": "^1.0.5",
+		"needle": "^2.5.2",
 		"source-map": "~0.6.0"
 	},
 	"devDependencies": {
@@ -82,6 +82,7 @@
 		"mocha": "^6.2.1",
 		"mocha-headless-chrome": "^2.0.3",
 		"mocha-teamcity-reporter": "^3.0.0",
+		"nock": "^13.0.5",
 		"npm-run-all": "^4.1.5",
 		"performance-now": "^0.2.0",
 		"phin": "^2.2.3",

--- a/packages/test-data/less/import-redirect/import-redirect.less
+++ b/packages/test-data/less/import-redirect/import-redirect.less
@@ -1,0 +1,3 @@
+@import "https://example.com/redirect.less";
+
+h1 { color: red; }


### PR DESCRIPTION
Quick overview of the changes:

1. Replace `native-request` with [needle](https://www.npmjs.com/package/needle) - hopefully small enough http client to not be a burden.
2. Add [nock](https://www.npmjs.com/package/nock) based test to verify correct work of the redirect.
3. Moved `logger.addListener` call outside of `lessTester` factory function in `less/test/less-test.js`. This was necessary to avoid registering the same listeners twice as for the test it was necessary to instantiate `lessTester` one more time.
4. Created one more instance of `lessTester` in `less/test/index.js`. This is necessary since tests in the test suite are not isolated and leave `less` instance in the state in which remote imports are completely broken.