### PR TITLE
Fix 3407

### DIFF
--- a/packages/less/src/less/tree/ruleset.js
+++ b/packages/less/src/less/tree/ruleset.js
@@ -264,6 +264,7 @@ Ruleset.prototype = Object.assign(new Node(), {
     // lets you call a css selector with a guard
     matchCondition(args, context) {
         const lastSelector = this.selectors[this.selectors.length - 1];
+        // fix:3407
         if (!lastSelector.evaldCondition && !lastSelector.condition) {
             return false;
         }

--- a/packages/less/src/less/tree/ruleset.js
+++ b/packages/less/src/less/tree/ruleset.js
@@ -264,7 +264,7 @@ Ruleset.prototype = Object.assign(new Node(), {
     // lets you call a css selector with a guard
     matchCondition(args, context) {
         const lastSelector = this.selectors[this.selectors.length - 1];
-        if (!lastSelector.evaldCondition) {
+        if (!lastSelector.evaldCondition && !lastSelector.condition) {
             return false;
         }
         if (lastSelector.condition &&

--- a/packages/test-data/css/_main/mixins-guards.css
+++ b/packages/test-data/css/_main/mixins-guards.css
@@ -173,6 +173,18 @@
 #guarded-deeper {
   should: match 1;
 }
+@media (min-width: 700px) {
+  .example1 {
+    success1: 1;
+    success2: 2;
+    success3: 3;
+  }
+}
+@media (min-width: 700px) {
+  .example2 {
+    wut: 1;
+  }
+}
 #parenthesisNot-true {
   parenthesisNot: just-value;
   parenthesisNot: negated twice 1;

--- a/packages/test-data/less/_main/mixins-guards.less
+++ b/packages/test-data/less/_main/mixins-guards.less
@@ -270,6 +270,43 @@
   #top > #deeper > .mixin(1);
 }
 
+// guarded namespaced should pass when true
+#desktop (@ruleset) {
+  @media (min-width: 700px) {
+    @ruleset();
+  }
+}
+
+@switch: demo;
+
+.example1 {
+  #lookup when (@switch = demo) {
+    @not-found: 1;
+  }
+
+  @found: 2;
+  
+  #lookup2 {
+    @also-found: 3;
+  }
+
+  #desktop({
+    success1: #lookup[@not-found];
+    success2: @found;
+    success3: #lookup2[@also-found];
+  });
+}
+
+.example2 {
+  #lookup () when (@switch = demo) {
+    @not-found: 1;
+  }
+
+  #desktop({
+    wut: #lookup[@not-found];
+  });
+}
+
 // namespaced & guarded mixin in root
 // outputs nothing but should pass:
 


### PR DESCRIPTION
**What**: fix https://github.com/less/less.js/issues/3407

<!-- Why are these changes necessary? -->

**Why**: 
If a namespace has a guard, mixins defined by it are used only if the guard condition returns true.The behavior of the variables should also be consistent.
![image](https://user-images.githubusercontent.com/87313750/167246661-ecdc4a4a-2841-4bc7-b6fb-e5b976926be0.png)


<!-- How were these changes implemented? -->

**How**:  In `matchcondition` we should let the condition evaluate.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->
