### PR TITLE
Fix `currentFileInfo` and `index` properties on nodes

### DIFF
--- a/packages/less/src/less/tree/node.js
+++ b/packages/less/src/less/tree/node.js
@@ -11,15 +11,14 @@ class Node {
         this.nodeVisible = undefined;
         this.rootNode = null;
         this.parsed = null;
+    }
 
-        const self = this;
-        Object.defineProperty(this, 'currentFileInfo', {
-            get: function() { return self.fileInfo(); }
-        });
-        Object.defineProperty(this, 'index', {
-            get: function() { return self.getIndex(); }
-        });
+    get currentFileInfo() {
+        return this.fileInfo();
+    }
 
+    get index() {
+        return this.getIndex();
     }
 
     setParent(nodes, parent) {


### PR DESCRIPTION
These fields are accessed by other tools such as parcel (for resolving local
asset URLs). As per 257efdd6884268af27beaceda467fd3a4aea5e08 the behavior with
(at least) parcel for relative paths in sub-directries changed. Prior to that
commit (last release 3.12.2) assets were resolved relative to the less module
that contains the `url(..)`. From release 3.13.0 parcel resolves assets relative
to the root less module, because no `currentFileInfo` is available.

This is caused by tree nodes setting their prototype to an instance of
`Node`. This leaves the `self` reference in `Node`s constructor pointing to the
prototype, not the actual instance the data is set on. Replacing this with
properties defined on `Node`s prototype fixes this.