### PR TITLE
fix: file path is not an absolute path when startswith "#"

### DIFF
--- a/packages/less/src/less/environment/abstract-file-manager.js
+++ b/packages/less/src/less/environment/abstract-file-manager.js
@@ -31,7 +31,7 @@ class AbstractFileManager {
     }
 
     isPathAbsolute(filename) {
-        return (/^(?:[a-z-]+:|\/|\\|#)/i).test(filename);
+        return (/^(?:[a-z-]+:|\/|\\)/i).test(filename);
     }
 
     // TODO: pull out / replace?


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

I don't know why this function thinks that the path starting with '#' an absolute path, but according to the definition of absolute path, this is wrong, and the path name starting with '#' return false in the built-in functions in many languages

<!-- Why are these changes necessary? -->

**Why**:

Same as nodejs built-in implementation `require('path').isAbsolute()`. The file path starting with '#' is not an absolute path.

<!-- How were these changes implemented? -->

**How**:

Modify the regular expression to remove the match at the starting of '#'

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->
