### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/less/src/less-node/plugin-loader.js
+++ b/packages/less/src/less-node/plugin-loader.js
@@ -9,7 +9,7 @@ const PluginLoader = function(less) {
     this.require = prefix => {
         prefix = path.dirname(prefix);
         return id => {
-            const str = id.substr(0, 2);
+            const str = id.slice(0, 2);
             if (str === '..' || str === './') {
                 return require(path.join(prefix, id));
             }

--- a/packages/less/src/less/less-error.js
+++ b/packages/less/src/less/less-error.js
@@ -52,7 +52,7 @@ const LessError = function(e, fileContentMap, currentFilename) {
             /**
              * We have to figure out how this environment stringifies anonymous functions
              * so we can correctly map plugin errors.
-             * 
+             *
              * Note, in Node 8, the output of anonymous funcs varied based on parameters
              * being present or not, so we inject dummy params.
              */
@@ -129,7 +129,7 @@ LessError.prototype.toString = function(options) {
             let errorTxt = `${this.line} `;
             if (extract[1]) {
                 errorTxt += extract[1].slice(0, this.column) +
-                    stylize(stylize(stylize(extract[1].substr(this.column, 1), 'bold') +
+                    stylize(stylize(stylize(extract[1].slice(this.column, this.column + 1), 'bold') +
                         extract[1].slice(this.column + 1), 'red'), 'inverse');
             }
             error.push(errorTxt);

--- a/packages/less/src/less/parser/parser-input.js
+++ b/packages/less/src/less/parser/parser-input.js
@@ -58,7 +58,7 @@ export default () => {
                         nextNewLine = endIndex;
                     }
                     parserInput.i = nextNewLine;
-                    comment.text = inp.substr(comment.index, parserInput.i - comment.index);
+                    comment.text = inp.slice(comment.index, parserInput.i);
                     parserInput.commentStore.push(comment);
                     continue;
                 } else if (nextChar === '*') {
@@ -66,7 +66,7 @@ export default () => {
                     if (nextStarSlash >= 0) {
                         comment = {
                             index: parserInput.i,
-                            text: inp.substr(parserInput.i, nextStarSlash + 2 - parserInput.i),
+                            text: inp.slice(parserInput.i, nextStarSlash + 2),
                             isLineComment: false
                         };
                         parserInput.i += comment.text.length - 1;
@@ -183,7 +183,7 @@ export default () => {
                 case '\n':
                     break;
                 case startChar:
-                    const str = input.substr(currentPosition, i + 1);
+                    const str = input.slice(currentPosition, currentPosition + i + 1);
                     if (!loc && loc !== 0) {
                         skipWhitespace(i + 1);
                         return str
@@ -223,7 +223,7 @@ export default () => {
             let prevChar;
             let nextChar = input.charAt(i);
             if (blockDepth === 0 && testChar(nextChar)) {
-                returnVal = input.substr(lastPos, i - lastPos);
+                returnVal = input.slice(lastPos, i);
                 if (returnVal) {
                     parseGroups.push(returnVal);
                 }
@@ -235,7 +235,7 @@ export default () => {
                 loop = false
             } else {
                 if (inComment) {
-                    if (nextChar === '*' && 
+                    if (nextChar === '*' &&
                         input.charAt(i + 1) === '/') {
                         i++;
                         blockDepth--;
@@ -248,7 +248,7 @@ export default () => {
                     case '\\':
                         i++;
                         nextChar = input.charAt(i);
-                        parseGroups.push(input.substr(lastPos, i - lastPos + 1));
+                        parseGroups.push(input.slice(lastPos, i + 1));
                         lastPos = i + 1;
                         break;
                     case '/':
@@ -262,7 +262,7 @@ export default () => {
                     case '"':
                         quote = parserInput.$quoted(i);
                         if (quote) {
-                            parseGroups.push(input.substr(lastPos, i - lastPos), quote);
+                            parseGroups.push(input.slice(lastPos, i), quote);
                             i += quote[1].length - 1;
                             lastPos = i + 1;
                         }

--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -60,7 +60,7 @@ const Parser = function Parser(context, imports, fileInfo) {
         if (result) {
             return result;
         }
-        
+
         error(msg || (typeof arg === 'string'
             ? `expected '${arg}' got '${parserInput.currentChar()}'`
             : 'unexpected token'));
@@ -85,8 +85,8 @@ const Parser = function Parser(context, imports, fileInfo) {
 
     /**
      *  Used after initial parsing to create nodes on the fly
-     * 
-     *  @param {String} str          - string to parse 
+     *
+     *  @param {String} str          - string to parse
      *  @param {Array}  parseList    - array of parsers to run input through e.g. ["value", "important"]
      *  @param {Number} currentIndex - start number to begin indexing
      *  @param {Object} fileInfo     - fileInfo to attach to created nodes
@@ -197,7 +197,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                 root.root = true;
                 root.firstRoot = true;
                 root.functionRegistry = functionRegistry.inherit();
-                
+
             } catch (e) {
                 return callback(new LessError(e, imports, fileInfo.filename));
             }
@@ -327,7 +327,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                         continue;
                     }
 
-                    node = mixin.definition() || this.declaration() || mixin.call(false, false) || 
+                    node = mixin.definition() || this.declaration() || mixin.call(false, false) ||
                         this.ruleset() || this.variableCall() || this.entities.call() || this.atrule();
                     if (node) {
                         root.push(node);
@@ -386,7 +386,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                     }
                     parserInput.forget();
 
-                    return new(tree.Quoted)(str.charAt(0), str.substr(1, str.length - 2), isEscaped, index, fileInfo);
+                    return new(tree.Quoted)(str.charAt(0), str.slice(1, -1), isEscaped, index, fileInfo);
                 },
 
                 //
@@ -423,7 +423,7 @@ const Parser = function Parser(context, imports, fileInfo) {
 
                     name = parserInput.$re(/^([\w-]+|%|~|progid:[\w\.]+)\(/);
                     if (!name) {
-                        parserInput.forget(); 
+                        parserInput.forget();
                         return;
                     }
 
@@ -448,7 +448,7 @@ const Parser = function Parser(context, imports, fileInfo) {
 
                     return new(tree.Call)(name, args, index, fileInfo);
                 },
-                
+
                 //
                 // Parsing rules for functions with non-standard args, e.g.:
                 //
@@ -471,11 +471,11 @@ const Parser = function Parser(context, imports, fileInfo) {
                     function f(parse, stop) {
                         return {
                             parse, // parsing function
-                            stop   // when true - stop after parse() and return its result, 
+                            stop   // when true - stop after parse() and return its result,
                             // otherwise continue for plain args
                         };
                     }
-                
+
                     function condition() {
                         return [expect(parsers.condition, 'expected condition')];
                     }
@@ -581,8 +581,8 @@ const Parser = function Parser(context, imports, fileInfo) {
 
                     expectChar(')');
 
-                    return new(tree.URL)((value.value != null || 
-                        value instanceof tree.Variable || 
+                    return new(tree.URL)((value.value != null ||
+                        value instanceof tree.Variable ||
                         value instanceof tree.Property) ?
                         value : new(tree.Anonymous)(value, index), index, fileInfo);
                 },
@@ -664,7 +664,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                         if (!rgb[2]) {
                             parserInput.forget();
                             return new(tree.Color)(rgb[1], undefined, rgb[0]);
-                        } 
+                        }
                     }
                     parserInput.restore();
                 },
@@ -739,7 +739,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                     js = parserInput.$re(/^[^`]*`/);
                     if (js) {
                         parserInput.forget();
-                        return new(tree.JavaScript)(js.substr(0, js.length - 1), Boolean(escape), index, fileInfo);
+                        return new(tree.JavaScript)(js.slice(0, -1), Boolean(escape), index, fileInfo);
                     }
                     parserInput.restore('invalid javascript definition');
                 }
@@ -946,7 +946,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                     while (true) {
                         elemIndex = parserInput.i;
                         e = parserInput.$re(re);
-                        
+
                         if (!e) {
                             break;
                         }
@@ -1157,13 +1157,13 @@ const Parser = function Parser(context, imports, fileInfo) {
                         parserInput.restore();
                     }
                 },
-            
+
                 ruleLookups: function() {
                     let rule;
                     let args;
                     const lookups = [];
 
-                    if (parserInput.currentChar() !== '[') { 
+                    if (parserInput.currentChar() !== '[') {
                         return;
                     }
 
@@ -1182,27 +1182,27 @@ const Parser = function Parser(context, imports, fileInfo) {
                         return lookups;
                     }
                 },
-    
+
                 lookupValue: function() {
                     parserInput.save();
-    
-                    if (!parserInput.$char('[')) { 
+
+                    if (!parserInput.$char('[')) {
                         parserInput.restore();
                         return;
                     }
-    
+
                     const name = parserInput.$re(/^(?:[@$]{0,2})[_a-zA-Z0-9-]*/);
-    
+
                     if (!parserInput.$char(']')) {
                         parserInput.restore();
                         return;
-                    } 
+                    }
 
                     if (name || name === '') {
                         parserInput.forget();
                         return name;
                     }
-    
+
                     parserInput.restore();
                 }
             },
@@ -1456,7 +1456,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                 parserInput.save();
                 if (parserInput.$re(/^[.#]\(/)) {
                     /**
-                     * DR args currently only implemented for each() function, and not 
+                     * DR args currently only implemented for each() function, and not
                      * yet settable as `@dr: #(@arg) {}`
                      * This should be done when DRs are merged with mixins.
                      * See: https://github.com/less/less-meta/issues/16
@@ -1588,7 +1588,7 @@ const Parser = function Parser(context, imports, fileInfo) {
              * Used for custom properties, at-rules, and variables (as fallback)
              * Parses almost anything inside of {} [] () "" blocks
              * until it reaches outer-most tokens.
-             * 
+             *
              * First, it will try to parse comments and entities to reach
              * the end. This is mostly like the Expression parser except no
              * math is allowed.
@@ -1894,7 +1894,7 @@ const Parser = function Parser(context, imports, fileInfo) {
                     parserInput.forget();
                     return args[1].trim();
                 }
-                else { 
+                else {
                     parserInput.restore();
                     return null;
                 }

--- a/packages/less/src/less/tree/dimension.js
+++ b/packages/less/src/less/tree/dimension.js
@@ -53,7 +53,7 @@ Dimension.prototype = Object.assign(new Node(), {
 
             // Float values doesn't need a leading zero
             if (value > 0 && value < 1) {
-                strValue = (strValue).substr(1);
+                strValue = (strValue).slice(1);
             }
         }
 

--- a/packages/less/src/less/tree/namespace-value.js
+++ b/packages/less/src/less/tree/namespace-value.js
@@ -15,7 +15,7 @@ NamespaceValue.prototype = Object.assign(new Node(), {
 
     eval(context) {
         let i, j, name, rules = this.value.eval(context);
-        
+
         for (i = 0; i < this.lookups.length; i++) {
             name = this.lookups[i];
 
@@ -33,12 +33,12 @@ NamespaceValue.prototype = Object.assign(new Node(), {
             }
             else if (name.charAt(0) === '@') {
                 if (name.charAt(1) === '@') {
-                    name = `@${new Variable(name.substr(1)).eval(context).value}`;
+                    name = `@${new Variable(name.slice(1)).eval(context).value}`;
                 }
                 if (rules.variables) {
                     rules = rules.variable(name);
                 }
-                
+
                 if (!rules) {
                     throw { type: 'Name',
                         message: `variable ${name} not found`,
@@ -48,7 +48,7 @@ NamespaceValue.prototype = Object.assign(new Node(), {
             }
             else {
                 if (name.substring(0, 2) === '$@') {
-                    name = `$${new Variable(name.substr(1)).eval(context).value}`;
+                    name = `$${new Variable(name.slice(1)).eval(context).value}`;
                 }
                 else {
                     name = name.charAt(0) === '$' ? name : `$${name}`;
@@ -56,10 +56,10 @@ NamespaceValue.prototype = Object.assign(new Node(), {
                 if (rules.properties) {
                     rules = rules.property(name);
                 }
-            
+
                 if (!rules) {
                     throw { type: 'Name',
-                        message: `property "${name.substr(1)}" not found`,
+                        message: `property "${name.slice(1)}" not found`,
                         filename: this.fileInfo().filename,
                         index: this.getIndex() };
                 }


### PR DESCRIPTION
**What**:

Replacing usage of `.substr()` with `.slice()`

**Why**:

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated.

**Checklist**:

- [ ] Documentation N/A
- [ ] Added/updated unit tests N/A
- [x] Code complete

