### PR TITLE
Remove unused `parsers.entities.propertyCurly()`

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -678,15 +678,6 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     }
                 },
 
-                // A property entity useing the protective {} e.g. ${prop}
-                propertyCurly: function () {
-                    let curly;
-                    const index = parserInput.i;
-
-                    if (parserInput.currentChar() === '$' && (curly = parserInput.$re(/^\$\{([\w-]+)\}/))) {
-                        return new(tree.Property)(`$${curly[1]}`, index + currentIndex, fileInfo);
-                    }
-                },
                 //
                 // A Hexadecimal color
                 //


### PR DESCRIPTION
**What**:

Remove unused `parsers.entities.propertyCurly()`

**Why**:

Follows-up a38f8a1eb7beed589d2fa734fcf411cf4461d231 (https://github.com/less/less.js/pull/3163), which introduced this as part of implementing property accessors. The method was not used there, and hasn't been used elsewhere since then either.

This was found by @polishdeveloper during recent work on https://github.com/wikimedia/less.php.

**Checklist**:

- Documentation: N/A
- Added/updated unit tests: N/A
- [x] Code complete