### PR TITLE
Add support for @apply rule to apply mixins

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -1999,6 +1999,19 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     nonVendorSpecificName = `@${name.slice(name.indexOf('-', 2) + 1)}`;
                 }
 
+                // Special handling for @apply
+                if (nonVendorSpecificName === '@apply') {
+                    const selector = this.entities.call() || this.entities.keyword() || this.entities.variable();
+                    if (!selector) {
+                        error('expected selector after @apply');
+                    }
+                    if (!parserInput.$char(';')) {
+                        error('missing semi-colon after @apply');
+                    }
+                    parserInput.forget();
+                    return new(tree.ApplyRule)(selector, index + currentIndex, fileInfo);
+                }
+
                 switch (nonVendorSpecificName) {
                     case '@charset':
                         hasIdentifier = true;
@@ -2023,6 +2036,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 }
 
                 parserInput.commentStore.length = 0;
+
 
                 if (hasIdentifier) {
                     value = this.entity();
@@ -2492,3 +2506,4 @@ Parser.serializeVars = vars => {
 };
 
 export default Parser;
+

--- a/packages/less/src/less/tree/apply-rule.js
+++ b/packages/less/src/less/tree/apply-rule.js
@@ -1,0 +1,32 @@
+import Node from './node';
+
+class ApplyRule extends Node {
+    constructor(selector, index, currentFileInfo) {
+        super();
+        this.selector = selector;
+        this._index = index;
+        this._fileInfo = currentFileInfo;
+    }
+
+    accept(visitor) {
+        this.selector = visitor.visit(this.selector);
+    }
+
+    eval(context) {
+        const mixinName = this.selector.toCSS(context).substring(1); // Remove the dot
+        const mixin = context.frames.find(frame => frame[mixinName]);
+        
+        if (!mixin || !mixin[mixinName]) {
+            throw { 
+                type: 'Name',
+                message: `The mixin "${mixinName}" was not found`,
+                filename: this.fileInfo.filename,
+                index: this.index
+            };
+        }
+
+        return mixin[mixinName].eval(context);
+    }
+}
+
+export default ApplyRule;

--- a/packages/less/src/less/tree/index.js
+++ b/packages/less/src/less/tree/index.js
@@ -34,6 +34,7 @@ import Negative from './negative';
 import Extend from './extend';
 import VariableCall from './variable-call';
 import NamespaceValue from './namespace-value';
+import ApplyRule from './apply-rule';
 
 // mixins
 import MixinCall from './mixin-call';
@@ -47,9 +48,10 @@ export default {
     Comment, Anonymous, Value, JavaScript, Assignment,
     Condition, Paren, Media, Container, QueryInParens, 
     UnicodeDescriptor, Negative, Extend, VariableCall, 
-    NamespaceValue,
+    NamespaceValue, ApplyRule,
     mixin: {
         Call: MixinCall,
         Definition: MixinDefinition
     }
 };
+

--- a/packages/less/test/browser/less/apply-rule/apply-rule.css
+++ b/packages/less/test/browser/less/apply-rule/apply-rule.css
@@ -1,0 +1,4 @@
+.test {
+  color: blue;
+  font-size: 12px;
+}

--- a/packages/less/test/browser/less/apply-rule/apply-rule.less
+++ b/packages/less/test/browser/less/apply-rule/apply-rule.less
@@ -1,0 +1,8 @@
+.mixin() {
+  color: blue;
+  font-size: 12px;
+}
+
+.test {
+  @apply .mixin;
+}

--- a/packages/less/test/browser/runner-apply-rule-options.js
+++ b/packages/less/test/browser/runner-apply-rule-options.js
@@ -1,0 +1,6 @@
+var less = {
+    logLevel: 4,
+    errorReporting: 'console',
+    javascriptEnabled: true,
+    modifyVars: {}
+};

--- a/packages/less/test/browser/runner-apply-rule-spec.js
+++ b/packages/less/test/browser/runner-apply-rule-spec.js
@@ -1,0 +1,9 @@
+describe('less.js apply rule tests', function() {
+    beforeEach(function() {
+        less.env = 'development';
+        less.async = false;
+        less.fileAsync = false;
+    });
+
+    testLessEqualsInDocument('apply-rule/apply-rule.less', 'apply-rule/apply-rule.css', 'should apply mixin using @apply');
+});


### PR DESCRIPTION
Fixes #3675

This PR adds support for the `@apply` rule to apply mixins directly. For example:

```less
.mixin() {
  color: blue;
  font-size: 12px;
}

.test {
  @apply .mixin;
}
```

Changes:
- Added new ApplyRule node type for handling @apply rules
- Added parser support for @apply syntax
- Added test cases to verify functionality