### PR TITLE
fix: Output correct css when using css function in max().

### DIFF
--- a/packages/less/src/less/functions/number.js
+++ b/packages/less/src/less/functions/number.js
@@ -26,8 +26,8 @@ const minMax = function (isMin, args) {
         if (!(current instanceof Dimension)) {
             if (Array.isArray(args[i].value)) {
                 Array.prototype.push.apply(args, Array.prototype.slice.call(args[i].value));
+                continue;
             }
-            continue;
         }
         currentUnified = current.unit.toString() === '' && unitClone !== undefined ? new Dimension(current.value, unitClone).unify() : current.unify();
         unit = currentUnified.unit.toString() === '' && unitStatic !== undefined ? unitStatic : currentUnified.unit.toString();

--- a/packages/test-data/css/_main/functions.css
+++ b/packages/test-data/css/_main/functions.css
@@ -109,8 +109,10 @@
   min: 5;
   min: 1pt;
   min: 3mm;
+  min: min(calc(1 + 1), 1);
   max: 3;
   max: 5em;
+  max: max(1, calc(1 + 1));
   max-native: max(10vw, 100px);
   percentage: 20%;
   color-quoted-digit: #dda0dd;

--- a/packages/test-data/less/_main/functions.less
+++ b/packages/test-data/less/_main/functions.less
@@ -116,8 +116,10 @@
   min: min(6, 5);
   min: min(1pt, 3pt);
   min: min(1cm, 3mm);
+  min: min(calc(1 + 1), 1);
   max: max(1, 3);
   max: max(3em, 1em, 2em, 5em);
+  max: max(1, calc(1 + 1));
   max-native: max(10vw, 100px);
   percentage: percentage((10px / 50));
   color-quoted-digit: color("#dda0dd");
@@ -135,11 +137,11 @@
 
   fade-out: fadeout(red, 5%); // support fadeOut and fadeout
   fade-in: fadein(fadeout(red, 10%), 5%);
-  fade-out-relative: fadeout(red, 5%,relative); 
+  fade-out-relative: fadeout(red, 5%,relative);
   fade-in-relative: fadein(fadeout(red, 10%, relative), 5%, relative);
-  fade-out2:  fadeout(fadeout(red, 50%), 50%); 
+  fade-out2:  fadeout(fadeout(red, 50%), 50%);
   fade-out2-relative: fadeout(fadeout(red, 50%, relative), 50%, relative);
-  
+
   hsv: hsv(5, 50%, 30%);
   hsva: hsva(3, 50%, 30%, 0.2);
 
@@ -269,7 +271,7 @@ html {
   // see: https://github.com/less/less.js/issues/3371
   @some: foo;
   l: if((iscolor(@some)), darken(@some, 10%), black);
-  
+
 
   if((false), {g: 7}); /* results in void */
 


### PR DESCRIPTION
**What**: fix #3604

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:
For the following ast node
```
[Dimension, Expression]
```
less will skip non-Dimension nodes
https://github.com/lumburr/less.js/blob/master/packages/less/src/less/functions/number.js#L26-L31
So, max(1, calc(1 + 1)) is treated as max(1).

We should not skip these nodes.
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->
