### PR TITLE
fix: Fix https failures on macOS

### DIFF
--- a/packages/less/package-lock.json
+++ b/packages/less/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "less",
-	"version": "4.1.1",
+	"version": "4.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -3373,6 +3373,7 @@
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
@@ -4436,13 +4437,13 @@
 			"dev": true
 		},
 		"needle": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
-			"integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/needle/-/needle-3.1.0.tgz",
+			"integrity": "sha512-gCE9weDhjVGCRqS8dwDR/D3GTAeyXLXuqp7I8EzH6DllZGXSUyxuqqLh+YX9rMAWaaTFyVAg6rHGL25dqvczKw==",
 			"optional": true,
 			"requires": {
 				"debug": "^3.2.6",
-				"iconv-lite": "^0.4.4",
+				"iconv-lite": "^0.6.3",
 				"sax": "^1.2.4"
 			},
 			"dependencies": {
@@ -4453,6 +4454,15 @@
 					"optional": true,
 					"requires": {
 						"ms": "^2.1.1"
+					}
+				},
+				"iconv-lite": {
+					"version": "0.6.3",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+					"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+					"optional": true,
+					"requires": {
+						"safer-buffer": ">= 2.1.2 < 3.0.0"
 					}
 				}
 			}

--- a/packages/less/package.json
+++ b/packages/less/package.json
@@ -50,7 +50,7 @@
 		"image-size": "~0.5.0",
 		"make-dir": "^2.1.0",
 		"mime": "^1.4.1",
-		"needle": "^2.5.2",
+		"needle": "^3.1.0",
 		"source-map": "~0.6.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
The issue was traced upstream to needle, and resolved in:
 - https://github.com/tomas/needle/pull/392
 - https://github.com/tomas/needle/pull/394
 - https://github.com/tomas/needle/pull/396
 - https://github.com/tomas/needle/pull/398

Closes #3693

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fix macOS ECONNRESET w/ node v14+

<!-- Why are these changes necessary? -->

**Why**: Without the upgrade to needle, some more complex less files with https inline imports can fail with ECONNRESET, specifically on macOS w/ node v14+

<!-- How were these changes implemented? -->

**How**: The root cause was traced to the dependency `needle`, and fixed there over several PRs addressing various combinations of OS and node version

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation (N/A)
- [ ] Added/updated unit tests (tried, but failed; see comments in issue #3693)
- [x] Code complete
