### PR TITLE
[skip ci] Add github CI status badge and npm downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 <p align="center"><img src="http://lesscss.org/public/img/less_logo.png" width="264" height="117">
-
-<p align="center"><a href="http://badge.fury.io/js/less"><img src="https://badge.fury.io/js/less.svg"></a> <a href="https://twitter.com/lesstocss"><img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/lesstocss.svg?style=flat-square" style="max-width:100%;"></a></p>
+    
+<p align="center">
+    <a href="https://github.com/less/less.js/actions?query=branch%3Amaster"><img src="https://github.com/less/less.js/actions/workflows/ci.yml/badge.svg?branch=master"/></a>
+    <a href="https://www.npmtrends.com/less"><img src="https://img.shields.io/npm/dm/less.svg?sanitize=true" alt="Downloads"></a>
+    <a href="https://www.npmjs.com/package/less"><img src="https://img.shields.io/npm/v/less.svg?sanitize=true" /></a>
+    <a href="https://twitter.com/lesstocss"><img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/lesstocss.svg?style=flat-square" style="max-width:100%;" /></a>
+</p>
 
 <p align="center"><a href="https://gitter.im/less/less.js?utm_source=badge&amp;utm_medium=badge&amp;utm_campaign=pr-badge&amp;utm_content=badge"><img src="https://badges.gitter.im/Join%20Chat.svg" style="max-width:100%;"></a> <br><sup class="rich-diff-level-one">Chat with Less.js users and contributors</sup></p>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center"><img src="http://lesscss.org/public/img/less_logo.png" width="264" height="117">
     
 <p align="center">
-    <a href="https://github.com/less/less.js/actions?query=branch%3Amaster"><img src="https://github.com/less/less.js/actions/workflows/ci.yml/badge.svg?branch=master"/></a>
+    <a href="https://github.com/less/less.js/actions?query=branch%3Amaster"><img src="https://github.com/less/less.js/actions/workflows/ci.yml/badge.svg?branch=master" alt="Github Actions CI"/></a>
     <a href="https://www.npmtrends.com/less"><img src="https://img.shields.io/npm/dm/less.svg?sanitize=true" alt="Downloads"></a>
     <a href="https://www.npmjs.com/package/less"><img src="https://img.shields.io/npm/v/less.svg?sanitize=true" /></a>
     <a href="https://twitter.com/lesstocss"><img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/lesstocss.svg?style=flat-square" style="max-width:100%;" /></a>


### PR DESCRIPTION
Add two badges(github actions ci / npm downloads) for better `README.md` information shown.
Even this PR is only a markdwon file change, so skip CI trigger

/cc @matthew-dean 

> https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci
GitHub Actions now supports skipping push and pull_request workflows by looking for some common keywords in your commit message.
>If any commit message in your push or the HEAD commit of your PR contains the strings [skip ci], [ci skip], [no ci], [skip actions], or [actions skip] workflows triggered on the push or pull_request events will be skipped.