### PR TITLE
feat: add `disablePlugins` flag for render() options

### DIFF
--- a/packages/less/bin/lessc
+++ b/packages/less/bin/lessc
@@ -90,8 +90,8 @@ function render() {
     output = path.resolve(process.cwd(), output);
   }
 
-  if (options.disablePlugins && queuePlugins.length > 0) {
-    console.error('--plugin and --disable-plugins may not be used at the same time');
+  if (options.disablePluginRule && queuePlugins.length > 0) {
+    console.error('--plugin and --disable-plugin-rule may not be used at the same time');
     process.exitCode = 1;
     return;
   }
@@ -640,8 +640,8 @@ function processPluginQueue() {
         });
         break;
 
-      case 'disable-plugins':
-        options.disablePlugins = true;
+      case 'disable-plugin-rule':
+        options.disablePluginRule = true;
         break;
   
       default:

--- a/packages/less/bin/lessc
+++ b/packages/less/bin/lessc
@@ -91,7 +91,7 @@ function render() {
   }
 
   if (options.disablePlugins && queuePlugins.length > 0) {
-    console.error('--plugin and --disable-plugings may not be used at the same time');
+    console.error('--plugin and --disable-plugins may not be used at the same time');
     process.exitCode = 1;
     return;
   }

--- a/packages/less/bin/lessc
+++ b/packages/less/bin/lessc
@@ -90,6 +90,12 @@ function render() {
     output = path.resolve(process.cwd(), output);
   }
 
+  if (options.disablePlugins && queuePlugins.length > 0) {
+    console.error('--plugin and --disable-plugings may not be used at the same time');
+    process.exitCode = 1;
+    return;
+  }
+
   if (options.sourceMap) {
     sourceMapOptions.sourceMapInputFilename = input;
 
@@ -634,6 +640,10 @@ function processPluginQueue() {
         });
         break;
 
+      case 'disable-plugins':
+        options.disablePlugins = true;
+        break;
+  
       default:
         queuePlugins.push({
           name: arg,

--- a/packages/less/bin/lessc
+++ b/packages/less/bin/lessc
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+/* eslint indent: [2, 2, {"SwitchCase": 1}] */
+
 "use strict";
 
 var path = require('path');
@@ -113,6 +116,7 @@ function render() {
       var mapDir = path.dirname(mapFilename);
       var outputDir = path.dirname(output); // find the path from the map to the output file
 
+      // eslint-disable-next-line max-len
       sourceMapOptions.sourceMapOutputFilename = path.join(path.relative(mapDir, outputDir), path.basename(output)); // make the sourcemap filename point to the sourcemap relative to the css file output directory
 
       sourceMapOptions.sourceMapFilename = path.join(path.relative(outputDir, mapDir), path.basename(sourceMapOptions.sourceMapFullFilename));
@@ -180,8 +184,8 @@ function render() {
       var filename = sourceMapOptions.sourceMapFullFilename;
       ensureDirectory(filename);
 
-      //To fix https://github.com/less/less.js/issues/3646
-      output=output.toString();
+      // To fix https://github.com/less/less.js/issues/3646
+      output = output.toString();
       
       fs.writeFile(filename, output, 'utf8', function (err) {
         if (err) {
@@ -444,7 +448,8 @@ function processPluginQueue() {
         break;
 
       case 'no-js':
-        console.error('The "--no-js" argument is deprecated, as inline JavaScript ' + 'is disabled by default. Use "--js" to enable inline JavaScript (not recommended).');
+        // eslint-disable-next-line max-len
+        console.error('The "--no-js" argument is deprecated, as inline JavaScript is disabled by default. Use "--js" to enable inline JavaScript (not recommended).');
         break;
 
       case 'include-path':

--- a/packages/less/src/less-browser/utils.js
+++ b/packages/less/src/less-browser/utils.js
@@ -9,7 +9,7 @@ export function extractId(href) {
 }
 
 export function addDataAttr(options, tag) {
-	if(!tag) return; // in case of tag is null or undefined
+    if (!tag) {return;} // in case of tag is null or undefined
     for (const opt in tag.dataset) {
         if (tag.dataset.hasOwnProperty(opt)) {
             if (opt === 'env' || opt === 'dumpLineNumbers' || opt === 'rootpath' || opt === 'errorReporting') {

--- a/packages/less/src/less-node/lessc-helper.js
+++ b/packages/less/src/less-node/lessc-helper.js
@@ -67,7 +67,7 @@ const lessc_helper = {
         console.log('                               --plugin=less-plugin-clean-css or just --clean-css');
         console.log('                               specify options afterwards e.g. --plugin=less-plugin-clean-css="advanced"');
         console.log('                               or --clean-css="advanced"');
-        console.log('  --disable-plugins            Disallow @plugin statements');
+        console.log('  --disable-plugin-rule        Disallow @plugin statements');
         console.log('');
         console.log('-------------------------- Deprecated ----------------');
         console.log('  -sm=on|off               Legacy parens-only math. Use --math');

--- a/packages/less/src/less-node/lessc-helper.js
+++ b/packages/less/src/less-node/lessc-helper.js
@@ -67,6 +67,7 @@ const lessc_helper = {
         console.log('                               --plugin=less-plugin-clean-css or just --clean-css');
         console.log('                               specify options afterwards e.g. --plugin=less-plugin-clean-css="advanced"');
         console.log('                               or --clean-css="advanced"');
+        console.log('  --disable-plugins            Disallow @plugin statements');
         console.log('');
         console.log('-------------------------- Deprecated ----------------');
         console.log('  -sm=on|off               Legacy parens-only math. Use --math');

--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -156,11 +156,11 @@ const Parser = function Parser(context, imports, fileInfo) {
             let preText = '';
 
             // Optionally disable @plugin parsing
-            if (additionalData && additionalData.disablePlugins) {
+            if (additionalData && additionalData.disablePluginRule) {
                 parsers.plugin = function() {
                     var dir = parserInput.$re(/^@plugin?\s+/);
                     if (dir) {
-                        error('@plugin statements are not allowed when disablePlugins is set to true');
+                        error('@plugin statements are not allowed when disablePluginRule is set to true');
                     }
                 }
             };

--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -149,11 +149,21 @@ const Parser = function Parser(context, imports, fileInfo) {
         //
         parse: function (str, callback, additionalData) {
             let root;
-            let error = null;
+            let err = null;
             let globalVars;
             let modifyVars;
             let ignored;
             let preText = '';
+
+            // Optionally disable @plugin parsing
+            if (additionalData && additionalData.disablePlugins) {
+                parsers.plugin = function() {
+                    var dir = parserInput.$re(/^@plugin?\s+/);
+                    if (dir) {
+                        error('@plugin not supported');
+                    }
+                }
+            };
 
             globalVars = (additionalData && additionalData.globalVars) ? `${Parser.serializeVars(additionalData.globalVars)}\n` : '';
             modifyVars = (additionalData && additionalData.modifyVars) ? `\n${Parser.serializeVars(additionalData.modifyVars)}` : '';
@@ -226,7 +236,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                     }
                 }
 
-                error = new LessError({
+                err = new LessError({
                     type: 'Parse',
                     message,
                     index: endInfo.furthest,
@@ -235,7 +245,7 @@ const Parser = function Parser(context, imports, fileInfo) {
             }
 
             const finish = e => {
-                e = error || e || imports.error;
+                e = err || e || imports.error;
 
                 if (e) {
                     if (!(e instanceof LessError)) {

--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -160,7 +160,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                 parsers.plugin = function() {
                     var dir = parserInput.$re(/^@plugin?\s+/);
                     if (dir) {
-                        error('@plugin not supported');
+                        error('@plugin statements are not allowed when disablePlugins is set to true');
                     }
                 }
             };

--- a/packages/less/test/index.js
+++ b/packages/less/test/index.js
@@ -88,7 +88,7 @@ lessTester.testSyncronous({syncImport: true}, '_main/import');
 lessTester.testSyncronous({syncImport: true}, '_main/plugin');
 lessTester.testSyncronous({syncImport: true}, 'math/strict/css');
 lessTester.testNoOptions();
-lessTester.testDisablePlugins();
+lessTester.testDisablePluginRule();
 lessTester.testJSImport();
 lessTester.finished();
 

--- a/packages/less/test/index.js
+++ b/packages/less/test/index.js
@@ -88,6 +88,7 @@ lessTester.testSyncronous({syncImport: true}, '_main/import');
 lessTester.testSyncronous({syncImport: true}, '_main/plugin');
 lessTester.testSyncronous({syncImport: true}, 'math/strict/css');
 lessTester.testNoOptions();
+lessTester.testDisablePlugins();
 lessTester.testJSImport();
 lessTester.finished();
 

--- a/packages/less/test/less-test.js
+++ b/packages/less/test/less-test.js
@@ -568,7 +568,9 @@ module.exports = function() {
             '@plugin "../../plugin/some_plugin";',
             {disablePlugins: true},
             function(err) {
-                const EXPECTED = '@plugin not supported';
+                // TODO: Need a better way of identifing exactly which error is thrown.  Checking
+                // text like this tends to be rather brittle.
+                const EXPECTED = '@plugin statements are not allowed when disablePlugins is set to true';
                 if (!err || String(err).indexOf(EXPECTED) < 0) {
                     fail('ERROR: Expected "' + EXPECTED + '" error');
                     return;

--- a/packages/less/test/less-test.js
+++ b/packages/less/test/less-test.js
@@ -563,6 +563,21 @@ module.exports = function() {
         };
     }
 
+    function testDisablePlugins() {
+        less.render(
+            '@plugin "../../plugin/some_plugin";',
+            {disablePlugins: true},
+            function(err) {
+                const EXPECTED = '@plugin not supported';
+                if (!err || String(err).indexOf(EXPECTED) < 0) {
+                    fail('ERROR: Expected "' + EXPECTED + '" error');
+                    return;
+                }
+                ok(stylize('OK\n', 'green'));
+            }
+        );      
+    }
+
     return {
         runTestSet: runTestSet,
         runTestSetNormalOnly: runTestSetNormalOnly,
@@ -575,6 +590,7 @@ module.exports = function() {
         testImportRedirect: testImportRedirect,
         testEmptySourcemap: testEmptySourcemap,
         testNoOptions: testNoOptions,
+        testDisablePlugins: testDisablePlugins,
         testJSImport: testJSImport,
         finished: finished
     };

--- a/packages/less/test/less-test.js
+++ b/packages/less/test/less-test.js
@@ -563,14 +563,14 @@ module.exports = function() {
         };
     }
 
-    function testDisablePlugins() {
+    function testDisablePluginRule() {
         less.render(
             '@plugin "../../plugin/some_plugin";',
-            {disablePlugins: true},
+            {disablePluginRule: true},
             function(err) {
                 // TODO: Need a better way of identifing exactly which error is thrown.  Checking
                 // text like this tends to be rather brittle.
-                const EXPECTED = '@plugin statements are not allowed when disablePlugins is set to true';
+                const EXPECTED = '@plugin statements are not allowed when disablePluginRule is set to true';
                 if (!err || String(err).indexOf(EXPECTED) < 0) {
                     fail('ERROR: Expected "' + EXPECTED + '" error');
                     return;
@@ -592,7 +592,7 @@ module.exports = function() {
         testImportRedirect: testImportRedirect,
         testEmptySourcemap: testEmptySourcemap,
         testNoOptions: testNoOptions,
-        testDisablePlugins: testDisablePlugins,
+        testDisablePluginRule: testDisablePluginRule,
         testJSImport: testJSImport,
         finished: finished
     };


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:  

Adds support for a `options.disablePlugins` flag on the `less.render()` method.  Setting this to true disables parsing of `@plugin` statements and, instead, throws an error.

**Why**:

As `@plugin` statements may be used to run arbitrary system commands.  This is a significant security risk for applications that need to process untrusted code.  At a minimum, applications should be able to disable parsing of `@plugin` statements.

As noted by my colleague @shshaw here at CodePen, we ended up forking this repo so we could disable `@plugin` processing.  Adding this option will allow us and our users to stay current with the official `less` codebase.
 
See also:
* https://github.com/less/less.js/issues/3561
* https://github.com/codepen/cp/issues/1195

**How**:

Calling `less.render(inputString, {disablePlugins: true})` activates the new codepath.  With this option enabled, the `parsers.plugin()` method is replaced with one that failes with an error when an `@plugin` statement is detected.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation   N/A (where are the docs in this repo?)
- [x] Added/updated unit tests
- [x] Code complete