### PR TITLE
fix(issue:4268) nested pseudo-selector parsing

### DIFF
--- a/packages/test-data/css/_main/selectors.css
+++ b/packages/test-data/css/_main/selectors.css
@@ -183,3 +183,9 @@ blank blank blank blank blank blank blank blank blank blank blank blank blank bl
 .first-level .second-level.active2 {
   content: '\2661';
 }
+a:is(.b, :is(.c)) {
+  color: blue;
+}
+a:is(.b, :is(.c), :has(div)) {
+  color: red;
+}

--- a/packages/test-data/less/_main/selectors.less
+++ b/packages/test-data/less/_main/selectors.less
@@ -200,3 +200,11 @@ blank blank blank blank blank blank blank blank blank blank blank blank blank bl
     &.active2:extend(.extend-this) { }
   }
 }
+
+a:is(.b, :is(.c)) {
+  color: blue;
+}
+
+a:is(.b, :is(.c), :has(div)) {
+  color: red;
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fix for issue https://github.com/less/less.js/issues/4268.

<!-- Why are these changes necessary? -->

**Why**:

Issue #4268 concerns valid CSS, see example CodePen: https://codepen.io/puckowski/pen/azooPzZ?editors=1111

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->

Lines of code delta: 38 added (including tests)

The following Less

```css
a:is(.b, :is(.c)) {
  color: blue;
}

a:is(.b, :is(.c), :has(div)) {
  color: red;
}
```


becomes:

```css
a:is(.b, :is(.c)) {
  color: blue;
}
a:is(.b, :is(.c), :has(div)) {
  color: red;
}
```