### PR TITLE
Fix needle dependency warning typo.

### DIFF
--- a/packages/less/src/less-node/url-file-manager.js
+++ b/packages/less/src/less-node/url-file-manager.js
@@ -17,7 +17,7 @@ UrlFileManager.prototype = Object.assign(new AbstractFileManager(), {
                 catch (e) { request = null; }
             }
             if (!request) {
-                reject({ type: 'File', message: 'optional dependency \'native-request\' required to import over http(s)\n' });
+                reject({ type: 'File', message: 'optional dependency \'needle\' required to import over http(s)\n' });
                 return;
             }
 


### PR DESCRIPTION
The warning for using `@import url` without the optional `needle` dependency incorrectly specifies that `native-request` is the necessary package rather than `needle`.

Relates to the commit https://github.com/less/less.js/commit/ec7487586413f66e3a3da3ff6e5526868450e97b .