### PR TITLE
Allow !important case-insensitive token

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -2035,7 +2035,7 @@ const Parser = function Parser(context, imports, fileInfo) {
             },
             important: function () {
                 if (parserInput.currentChar() === '!') {
-                    return parserInput.$re(/^! *important/);
+                    return parserInput.$re(/^! *important/i);
                 }
             },
             sub: function () {

--- a/packages/test-data/css/_main/mixins-important.css
+++ b/packages/test-data/css/_main/mixins-important.css
@@ -55,3 +55,6 @@
 .class2-2421 {
   margin: 5px;
 }
+.case-insensitive {
+  background: black url('http://localhost/header.png') repeat-x !IMPORTANT;
+}

--- a/packages/test-data/less/_main/mixins-important.less
+++ b/packages/test-data/less/_main/mixins-important.less
@@ -50,4 +50,6 @@
 .class2-2421 {
     .test-ruleMixin-2421();
 }
-
+.case-insensitive {
+    background: black url('http://localhost/header.png') repeat-x !IMPORTANT;
+}


### PR DESCRIPTION
**What**:
Fixes https://github.com/less/less.js/issues/3731

**Why**:
According to https://www.w3.org/TR/css-syntax-3/#consume-declaration the token `important` is case-insensitive.

**How**:
Make the regex case-insensitive
<!-- Have you done all of these things?  -->

**Checklist**:

- [ ] Documentation N/A
- [x] Added/updated unit tests
- [x] Code complete
