### PR TITLE
fix: '..' shouldn't be ignored if directories is empty

### DIFF
--- a/packages/less/src/less/environment/abstract-file-manager.js
+++ b/packages/less/src/less/environment/abstract-file-manager.js
@@ -110,7 +110,7 @@ class AbstractFileManager {
             // collapse '..' and skip '.'
             for (i = 0; i < rawDirectories.length; i++) {
 
-                if (rawDirectories[i] === '..') {
+                if (rawDirectories[i] === '..' && directories.length > 0) {
                     directories.pop();
                 }
                 else if (rawDirectories[i] !== '.') {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

append `..` to `directories` if directories is empty

<!-- Why are these changes necessary? -->

**Why**:

`pathDiff` will broken if url startsWith `..`

`AbstractFileManager.prototype.pathDiff('../assets/', '')` returns `assets/` now

<!-- How were these changes implemented? -->

**How**:

pop directories only if it is not empty

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Added/updated unit tests
- [ ] Code complete

<!-- feel free to add additional comments -->
