### PR TITLE
fix: change keyword plugin and import regexp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .idea
 *.iml
 *.sublime-*
+.DS_Store
 
 # npm
 node_modules

--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -1684,7 +1684,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                 let features;
                 const index = parserInput.i;
 
-                const dir = parserInput.$re(/^@import?\s+/);
+                const dir = parserInput.$re(/^@import\s+/);
 
                 if (dir) {
                     const options = (dir ? this.importOptions() : null) || {};
@@ -1844,7 +1844,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                 let args;
                 let options;
                 const index = parserInput.i;
-                const dir   = parserInput.$re(/^@plugin?\s+/);
+                const dir   = parserInput.$re(/^@plugin\s+/);
 
                 if (dir) {
                     args = this.pluginArgs();

--- a/packages/test-data/css/_main/impor.css
+++ b/packages/test-data/css/_main/impor.css
@@ -1,1 +1,1 @@
-@impor "impor-type-dont-parse-as-import.less";
+@impor "impor-typo-dont-parse-as-@import.less";

--- a/packages/test-data/css/_main/impor.css
+++ b/packages/test-data/css/_main/impor.css
@@ -1,0 +1,1 @@
+@impor "impor-type-dont-parse-as-import.less";

--- a/packages/test-data/css/_main/plugi.css
+++ b/packages/test-data/css/_main/plugi.css
@@ -1,1 +1,1 @@
-@plugi "clean-css";
+@plugi "plugi-typo-dont-parse-as-@plugin";

--- a/packages/test-data/css/_main/plugi.css
+++ b/packages/test-data/css/_main/plugi.css
@@ -1,0 +1,1 @@
+@plugi "clean-css";

--- a/packages/test-data/errors/parse/impor-typo.less
+++ b/packages/test-data/errors/parse/impor-typo.less
@@ -1,0 +1,1 @@
+@impor "this-impor-is-invalid.less"

--- a/packages/test-data/errors/parse/impor-typo.less
+++ b/packages/test-data/errors/parse/impor-typo.less
@@ -1,1 +1,0 @@
-@impor "this-impor-is-invalid.less"

--- a/packages/test-data/less/_main/impor.less
+++ b/packages/test-data/less/_main/impor.less
@@ -2,4 +2,4 @@
 // const dir = parserInput.$re(/^@import?\s+/);
 // correct regexp is /^@import\s+/
 // so follow code will change nothing, parse result is same with raw less code
-@impor "impor-type-dont-parse-as-import.less";
+@impor "impor-typo-dont-parse-as-@import.less";

--- a/packages/test-data/less/_main/impor.less
+++ b/packages/test-data/less/_main/impor.less
@@ -1,0 +1,5 @@
+// https://github.com/less/less.js/issues/3660
+// const dir = parserInput.$re(/^@import?\s+/);
+// correct regexp is /^@import\s+/
+// so follow code will change nothing, parse result is same with raw less code
+@impor "impor-type-dont-parse-as-import.less";

--- a/packages/test-data/less/_main/plugi.less
+++ b/packages/test-data/less/_main/plugi.less
@@ -2,4 +2,4 @@
 // const dir = parserInput.$re(/^@plugin?\s+/);
 // correct regexp is /^@plugin\s+/
 // so follow code will change nothing, parse result is same with raw less code
-@plugi "clean-css";
+@plugi "plugi-typo-dont-parse-as-@plugin";

--- a/packages/test-data/less/_main/plugi.less
+++ b/packages/test-data/less/_main/plugi.less
@@ -1,0 +1,5 @@
+// https://github.com/less/less.js/issues/3660
+// const dir = parserInput.$re(/^@plugin?\s+/);
+// correct regexp is /^@plugin\s+/
+// so follow code will change nothing, parse result is same with raw less code
+@plugi "clean-css";


### PR DESCRIPTION
Try to fix https://github.com/less/less.js/issues/3660

> We discovered that the regex used for `import` and `plugin` have a `?` at the end of them, which means `@plugi` and `@impor` work as well as `@plugin` and `@import`.
These are defined here: https://github.com/less/less.js/blob/master/packages/less/src/less/parser/parser.js#L1687 and https://github.com/less/less.js/blob/master/packages/less/src/less/parser/parser.js#L1847.
This doesn't look like an intentional decision and more of a regex mistake. See here for example inputs: https://regex101.com/r/NUw7E2/2
Is this correct?  --from @edhgoose

https://github.com/less/less.js/blob/a4b6c8544c077a193a3d39955db76047545f1539/packages/less/src/less/parser/parser.js#L1687

https://github.com/less/less.js/blob/a4b6c8544c077a193a3d39955db76047545f1539/packages/less/src/less/parser/parser.js#L1847

ready for code review, cc @matthew-dean . btw, i add `.DS_Store` into `.gitignore`

- [x] code complete
- [x] unit test 
