### PR TITLE
Fix #3698 #3373 - parsing variables fail when there is no trailing semicolon

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -1541,7 +1541,7 @@ const Parser = function Parser(context, imports, fileInfo) {
 
                         // Custom property values get permissive parsing
                         if (name[0].value && name[0].value.slice(0, 2) === '--') {
-                            value = this.permissiveValue();
+                            value = this.permissiveValue(/[;}]/);
                         }
                         // Try to store values as anonymous
                         // If we need the value later we'll re-parse it in ruleset.parseValue

--- a/packages/test-data/css/_main/permissive-parse.css
+++ b/packages/test-data/css/_main/permissive-parse.css
@@ -35,3 +35,12 @@ foo[attr="blah"] {
   --value: a /* { ; } */;
   --comment-within: ( /* okay?; comment; */ );
 }
+.test-no-trailing-semicolon {
+  --value: foo;
+}
+.test-no-trailing-semicolon2 {
+  --value: foo;
+}
+.test-no-trailing-semicolon3 {
+  --value: foo;
+}

--- a/packages/test-data/less/_main/permissive-parse.less
+++ b/packages/test-data/less/_main/permissive-parse.less
@@ -48,3 +48,8 @@
   --value: a/* { ; } */;
   --comment-within: ( /* okay?; comment; */ );
 }
+.test-no-trailing-semicolon {
+  --value: foo
+}
+.test-no-trailing-semicolon2 {--value: foo}
+.test-no-trailing-semicolon3 { --value: foo }


### PR DESCRIPTION
**What**:

Added a fix for the parser crashing when a css variable property does not end with a semicolon. Fixes #3698 and Fixes  #3373.

**Why**:

This helps to avoid crashes when importing pre-minified css files from e.g. an npm package. In our case, [cssnano](https://cssnano.co/) always drops the trailing semicolon on the last property. This cannot be disabled without disabling all of whitespace normalization (`normalizeWhitespace` option). Fixing the bug in Less.js fixes this use case for us.

**How**:

When calling `permissiveValue` on a detected css variable, the `untilTokens` parameter is left unset. This defaults it to detecting `;` for ending the value. I've set the parameter to `/[;}]/` instead in order to close variables on either the semicolon (`;`) or the closing curly bracket (`}`) character. This may not be the most optimal fix, but it gets the job done in the test cases I've added. Additionally, it doesn't break any of the existing test cases.

**Checklist**:

- [ ] Documentation N/A
- [x] Added/updated unit tests
- [x] Code complete
