### PR TITLE
fix(issue:4267) support starting-style at-rule

### DIFF
--- a/packages/less/src/less/tree/atrule-syntax.js
+++ b/packages/less/src/less/tree/atrule-syntax.js
@@ -5,3 +5,7 @@ export const MediaSyntaxOptions = {
 export const ContainerSyntaxOptions = {
     queryInParens: true
 };
+
+export const StartingStyleSyntaxOptions = {
+    queryInParens: false
+};

--- a/packages/less/src/less/tree/index.js
+++ b/packages/less/src/less/tree/index.js
@@ -34,6 +34,7 @@ import Negative from './negative';
 import Extend from './extend';
 import VariableCall from './variable-call';
 import NamespaceValue from './namespace-value';
+import StartingStyle from './starting-style';
 
 // mixins
 import MixinCall from './mixin-call';
@@ -47,7 +48,7 @@ export default {
     Comment, Anonymous, Value, JavaScript, Assignment,
     Condition, Paren, Media, Container, QueryInParens, 
     UnicodeDescriptor, Negative, Extend, VariableCall, 
-    NamespaceValue,
+    NamespaceValue, StartingStyle,
     mixin: {
         Call: MixinCall,
         Definition: MixinDefinition

--- a/packages/less/src/less/tree/starting-style.js
+++ b/packages/less/src/less/tree/starting-style.js
@@ -1,0 +1,130 @@
+import Value from './value';
+import Selector from './selector';
+import AtRule from './atrule';
+import NestableAtRulePrototype from './nested-at-rule';
+import Anonymous from './anonymous';
+import Expression from './expression';
+import Ruleset from './ruleset';
+
+const StartingStyle = function(value, features, index, currentFileInfo, visibilityInfo) {
+    this._index = index;
+    this._fileInfo = currentFileInfo;
+    var selectors = (new Selector([], null, null, this._index, this._fileInfo)).createEmptySelectors();
+    this.simpleBlock = features && features[0] instanceof Expression === false;
+   
+    if (this.simpleBlock) {
+        this.features = new Value(features);
+        this.declarations = value;
+        this.allowRoot = true;
+     
+        this.setParent(selectors, this);
+        this.setParent(this.features, this);
+        this.setParent(this.declarations, this);
+    } else {
+        this.features = new Value([]);
+        this.rules = [new Ruleset(selectors, value)];//value;
+        this.rules[0].allowImports = true;
+        this.allowRoot = true;
+      
+        this.setParent(selectors, this);
+        this.setParent(this.features, this);
+        this.setParent(this.rules, this);
+    }
+
+    this.copyVisibilityInfo(visibilityInfo);
+
+};
+
+StartingStyle.prototype = Object.assign(new AtRule(), {
+    type: 'StartingStyle',
+
+    ...NestableAtRulePrototype,
+
+    genCSS(context, output) {
+        output.add('@starting-style', this._fileInfo, this._index);
+        context.firstSelector = true;
+        
+        this.features.genCSS(context, output);
+       
+        if (this.simpleBlock) {
+            this.outputRuleset(context, output, this.declarations);
+        } else {
+            this.outputRuleset(context, output, this.rules);  
+        }
+    },
+
+    eval(context) {
+        if (!context.mediaBlocks) {
+            context.mediaBlocks = [];
+            context.mediaPath = [];
+        }
+
+        const media = new StartingStyle(null, [], this._index, this._fileInfo, this.visibilityInfo());
+
+        if (this.simpleBlock) {
+            if (this.debugInfo) {
+                this.declarations[0].debugInfo = this.debugInfo;
+                media.debugInfo = this.debugInfo;
+            }
+
+            media.features = this.features.eval(context);
+
+            this.declarations[0].functionRegistry = context.frames[0].functionRegistry.inherit();
+            context.frames.unshift(this.declarations[0]);
+            media.declarations = this.declarations.map(rule => rule.eval(context));
+          
+            context.frames.shift();
+
+            return context.mediaPath.length == 0 ? media.evalTop(context) :
+                media.evalNestedBlock(context);
+        } else {
+            media.simpleBlock = false;
+
+            if (this.debugInfo) {
+                this.rules[0].debugInfo = this.debugInfo;
+                media.debugInfo = this.debugInfo;
+            }
+
+            media.features = this.features.eval(context);
+          
+            context.mediaPath.push(media);
+            context.mediaBlocks.push(media);
+          
+            this.rules[0].functionRegistry = context.frames[0].functionRegistry.inherit();
+            context.frames.unshift(this.rules[0]);
+            media.rules = [this.rules[0].eval(context)];
+
+            context.frames.shift();
+            context.mediaPath.pop();
+           
+            return context.mediaPath.length === 0 ? media.evalTop(context) :
+                media.evalNested(context);
+        }
+    },
+
+    evalNestedBlock: function (context) {
+        let i;
+        let value;
+        let path = context.mediaPath.concat([this]);
+       
+        for (i = 0; i < path.length; i++) {
+            value = path[i].features instanceof Value ?
+                path[i].features.value : path[i].features;
+            path[i] = Array.isArray(value) ? value : [value];
+        }
+
+        this.features = new Value(this.permute(path).map(function (path) {
+            path = path.map(function (fragment) { return fragment.toCSS ? fragment : new Anonymous(fragment); });
+            for (i = path.length - 1; i > 0; i--) {
+                path.splice(i, 0, new Anonymous('and'));
+            }
+            return new Expression(path);
+        }));
+        
+        this.setParent(this.features, this);
+
+        return new StartingStyle(this.declarations, this.features, this._index, this._fileInfo, this.visibilityInfo());
+    },
+});
+
+export default StartingStyle;

--- a/packages/less/src/less/visitors/import-visitor.js
+++ b/packages/less/src/less/visitors/import-visitor.js
@@ -188,6 +188,12 @@ ImportVisitor.prototype = {
     },
     visitMediaOut: function (mediaNode) {
         this.context.frames.shift();
+    },
+    visitStartingStyle: function (mediaNode, visitArgs) {
+        this.context.frames.unshift(mediaNode.declarations ? mediaNode.declarations[0] : mediaNode.rules[0]);
+    },
+    visitStartingStyleOut: function (mediaNode) {
+        this.context.frames.shift();
     }
 };
 export default ImportVisitor;

--- a/packages/less/src/less/visitors/join-selector-visitor.js
+++ b/packages/less/src/less/visitors/join-selector-visitor.js
@@ -56,6 +56,16 @@ class JoinSelectorVisitor {
             atRuleNode.rules[0].root = (atRuleNode.isRooted || context.length === 0 || null);
         }
     }
+
+    visitStartingStyle(mediaNode, visitArgs) {
+        let context = this.contexts[this.contexts.length - 1];
+        
+        if (mediaNode.declarations) {
+            mediaNode.declarations[0].root = (context.length === 0 || context[0].multiMedia);
+        } else {
+            mediaNode.rules[0].root = (context.length === 0 || context[0].multiMedia);
+        }
+    }
 }
 
 export default JoinSelectorVisitor;

--- a/packages/test-data/css/_main/starting-style.css
+++ b/packages/test-data/css/_main/starting-style.css
@@ -1,0 +1,41 @@
+#nav {
+  transition: background-color 3.5s;
+  background-color: gray;
+}
+[popover]:popover-open {
+  opacity: 1;
+  transform: scaleX(1);
+  @starting-style {
+    opacity: 0;
+    transform: scaleX(0);
+  }
+}
+#target {
+  transition: background-color 1.5s;
+  background-color: green;
+}
+@starting-style {
+  #target {
+    background-color: transparent;
+  }
+}
+#source {
+  transition: background-color 2.5s;
+  background-color: red;
+}
+source:first {
+  opacity: 1;
+  transform: scaleX(1);
+  @starting-style {
+    opacity: 0;
+    transform: scaleX(0);
+  }
+}
+#footer {
+  color: yellow;
+}
+@starting-style {
+  #footer {
+    background-color: transparent;
+  }
+}

--- a/packages/test-data/less/_main/starting-style.less
+++ b/packages/test-data/less/_main/starting-style.less
@@ -1,0 +1,50 @@
+#nav {
+    transition: background-color 3.5s;
+    background-color: gray;
+}
+
+[popover]:popover-open {
+    opacity: 1;
+    transform: scaleX(1);
+
+    @starting-style {
+        opacity: 0;
+        transform: scaleX(0);
+    }
+}
+
+#target {
+    transition: background-color 1.5s;
+    background-color: green;
+}
+
+@starting-style {
+    #target {
+        background-color: transparent;
+    }
+}
+
+#source {
+    transition: background-color 2.5s;
+    background-color: red;
+}
+
+source:first {
+    opacity: 1;
+    transform: scaleX(1);
+
+    @starting-style {
+        opacity: 0;
+        transform: scaleX(0);
+    }
+}
+
+#footer {
+    color: yellow;
+}
+
+@starting-style {
+    #footer {
+        background-color: transparent;
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

This pull request resolves issue [#4247](https://github.com/less/less.js/issues/4267) by fixing ```@starting-style``` at-rule nesting.

**Why**:

Users of Less.js may wish to use newer features of CSS supported by newer versions of most browsers. Estimated support for ```@starting-style``` is 84.76%+ (https://caniuse.com/mdn-css_at-rules_starting-style).

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->

**Bundle size:**

Less.js ```4.2.1``` minified is 151,936 bytes.
With PR merged Less.js bundle minified becomes 155,088 bytes.
Delta: 3,152 bytes

Lines of code delta: 275 added (including tests)

The following Less:

```css
[popover]:popover-open {
    opacity: 1;
    transform: scaleX(1);

    @starting-style {
        opacity: 0;
        transform: scaleX(0);
    }
}
```

becomes:

```css
[popover]:popover-open {
  opacity: 1;
  transform: scaleX(1);
  @starting-style {
    opacity: 0;
    transform: scaleX(0);
  }
}
```