### PR TITLE
fix: When format the less-node, keep its context.

### DIFF
--- a/packages/less/src/less/functions/function-caller.js
+++ b/packages/less/src/less/functions/function-caller.js
@@ -48,7 +48,7 @@ class functionCaller {
             return this.func(this.context, ...args);
         }
 
-        return this.func(...args);
+        return this.func.call(this, ...args);
     }
 }
 

--- a/packages/less/src/less/functions/string.js
+++ b/packages/less/src/less/functions/string.js
@@ -22,11 +22,18 @@ export default {
         const args = Array.prototype.slice.call(arguments, 1);
         let result = string.value;
 
+        const toCSSOptions = {
+            compress: !!this.context.compress,
+            dumpLineNumbers: !!this.context.dumpLineNumbers,
+            strictUnits: !!this.context.strictUnits,
+            numPrecision: 8
+        };
+
         for (let i = 0; i < args.length; i++) {
             /* jshint loopfunc:true */
             result = result.replace(/%[sda]/i, token => {
                 const value = ((args[i].type === 'Quoted') &&
-                    token.match(/s/i)) ? args[i].value : args[i].toCSS();
+                    token.match(/s/i)) ? args[i].value : args[i].toCSS(toCSSOptions);
                 return token.match(/[A-Z]$/) ? encodeURIComponent(value) : value;
             });
         }

--- a/packages/test-data/css/_main/functions.css
+++ b/packages/test-data/css/_main/functions.css
@@ -201,6 +201,7 @@
   format-escaped-string: hello escaped world;
   format-keyword: hello;
   format-anonymous: hello anonymous world;
+  format-color: 'hsla(90, 100%, 50%, 0.5)';
 }
 #list-details {
   length: 2;

--- a/packages/test-data/less/_main/functions.less
+++ b/packages/test-data/less/_main/functions.less
@@ -135,11 +135,11 @@
 
   fade-out: fadeout(red, 5%); // support fadeOut and fadeout
   fade-in: fadein(fadeout(red, 10%), 5%);
-  fade-out-relative: fadeout(red, 5%,relative); 
+  fade-out-relative: fadeout(red, 5%,relative);
   fade-in-relative: fadein(fadeout(red, 10%, relative), 5%, relative);
-  fade-out2:  fadeout(fadeout(red, 50%), 50%); 
+  fade-out2:  fadeout(fadeout(red, 50%), 50%);
   fade-out2-relative: fadeout(fadeout(red, 50%, relative), 50%, relative);
-  
+
   hsv: hsv(5, 50%, 30%);
   hsva: hsva(3, 50%, 30%, 0.2);
 
@@ -223,6 +223,7 @@
     format-escaped-string: %(~"hello %s", "escaped world");
     format-keyword: %(hello);
     format-anonymous: %(e("hello %s"), "anonymous world");
+    format-color: %('%s', hsla(90, 100%, 50%, 0.5));
   }
 }
 
@@ -269,7 +270,7 @@ html {
   // see: https://github.com/less/less.js/issues/3371
   @some: foo;
   l: if((iscolor(@some)), darken(@some, 10%), black);
-  
+
 
   if((false), {g: 7}); /* results in void */
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: fix: #3314 

<!-- Why are these changes necessary? -->

**Why**: Use `% ()` to format less node is missing parameters.

eg: `%("%d", hsla(90, 100%, 50%, 0.5));` will output `"hsla(89.99999999999999, 100%, 50%, 0.5)"`

<!-- How were these changes implemented? -->

**How**:

Add parameter `toCSSOptions` for `toCSS()`. like:
https://github.com/less/less.js/blob/7491578403a5a35464772c730854c3a5169c0de7/packages/less/src/less/parse-tree.js#L29-L40
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->
