### PR TITLE
fix(issue:4264) strip line comment from expression

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -2418,7 +2418,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
 
                 do {
                     e = this.comment();
-                    if (e) {
+                    if (e && !e.isLineComment) {
                         entities.push(e);
                         continue;
                     }

--- a/packages/test-data/css/_main/variables.css
+++ b/packages/test-data/css/_main/variables.css
@@ -80,3 +80,18 @@
 .radio_checked {
   border-color: #fff;
 }
+div#apple {
+  color: blue;
+}
+div#banana {
+  color: blue;
+}
+div#cherry {
+  color: blue;
+}
+div#carrot {
+  color: blue;
+}
+div#potato {
+  color: blue;
+}

--- a/packages/test-data/less/_main/variables.less
+++ b/packages/test-data/less/_main/variables.less
@@ -143,3 +143,19 @@
 .@{radio-cls-checked} {
   border-color: #fff;
 }
+
+@items:
+// Fruit
+    apple,
+    banana,
+    cherry,
+// Vegetables
+    carrot,
+    potato,
+;
+
+each(@items, {
+  div#@{value} {
+    color: blue;
+  }
+})


### PR DESCRIPTION

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fix for issue #4264. Strip line comments from expressions to avoid invalid CSS output.

<!-- Why are these changes necessary? -->

**Why**:

Less.js currently takes CSS like:

```css
@items:
// Fruit
    apple,
    banana,
    cherry,

// Vegetables
    carrot,
    potato,
;

each(@items, {
  div#@{value} {
    color: blue;
  }
})
```

and outputs:

```css
div#apple {
  color: blue;
}
div#banana {
  color: blue;
}
div#cherry {
  color: blue;
}
div#// Vegetables carrot {
  color: blue;
}
div#potato {
  color: blue;
}
```

With fix the output is:

```css
div#apple {
  color: blue;
}
div#banana {
  color: blue;
}
div#cherry {
  color: blue;
}
div#carrot {
  color: blue;
}
div#potato {
  color: blue;
}
```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->

Tests passing locally. Updated tests for variables.