### PR TITLE
fix(issue:4258) variable interpolation after math

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -1731,7 +1731,9 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                             }
                             // Treat like quoted values, but replace vars like unquoted expressions
                             const quote = new tree.Quoted('\'', item, true, index, fileInfo);
-                            quote.variableRegex = /@([\w-]+)/g;
+                            if (!item.startsWith('@{')) {
+                                quote.variableRegex = /@([\w-]+)/g;
+                            }
                             quote.propRegex = /\$([\w-]+)/g;
                             result.push(quote);
                         }

--- a/packages/test-data/css/_main/variables.css
+++ b/packages/test-data/css/_main/variables.css
@@ -69,7 +69,6 @@
   mul-px-2: 140px;
   mul-px-3: 140px;
 }
-<<<<<<< HEAD
 *,
 ::before,
 ::after {
@@ -77,8 +76,7 @@
   --tw-pan-y: ;
   --tw-pinch-zoom: ;
   --tw-scroll-snap-strictness: proximity;
-=======
+}
 .radio_checked {
   border-color: #fff;
->>>>>>> 9434f18b (fix(issue:4258) variable interpolation after math)
 }

--- a/packages/test-data/css/_main/variables.css
+++ b/packages/test-data/css/_main/variables.css
@@ -69,6 +69,7 @@
   mul-px-2: 140px;
   mul-px-3: 140px;
 }
+<<<<<<< HEAD
 *,
 ::before,
 ::after {
@@ -76,4 +77,8 @@
   --tw-pan-y: ;
   --tw-pinch-zoom: ;
   --tw-scroll-snap-strictness: proximity;
+=======
+.radio_checked {
+  border-color: #fff;
+>>>>>>> 9434f18b (fix(issue:4258) variable interpolation after math)
 }

--- a/packages/test-data/less/_main/variables.less
+++ b/packages/test-data/less/_main/variables.less
@@ -132,3 +132,14 @@
 	--tw-pinch-zoom:  ;
 	--tw-scroll-snap-strictness: proximity;
 }
+
+@a1: 1px;
+@b2: 2px;
+@c3: @a1 + @b2;
+
+@radio-cls: radio;
+@radio-cls-checked: @{radio-cls}_checked;
+
+.@{radio-cls-checked} {
+  border-color: #fff;
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes variable interpolation issue after previous variable addition.

<!-- Why are these changes necessary? -->

**Why**:

Current Less.js takes:

```css
@a: 1px;
@b: 2px;
@c: @a + @b;

@radio-cls: radio;
@radio-cls-checked: @{radio-cls}_checked;

.@{radio-cls-checked} {
  border-color: #fff;
}
```

and produces:

```css
._checked {
  border-color: #fff;
}
```

With fix the CSS is:

```css
.radio_checked {
  border-color: #fff;
}
```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->

Tests passing locally. Updated tests for variables.