### PR TITLE
fix: can not find the variable that be created in plugin.

### DIFF
--- a/packages/less/src/less/tree/ruleset.js
+++ b/packages/less/src/less/tree/ruleset.js
@@ -189,6 +189,9 @@ Ruleset.prototype = Object.assign(new Node(), {
         for (i = 0; (rule = rsRules[i]); i++) {
             if (!rule.evalFirst) {
                 rsRules[i] = rule = rule.eval ? rule.eval(context) : rule;
+                if (rule instanceof Declaration) {
+                    ruleset.resetCache();
+                }
             }
         }
 

--- a/packages/less/test/index.js
+++ b/packages/less/test/index.js
@@ -81,7 +81,8 @@ var testMap = [
     [{plugin: 'test/plugins/visitor/'}, 'visitorPlugin/'],
     [{plugin: 'test/plugins/filemanager/'}, 'filemanagerPlugin/'],
     [{math: 0}, '3rd-party/'],
-    [{ processImports: false }, 'process-imports/']
+    [{ processImports: false }, 'process-imports/'],
+    [{}, 'define-var/']
 ];
 testMap.forEach(function(args) {
     lessTester.runTestSet.apply(lessTester, args)

--- a/packages/test-data/css/define-var/define-var.css
+++ b/packages/test-data/css/define-var/define-var.css
@@ -1,0 +1,4 @@
+div {
+  height: 1px;
+  width: 33px;
+}

--- a/packages/test-data/less/define-var/define-var.less
+++ b/packages/test-data/less/define-var/define-var.less
@@ -1,0 +1,9 @@
+@plugin "../../plugin/plugin-define-var.js";
+
+@a: 1px;
+
+div {
+    height: @a;
+    x();
+    width: @x;
+}

--- a/packages/test-data/plugin/plugin-define-var.js
+++ b/packages/test-data/plugin/plugin-define-var.js
@@ -1,0 +1,11 @@
+module.exports = class LessPluginBestMixin {
+    install(less, pluginManager, functions) {
+        functions.add("x", () => {
+            return new less.tree.Declaration(
+                "@x",
+                new less.tree.Value(new less.tree.Keyword("33px"))
+            );
+        });
+        functions.add("define_var", (key) => {});
+    }
+};


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: clear cache when the type of Declaration be returned.

<!-- Why are these changes necessary? -->

**Why**: 
I want to define a variable in plugin. It will insert `@x: 33px` to current scope.
```js
module.exports = class LessPluginBestMixin {
    install(less, pluginManager, functions) {
        functions.add("x", () => {
            return new less.tree.Declaration(
                "@x",
                new less.tree.Value(new less.tree.Keyword("33px"))
            );
        });
        functions.add("define_var", (key) => {});
    }
};
```

When I write the code to a less file:
```less
@plugin "the-plugin-path";

div {
    x();
    width: @x;
}
```
It works and return the css code:
```css
div {
    width: 33px;
}
```
But when I write the code to a less file:
```less
@plugin "the-plugin-path";

@a: 1px;

div {
    height: @a;
    x();
    width: @x;
}
```
It not works and return a error cause can not find the variable of @x.

I had tried debug the source code of less and I found the code:
<img width="400" alt="image" src="https://github.com/less/less.js/assets/51100990/e5cf7120-b987-4815-b4e9-327dad1c84c1">
The height need read this variable and execute the function of variable and be cached. 
It lead to the function of variable can not run again when the width read the @x.

I changed the code that will clear the cache when the function return a Declaration.


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [ ] Code complete

<!-- feel free to add additional comments -->
