### PR TITLE
Fix no-prototype-builtins issue in Ruleset variables()

### DIFF
--- a/packages/less/src/less/tree/ruleset.js
+++ b/packages/less/src/less/tree/ruleset.js
@@ -295,8 +295,7 @@ Ruleset.prototype = Object.assign(new Node(), {
                 if (r.type === 'Import' && r.root && r.root.variables) {
                     const vars = r.root.variables();
                     for (const name in vars) {
-                        // eslint-disable-next-line no-prototype-builtins
-                        if (vars.hasOwnProperty(name)) {
+                        if (Object.prototype.hasOwnProperty.call(vars, name)) {
                             hash[name] = r.root.variable(name);
                         }
                     }

--- a/packages/less/src/less/visitors/to-css-visitor.js
+++ b/packages/less/src/less/visitors/to-css-visitor.js
@@ -303,19 +303,16 @@ ToCSSVisitor.prototype = {
         // remove duplicates
         const ruleCache = {};
 
-        let ruleList;
-        let rule;
-        let i;
-
-        for (i = rules.length - 1; i >= 0 ; i--) {
-            rule = rules[i];
+        for (let i = rules.length - 1; i >= 0 ; i--) {
+            let rule = rules[i];
             if (rule instanceof tree.Declaration) {
-                if (!ruleCache[rule.name]) {
+                if (!Object.prototype.hasOwnProperty.call(ruleCache, rule.name)) {
                     ruleCache[rule.name] = rule;
                 } else {
-                    ruleList = ruleCache[rule.name];
-                    if (ruleList instanceof tree.Declaration) {
-                        ruleList = ruleCache[rule.name] = [ruleCache[rule.name].toCSS(this._context)];
+                    let ruleList = ruleCache[rule.name];
+                    if (!Array.isArray(ruleList)) {
+                        const prevRuleCSS = ruleList.toCSS(this._context);
+                        ruleList = ruleCache[rule.name] = [prevRuleCSS];
                     }
                     const ruleCSS = rule.toCSS(this._context);
                     if (ruleList.indexOf(ruleCSS) !== -1) {

--- a/packages/test-data/css/_main/rulesets.css
+++ b/packages/test-data/css/_main/rulesets.css
@@ -1,5 +1,6 @@
 #first > .one {
   font-size: 2em;
+  hasOwnProperty: blue;
 }
 #first > .one > #second .two > #deux {
   width: 50%;

--- a/packages/test-data/less/_main/rulesets.less
+++ b/packages/test-data/less/_main/rulesets.less
@@ -27,4 +27,5 @@
     }
   }
   font-size: 2em;
+  hasOwnProperty: blue;
 }


### PR DESCRIPTION
**What**:

```css
div {
  hasOwnProperty: blue;
}
```

<http://lesscss.org/less-preview/#eyJjb2RlIjoiI2xpYigpIHtcbiAgICAuY29sb3JzKCkge1xuICAgICAgQHByaW1hcnk6IGJsdWU7XG4gICAgICBAc2Vjb25kYXJ5OiBncmVlbjtcbiAgICB9XG4gICAgLnJ1bGVzKEBzaXplKSB7XG4gICAgICBib3JkZXI6IEBzaXplIHNvbGlkIHdoaXRlO1xuICAgIH1cbiAgfVxuICBcbiAgLmJveCB3aGVuICgjbGliLmNvbG9yc1tAcHJpbWFyeV0gPSBibHVlKSB7XG4gICAgd2lkdGg6IDEwMHB4O1xuICAgIGhlaWdodDogKCR3aWR0aCAvIDIpO1xuICB9XG4gIFxuICAuYmFyOmV4dGVuZCguYm94KSB7XG4gICAgQG1lZGlhIChtaW4td2lkdGg6IDYwMHB4KSB7XG4gICAgICB3aWR0aDogMjAwcHg7XG4gICAgICAjbGliLnJ1bGVzKDFweCk7XG4gICAgfVxuICB9IiwiYWN0aXZlVmVyc2lvbiI6IjQuMi4wIiwibWF0aCI6InBhcmVucy1kaXZpc2lvbiIsInN0cmljdFVuaXRzIjpmYWxzZX0=>

**Why**:

```
t.indexOf is not a function
```

The added test fails in CI without this patch as:

```
- /home/runner/work/less.js/less.js/packages/test-data/less/_main/property-name-interp: OK
ERROR: ruleList.indexOf is not a function

TypeError: ruleList.indexOf is not a function
    at ToCSSVisitor._removeDuplicateRules (/home/runner/work/less.js/less.js/packages/less/lib/less/visitors/to-css-visitor.js:282:34)
    at ToCSSVisitor.visitRuleset (/home/runner/work/less.js/less.js/packages/less/lib/less/visitors/to-css-visitor.js:232:18)
    at Visitor.visit (/home/runner/work/less.js/less.js/packages/less/lib/less/visitors/visitor.js:67:32)
    at Visitor.visitArray (/home/runner/work/less.js/less.js/packages/less/lib/less/visitors/visitor.js:105:30)
    at Ruleset.accept (/home/runner/work/less.js/less.js/packages/less/lib/less/tree/ruleset.js:42:34)
    at ToCSSVisitor.visitRuleset (/home/runner/work/less.js/less.js/packages/less/lib/less/visitors/to-css-visitor.js:227:25)
    at Visitor.visit (/home/runner/work/less.js/less.js/packages/less/lib/less/visitors/visitor.js:67:32)
    at ToCSSVisitor.run (/home/runner/work/less.js/less.js/packages/less/lib/less/visitors/to-css-visitor.js:81:30)
    at default_1 (/home/runner/work/less.js/less.js/packages/less/lib/less/transform-tree.js:78:21)
    at ParseTree.toCSS (/home/runner/work/less.js/less.js/packages/less/lib/less/parse-tree.js:18:58)
- /home/runner/work/less.js/less.js/packages/test-data/less/_main/scope: OK
```

I note that it doesn't say which LESS file the failure happened in, or which test case it was running (both would point to rulesets.less in this case).

**Checklist**:

- Documentation: N/A
- [ ] Added/updated unit tests
- [ ] Code complete
