### PR TITLE
fix faulty source map generation with variables in selectors

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -108,8 +108,15 @@ const Parser = function Parser(context, imports, fileInfo) {
                 result = parsers[p]();
                 if (result) {
                     try {
-                        result._index = i + currentIndex;
-                        result._fileInfo = fileInfo;
+                        if (Array.isArray(result)) {
+                            result.forEach((r) => {
+                                r._index = i + currentIndex;
+                                r._fileInfo = fileInfo;
+                            })
+                        } else {
+                            result._index = i + currentIndex;
+                            result._fileInfo = fileInfo;
+                        }
                     } catch (e) {}
                     returnNodes.push(result);
                 }

--- a/packages/less/src/less/tree/ruleset.js
+++ b/packages/less/src/less/tree/ruleset.js
@@ -79,14 +79,22 @@ Ruleset.prototype = Object.assign(new Node(), {
                     selector = selectors[i];
                     toParseSelectors[i] = selector.toCSS(context);
                 }
+                const startingIndex = selectors[0].getIndex();
+                const selectorFileInfo = selectors[0].fileInfo();
                 this.parse.parseNode(
                     toParseSelectors.join(','),
-                    ["selectors"], 
-                    selectors[0].getIndex(), 
-                    selectors[0].fileInfo(), 
+                    ["selectors"],
+                    startingIndex,
+                    selectorFileInfo,
                     function(err, result) {
                         if (result) {
                             selectors = utils.flattenArray(result);
+                            selectors.forEach((selector) => {
+                                selector.elements.forEach((element) => {
+                                    element._index += startingIndex;
+                                    element._fileInfo = selectorFileInfo;
+                                });
+                            });
                         }
                     });
             }

--- a/packages/less/src/less/tree/selector.js
+++ b/packages/less/src/less/tree/selector.js
@@ -2,6 +2,7 @@ import Node from './node';
 import Element from './element';
 import LessError from '../less-error';
 import * as utils from '../utils';
+import Parser from '../parser/parser';
 
 const Selector = function(elements, extendList, condition, index, currentFileInfo, visibilityInfo) {
     this.extendList = extendList;
@@ -44,11 +45,9 @@ Selector.prototype = Object.assign(new Node(), {
             return [new Element('', '&', false, this._index, this._fileInfo)];
         }
         if (typeof els === 'string') {
-            this.parse.parseNode(
-                els, 
+            new Parser(this.parse.context, this.parse.importManager, this._fileInfo, this._index).parseNode(
+                els,
                 ['selector'],
-                this._index, 
-                this._fileInfo, 
                 function(err, result) {
                     if (err) {
                         throw new LessError({

--- a/packages/less/test/index.js
+++ b/packages/less/test/index.js
@@ -63,6 +63,8 @@ var testMap = [
         'sourcemaps-empty/', lessTester.testEmptySourcemap],
     [{math: 'strict', strictUnits: true, sourceMap: {disableSourcemapAnnotation: true}},
         'sourcemaps-disable-annotation/', lessTester.testSourcemapWithoutUrlAnnotation],
+    [{math: 'strict', strictUnits: true, sourceMap: true},
+        'sourcemaps-variable-selector/', lessTester.testSourcemapWithVariableInSelector],
     [{globalVars: true, banner: '/**\n  * Test\n  */\n'}, 'globalVars/',
         null, null, null, function(name, type, baseFolder) { return path.join(baseFolder, name) + '.json'; }],
     [{modifyVars: true}, 'modifyVars/',

--- a/packages/less/test/less-test.js
+++ b/packages/less/test/less-test.js
@@ -169,6 +169,29 @@ module.exports = function() {
         }
     }
 
+    function testSourcemapWithVariableInSelector(name, err, compiledLess, doReplacements, sourcemap, baseFolder) {
+        if (err) {
+            fail('ERROR: ' + (err && err.message));
+            return;
+        }
+
+        // Even if annotation is not necessary, the map file should be there.
+        fs.readFile(path.join('test/', name) + '.json', 'utf8', function (e, expectedSourcemap) {
+            process.stdout.write('- ' + path.join(baseFolder, name) + ': ');
+            if (sourcemap === expectedSourcemap) {
+                ok('OK');
+            } else if (err) {
+                fail('ERROR: ' + (err && err.message));
+                if (isVerbose) {
+                    process.stdout.write('\n');
+                    process.stdout.write(err.stack + '\n');
+                }
+            } else {
+                difference('FAIL', expectedSourcemap, sourcemap);
+            }
+        });
+    }
+
     function testImports(name, err, compiledLess, doReplacements, sourcemap, baseFolder, imports) {
         if (err) {
             fail('ERROR: ' + (err && err.message));
@@ -228,7 +251,7 @@ module.exports = function() {
 
     // To fix ci fail about error format change in upstream v8 project
     // https://github.com/v8/v8/commit/c0fd89c3c089e888c4f4e8582e56db7066fa779b
-    // Node 16.9.0+ include this change via https://github.com/nodejs/node/pull/39947 
+    // Node 16.9.0+ include this change via https://github.com/nodejs/node/pull/39947
     function testTypeErrors(name, err, compiledLess, doReplacements, sourcemap, baseFolder) {
         const fileSuffix = semver.gte(process.version, 'v16.9.0') ? '-2.txt' : '.txt';
         fs.readFile(path.join(baseFolder, name) + fileSuffix, 'utf8', function (e, expectedErr) {
@@ -254,7 +277,7 @@ module.exports = function() {
     // https://github.com/less/less.js/issues/3112
     function testJSImport() {
         process.stdout.write('- Testing root function registry');
-        less.functions.functionRegistry.add('ext', function() { 
+        less.functions.functionRegistry.add('ext', function() {
             return new less.tree.Anonymous('file');
         });
         var expected = '@charset "utf-8";\n';
@@ -282,7 +305,7 @@ module.exports = function() {
             .replace(/\{pathhref\}/g, '')
             .replace(/\{404status\}/g, '')
             .replace(/\{nodepath\}/g, path.join(process.cwd(), 'node_modules', '/'))
-            .replace(/\{pathrel\}/g, path.join(path.relative(lessFolder, p), '/')) 
+            .replace(/\{pathrel\}/g, path.join(path.relative(lessFolder, p), '/'))
             .replace(/\{pathesc\}/g, pathesc)
             .replace(/\{pathimport\}/g, pathimport)
             .replace(/\{pathimportesc\}/g, pathimportesc)
@@ -327,7 +350,7 @@ module.exports = function() {
 
     function runTestSetInternal(baseFolder, opts, foldername, verifyFunction, nameModifier, doReplacements, getFilename) {
         foldername = foldername || '';
-        
+
         var originalOptions = opts || {};
 
         if (!doReplacements) {
@@ -497,10 +520,10 @@ module.exports = function() {
     }
 
     /**
-     * 
-     * @param {Object} options 
-     * @param {string} filePath 
-     * @param {Function} callback 
+     *
+     * @param {Object} options
+     * @param {string} filePath
+     * @param {Function} callback
      */
     function toCSS(options, filePath, callback) {
         options = options || {};
@@ -577,7 +600,7 @@ module.exports = function() {
                 }
                 ok(stylize('OK\n', 'green'));
             }
-        );      
+        );
     }
 
     return {
@@ -588,6 +611,7 @@ module.exports = function() {
         testTypeErrors: testTypeErrors,
         testSourcemap: testSourcemap,
         testSourcemapWithoutUrlAnnotation: testSourcemapWithoutUrlAnnotation,
+        testSourcemapWithVariableInSelector: testSourcemapWithVariableInSelector,
         testImports: testImports,
         testImportRedirect: testImportRedirect,
         testEmptySourcemap: testEmptySourcemap,

--- a/packages/less/test/sourcemaps-variable-selector/basic.json
+++ b/packages/less/test/sourcemaps-variable-selector/basic.json
@@ -1,0 +1,1 @@
+{"version":3,"sources":["testweb/sourcemaps-variable-selector/basic.less"],"names":[],"mappings":"AAEC;EACG,eAAA","file":"sourcemaps-variable-selector/basic.css"}

--- a/packages/test-data/less/sourcemaps-variable-selector/basic.less
+++ b/packages/test-data/less/sourcemaps-variable-selector/basic.less
@@ -1,0 +1,5 @@
+@import (reference) "./vars.less";
+
+.@{hello}-class {
+    font-size: @font-size;
+}

--- a/packages/test-data/less/sourcemaps-variable-selector/vars.less
+++ b/packages/test-data/less/sourcemaps-variable-selector/vars.less
@@ -1,0 +1,3 @@
+@foo: bar;
+@font-size: 12px;
+@hello: world;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

**Note to reviewer:** There are two potential solutions here, one that fixes the specific issue linked, and one that might be a bit more robust. Filter down to the first commit for the bandaid fix, second commit for the more robust one, third commit for added test. I recommend hiding whitespace changes in the GitHub UI – my editor removed a bunch of unnecessary trailing spaces

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

## PR Template

**What**:

Fixes https://github.com/less/less.js/issues/3567

Source maps are pointing to the wrong files, and it seems that it points at different files on different runs, causing non-deterministic source map output.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation - N/A
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->

**Why** and **How** are included in the below description, which details the problem in the code and the proposed solutions.

## Investigation and the problems

Bear with me a bit, this was my first venture into the less source code 🙂

We were seeing that we got weird source map output, mapping to files that shouldn't even appear in the source maps (e.g. reference imports from which nothing was used). After digging, there are a couple of problems that are causing this whole issue.

### Background information

I was able to narrow down my search a bit by finding when this bug was introduced. It was released in `3.5.0-beta.2`, and the bug was introduced in https://github.com/less/less.js/pull/3227.

We were seeing this happen when a selector included a variable, which directed me to this bit: https://github.com/less/less.js/pull/3227/files#diff-d8c0204835f49ae90096efe1e2d0d80868e0e6214bfd4c960a097eb20cc14ec9R67-R83

It looks like what this is doing is recreating the selector CSS with the "variableCurly" node replaced with the variable's value. Then it parses that newly created CSS, and replaces the old `Selector` node(s) with the new one(s). It looks like the code is trying to preserve source information by passing in the `fileInfo` and `index` of the original selectors to `parseNode`: https://github.com/less/less.js/blob/eefe33a47f6fdcc228817df7435a1770ce9e51ea/packages/less/src/less/tree/ruleset.js#L85-L86

For a little more context, my understanding is that `parseNode` is used for creating new nodes after the original input files are parsed.

### First problem

In `parseNode`, the provided `currentIndex` and `fileInfo` are added to the newly created node(s) here: https://github.com/less/less.js/blob/eefe33a47f6fdcc228817df7435a1770ce9e51ea/packages/less/src/less/parser/parser.js#L111-L112

These lines assume that `result` is a tree node. However, in some cases, `result` is actually an _array_ of nodes. So when it tries to add the source info from the old selectors to the new ones, it's actually just setting `_index` and `_fileInfo` properties on the array itself, so it doesn't actually ever make it to the source maps. In this case, [the `parseList` is `["selectors"]`](https://github.com/less/less.js/pull/3227/files#diff-d8c0204835f49ae90096efe1e2d0d80868e0e6214bfd4c960a097eb20cc14ec9R75), so `result` is an array of `Selector` tree nodes.

### Second problem

`Selector` nodes have an `elements` array, containing the elements that make up the selector. When a `Selector` is added to the output, it actually does so by generating the CSS for each of its elements: https://github.com/less/less.js/blob/eefe33a47f6fdcc228817df7435a1770ce9e51ea/packages/less/src/less/tree/selector.js#L135-L138

This means that if the `_fileInfo` or `_index` for the Selector's elements is incorrect, then the output source map will be incorrect. That also means that even if the `_fileInfo` and `_index` were correctly set on the `Selector`(s) rather than the array containing the `Selector`(s), the source maps would still be incorrect on the `Element`s that make up the selector. The source info for the elements gets set here: https://github.com/less/less.js/blob/eefe33a47f6fdcc228817df7435a1770ce9e51ea/packages/less/src/less/parser/parser.js#L1299

There are two problems here:
1. The `currentIndex` passed into `parseNode` doesn't get added to the created `Element`s index
2. That `fileInfo` is _not_ the `fileInfo` that gets passed into `parseNode`. It's the `fileInfo` that's given to the `Parser` when it's instantiated: https://github.com/less/less.js/blob/eefe33a47f6fdcc228817df7435a1770ce9e51ea/packages/less/src/less/parser/parser.js#L41

## The proposed solution(s)

I have two proposals for how we can solve this. One is more of a bandaid fix, and the other is (I believe) a bit more robust. Both solutions include the fix for where `_fileInfo` and `_index` get set on an array.

1. Bandaid fix by going through the `elements` for each selector returned by `parseNode`, and update the `_fileInfo` and add the `currentIndex` to the `_index` for each one.
2. Instead of calling `this.parse.parseNode` and relying on `parseNode` to update the `_index` and `_fileInfo` of the created nodes, create a new `Parser` object each time we want to call `parseNode`. This removes the `currentIndex` and `fileInfo` params for `parseNode`, and adds a `currentIndex` param to the `Parser` itself. All nodes created by the parser will add `currentIndex` (which defaults to 0) to the index from `parserInput`. This way, we can ensure that any nodes created with `parseNode` will have the correct source information.

The first proposed solution can be seen by filtering to the first commit, and the second proposed solution can be seen by filtering to both the first and second commits. The third commit adds a test to ensure that selectors with variables in them have properly generated source maps. I recommend hiding whitespace changes in the GitHub UI – my editor removed a bunch of unnecessary trailing spaces.
