### PR TITLE
Adding attribute selector with variable concatenation feature

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -1448,8 +1448,18 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 //
                 let cif;
 
-                if (!(key = entities.variableCurly())) {
-                    key = expect(/^(?:[_A-Za-z0-9-*]*\|)?(?:[_A-Za-z0-9-]|\\.)+/);
+                let keys;
+                while((key = entities.variableCurly()) || (key = parserInput.$re(/^(?:[_A-Za-z0-9-*]*\|)?(?:[_A-Za-z0-9-]|\\.)+/))){
+                    if(keys){
+                        keys.push(key);
+                    }else{
+                        keys = [key];
+                    }
+                    key = null
+                }
+
+                if(keys.length == 0){
+                    error('unexpected token');
                 }
 
                 op = parserInput.$re(/^[|~*$^]?=/);
@@ -1462,7 +1472,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
 
                 expectChar(']');
 
-                return new(tree.Attribute)(key, op, val, cif);
+                return new(tree.Attribute)(keys, op, val, cif);
             },
 
             //

--- a/packages/less/src/less/tree/attribute.js
+++ b/packages/less/src/less/tree/attribute.js
@@ -11,8 +11,12 @@ Attribute.prototype = Object.assign(new Node(), {
     type: 'Attribute',
 
     eval(context) {
+        let key = [];
+        for(let i=0;i<this.key.length;++i){
+            key.push(this.key[i].eval?this.key[i].eval(context):this.key[i]);
+        }
         return new Attribute(
-            this.key.eval ? this.key.eval(context) : this.key,
+            key,
             this.op,
             (this.value && this.value.eval) ? this.value.eval(context) : this.value,
             this.cif
@@ -24,7 +28,10 @@ Attribute.prototype = Object.assign(new Node(), {
     },
 
     toCSS(context) {
-        let value = this.key.toCSS ? this.key.toCSS(context) : this.key;
+        let value = '';
+        for(let i=0;i<this.key.length;++i){
+            value += this.key[i].toCSS ? this.key[i].toCSS(context) : this.key[i];
+        }
 
         if (this.op) {
             value += this.op;

--- a/packages/less/src/less/visitors/extend-visitor.js
+++ b/packages/less/src/less/visitors/extend-visitor.js
@@ -375,8 +375,16 @@ class ProcessExtendsVisitor {
             return elementValue1 === elementValue2;
         }
         if (elementValue1 instanceof tree.Attribute) {
-            if (elementValue1.op !== elementValue2.op || elementValue1.key !== elementValue2.key) {
+            if (elementValue1.op !== elementValue2.op) {
                 return false;
+            }
+            if (elementValue1.key.length !== elementValue2.key.length) {
+                return false;
+            }
+            for(let i=0;i<elementValue1.key.length;++i){
+                if(elementValue1.key[i] !== elementValue2.key[i]){
+                    return false;
+                }
             }
             if (!elementValue1.value || !elementValue2.value) {
                 if (elementValue1.value || elementValue2.value) {

--- a/packages/test-data/css/_main/selectors.css
+++ b/packages/test-data/css/_main/selectors.css
@@ -143,6 +143,11 @@ p a span {
 [p] {
   attributes: yes;
 }
+[p-attr^="val3"],
+[p-attr=3],
+[p-attr] {
+  attributes: yes;
+}
 /**
  * https://www.w3.org/TR/selectors-4/#attribute-case
  */

--- a/packages/test-data/less/_main/selectors.less
+++ b/packages/test-data/less/_main/selectors.less
@@ -146,6 +146,11 @@ a {
 [@{prop}] {
   attributes: yes;
 }
+[@{prop}-attr^="val@{num}"],
+[@{prop}-attr=@{num}],
+[@{prop}-attr] {
+  attributes: yes;
+}
 
 /**
  * https://www.w3.org/TR/selectors-4/#attribute-case


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:Adding attribute selector with variable concatenation feature

<!-- Why are these changes necessary? -->

**Why**:I use less.js to compile file , but I find that it can not handle the variable concatennation in attribute selector. This is not comfortable ,  and sass is support this feather , but sass' can not support something that less support.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Added/updated unit tests 
- [ ] Code complete

<!-- feel free to add additional comments -->
