### PR TITLE
chore: fix elisnt rules no-eq-null

### DIFF
--- a/packages/less/src/less/environment/environment.js
+++ b/packages/less/src/less/environment/environment.js
@@ -30,7 +30,7 @@ class Environment {
         if (!filename) {
             logger.warn('getFileManager called with no filename.. Please report this issue. continuing.');
         }
-        if (currentDirectory == null) {
+        if (currentDirectory === null) {
             logger.warn('getFileManager called with null directory.. Please report this issue. continuing.');
         }
 

--- a/packages/less/src/less/functions/default.js
+++ b/packages/less/src/less/functions/default.js
@@ -7,7 +7,7 @@ const defaultFunc = {
         if (e) {
             throw e;
         }
-        if (v != null) {
+        if (v !== null) {
             return v ? Keyword.True : Keyword.False;
         }
     },

--- a/packages/less/src/less/functions/math-helper.js
+++ b/packages/less/src/less/functions/math-helper.js
@@ -4,7 +4,7 @@ const MathHelper = (fn, unit, n) => {
     if (!(n instanceof Dimension)) {
         throw { type: 'Argument', message: 'argument must be a number' };
     }
-    if (unit == null) {
+    if (unit === null) {
         unit = n.unit;
     } else {
         n = n.unify();

--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -581,7 +581,7 @@ const Parser = function Parser(context, imports, fileInfo) {
 
                     expectChar(')');
 
-                    return new(tree.URL)((value.value != null || 
+                    return new(tree.URL)((value.value !== null || 
                         value instanceof tree.Variable || 
                         value instanceof tree.Property) ?
                         value : new(tree.Anonymous)(value, index), index, fileInfo);

--- a/packages/less/src/less/tree/node.js
+++ b/packages/less/src/less/tree/node.js
@@ -125,21 +125,21 @@ class Node {
 
     // Returns true if this node represents root of ast imported by reference
     blocksVisibility() {
-        if (this.visibilityBlocks == null) {
+        if (this.visibilityBlocks === null) {
             this.visibilityBlocks = 0;
         }
         return this.visibilityBlocks !== 0;
     }
 
     addVisibilityBlock() {
-        if (this.visibilityBlocks == null) {
+        if (this.visibilityBlocks === null) {
             this.visibilityBlocks = 0;
         }
         this.visibilityBlocks = this.visibilityBlocks + 1;
     }
 
     removeVisibilityBlock() {
-        if (this.visibilityBlocks == null) {
+        if (this.visibilityBlocks === null) {
             this.visibilityBlocks = 0;
         }
         this.visibilityBlocks = this.visibilityBlocks - 1;

--- a/packages/less/src/less/tree/quoted.js
+++ b/packages/less/src/less/tree/quoted.js
@@ -4,7 +4,7 @@ import Property from './property';
 
 
 const Quoted = function(str, content, escaped, index, currentFileInfo) {
-    this.escaped = (escaped == null) ? true : escaped;
+    this.escaped = (escaped === null) ? true : escaped;
     this.value = content || '';
     this.quote = str.charAt(0);
     this._index = index;

--- a/packages/less/src/less/tree/ruleset.js
+++ b/packages/less/src/less/tree/ruleset.js
@@ -734,7 +734,7 @@ Ruleset.prototype = Object.assign(new Node(), {
                 // non parent reference elements just get added
                 if (el.value !== '&') {
                     const nestedSelector = findNestedSelector(el);
-                    if (nestedSelector != null) {
+                    if (nestedSelector !== null) {
                         // merge the current list of non parent selector elements
                         // on to the current list of selectors to add
                         mergeElementsOnToSelectors(currentElements, newSelectors);

--- a/packages/less/src/less/tree/selector.js
+++ b/packages/less/src/less/tree/selector.js
@@ -33,7 +33,7 @@ Selector.prototype = Object.assign(new Node(), {
         elements = this.getElements(elements);
         const newSelector = new Selector(elements, extendList || this.extendList,
             null, this.getIndex(), this.fileInfo(), this.visibilityInfo());
-        newSelector.evaldCondition = (evaldCondition != null) ? evaldCondition : this.evaldCondition;
+        newSelector.evaldCondition = (evaldCondition !== null) ? evaldCondition : this.evaldCondition;
         newSelector.mediaEmpty = this.mediaEmpty;
         return newSelector;
     },


### PR DESCRIPTION
ESLint warning fix is a progressive work,  this PR is first step, just fix `no-eq-null` rules.
If CI passed, we can merge it. I think it's a safe change(~maybe 😄  ) /cc @matthew-dean 

> https://eslint.org/docs/rules/no-eq-null