### PR TITLE
Remove redundant return from `parsers.blockRuleset()`

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -1478,11 +1478,9 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
 
             blockRuleset: function() {
                 let block = this.block();
-
                 if (block) {
-                    block = new tree.Ruleset(null, block);
+                    return new tree.Ruleset(null, block);
                 }
-                return block;
             },
 
             detachedRuleset: function() {


### PR DESCRIPTION
**What**:

Remove redundant return from `parsers.blockRuleset()`.

**Why**:

The `content` from `parseBlock()` is either undefined or an array array from `parsers.primary()`. The falsy return that preserves `block` creates the impression that something is happening or being changed, but in actuality it is equivalent to matching nothing / returning nothing. Other parser methods like `block` and `detachedRuleset` handle this by not having a return value.

What led me to this change is the PHP code in <https://github.com/wikimedia/less.php>. In PHP, arrays are primitives values (like Python tuples) which means `if (block)` is falsy for empty arrays. As opposed to in JS, where arrays are objects and thus always truthy. When porting this over, we forgot to convert this to `if ( block !== null )`. Combined with the fake `return block` at the end for the implied `else` block, led to a subtle bug. This doesn't apply to the JS code base of course, but it felt to me like removing this made for improved visual clarity overall, so I'm offering it up for your consideration 🙂 

https://github.com/wikimedia/less.php/commit/2cd9715950688d1f4346e8f815e108e10f0d80e2

https://gerrit.wikimedia.org/r/c/mediawiki/libs/less.php/+/1010592

**Checklist**: N/A
