### PR TITLE
Exclude function from imported file if its arguments are overridden by the importing file

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -444,6 +444,19 @@ const Parser = function Parser(context, imports, fileInfo) {
                         return;
                     }
 
+                    for (let i = 0; i < args.length; i++) {
+                        const arg = args[i];
+                        // Do not call function with variable argument if this file is being imported by another file
+                        // and said variable is being redefined by the importing file
+                        if (fileInfo.filename !== fileInfo.rootFilename
+                            && imports.contents[fileInfo.rootFilename].match(arg.name + '\\s*:')
+                            && arg.name.match(/^(@[\w-]+)/)
+                        )
+                        {
+                            return;
+                        }
+                    }
+
                     parserInput.forget();
 
                     return new(tree.Call)(name, args, index, fileInfo);

--- a/packages/test-data/css/_main/import-reference-issues.css
+++ b/packages/test-data/css/_main/import-reference-issues.css
@@ -22,3 +22,7 @@ show-all-content .something {
 call-mixin-with-import-by-reference-inside {
   the-only-property: nothing-below-this;
 }
+.class-with-overridden-variables {
+  color: var(--primary-color);
+  backgroundColor: var(--bg-color);
+}

--- a/packages/test-data/less/_main/import-reference-issues.less
+++ b/packages/test-data/less/_main/import-reference-issues.less
@@ -48,3 +48,8 @@ show-all-content {
 call-mixin-with-import-by-reference-inside {
   .mixin-with-import-by-reference-inside();
 }
+
+// #3563 - Lazy variables of css custom properties with less functions (even if it's overwritten) will break building
+@import "import-reference-issues/overridden-arguments-3563.less";
+@base-color: var(--primary-color);
+@dark-color: var(--bg-color);

--- a/packages/test-data/less/_main/import-reference-issues/overridden-arguments-3563.less
+++ b/packages/test-data/less/_main/import-reference-issues/overridden-arguments-3563.less
@@ -1,0 +1,7 @@
+@base-color: green;
+@dark-color: darken(@base-color, 50%);
+
+.class-with-overridden-variables {
+    color: @base-color;
+    backgroundColor: @dark-color;
+}


### PR DESCRIPTION
This addresses issue #3563 by excluding functions in an imported file whose variable arguments are overridden by the file that is importing it. For every argument in the function, 3 things are checked:

1. Is there a difference between `filename` and `rootFilename` for this file, i.e. is this a file that is being imported by another file?
2. Does the root file contain a redefinition of the variable?
3. Is this a variable argument?

If all 3 of these conditions are met for any of the arguments, the function is excluded from the final output, and any variables using this function to obtain a value remain undefined. Since silently ignoring these functions might lead to unexpected behaviors, perhaps Less could signal to the user in some way that it's doing this?