### PR TITLE
Fix: #3777- CSS min and max function calls that hold CSS variables fail with "Operation on an invalid type"

### DIFF
--- a/packages/less/src/less/functions/number.js
+++ b/packages/less/src/less/functions/number.js
@@ -55,17 +55,24 @@ const minMax = function (isMin, args) {
     return new Anonymous(`${isMin ? 'min' : 'max'}(${args})`);
 };
 
+function evaluateWithFallback(func, context) {
+    return function (...args) {
+        try {
+            return func.apply(context, args);
+        } catch (e) {
+        // Return the original node as-is if evaluation fails
+            return args
+        }
+    };
+}
+  
 export default {
-    min: function(...args) {
-        try {
-            return minMax.call(this, true, args);
-        } catch (e) {}
-    },
-    max: function(...args) {
-        try {
-            return minMax.call(this, false, args);
-        } catch (e) {}
-    },
+    min: evaluateWithFallback(function (...args) {
+        return minMax.call(this, true, args);
+    }, this),
+    max: evaluateWithFallback(function (...args) {
+        return minMax.call(this, false, args);
+    }, this),
     convert: function (val, unit) {
         return val.convertTo(unit.value);
     },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**Issue**: #3777 CSS min and max function calls that hold CSS variables fail with "Operation on an invalid type"

**What**:  Added Abstratcion that outputs min and max function as-is

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Added/updated unit tests N/A
- [ x] Code complete

<!-- feel free to add additional comments -->
2-3 test cases with different unit types are failing.
