### PR TITLE
ci: reduce ci times and add node17 test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,13 @@ name: Nodejs Test
 on: [push, pull_request]
 
 jobs:
-  test:
+  platform_spec_test:
     name: 'Tests on ${{matrix.os}} with node${{matrix.node}}'
     strategy:
       matrix:
         # Test all mainstream operating system
         os: [ubuntu-latest, macos-latest, windows-latest]
-        # Latest four Nodejs LTS version
-        node: [10, 12, 14, 16]
+        node: [16]
     runs-on: ${{ matrix.os }}
     steps:
      # Pull repo to test machine
@@ -22,7 +21,6 @@ jobs:
        with:
          # The Node.js version to configure
          node-version: ${{ matrix.node }}
-         
      # Caching dependencies to speed up workflows    
      - name: Get npm cache directory
        id: npm-cache-dir
@@ -35,13 +33,29 @@ jobs:
          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
          restore-keys: |
            ${{ runner.os }}-node-
-
      - name: Install npm dependencies
        run: npm install
-
      - name: Print put node & npm version
        # Output useful info for debugging.
        run: node --version && npm --version 
+     - name: Run unit test
+       run: cd packages/less && npm test
 
+  fast_node_test:
+    name: 'Tests on ${{matrix.os}} with node${{matrix.node}}'
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [10, 12, 14, 17]
+    runs-on: ${{ matrix.os }}
+    steps:
+     - uses: actions/checkout@v2
+     - uses: actions/setup-node@v2
+       with:
+         node-version: ${{ matrix.node }}
+     - name: Install npm dependencies
+       run: npm install
+     - name: Print put node & npm version
+       run: node --version && npm --version 
      - name: Run unit test
        run: cd packages/less && npm test


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

| previous ci config | new ci config |
| :--- | :---- |
| matrix tests node(10/12/14/16) with os(win/mac/linux) | matrix tests node16 with os(win/mac/linux) and node(10,12,14,17) width ubuntu | 
| Total 12 tests suite |  Total 7 tests suite |

<img src="https://user-images.githubusercontent.com/14012511/143806701-54b31c5e-3e44-4fdf-840b-27c223d7921e.png" width="750px" />

<!-- Why are these changes necessary? -->

**Why**:

Too many Redundant tests ci, reconfig to reduce ci times and failures ( https://github.com/less/less.js/actions?query=is%3Afailure )

<!-- How were these changes implemented? -->

**How**:

Change `ci.yml`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Added/updated unit tests
- [ ] Code complete

<!-- feel free to add additional comments -->

cc @matthew-dean 
