### PR TITLE
feat(less-browser): support deno

### DIFF
--- a/packages/less/src/less-browser/bootstrap.js
+++ b/packages/less/src/less-browser/bootstrap.js
@@ -18,7 +18,9 @@ if (window.less) {
         }
     }
 }
-addDefaultOptions(window, options);
+if (typeof Deno === 'undefined') {
+    addDefaultOptions(window, options);
+}
 
 options.plugins = options.plugins || [];
 


### PR DESCRIPTION
don't add `defaultOptions` in deno.

https://esm.sh/less can work in browser, but will fail in deno.