### PR TITLE
fix(issue:3737) allow blank variable declarations

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -1598,7 +1598,11 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
 
                         // Custom property values get permissive parsing
                         if (name[0].value && name[0].value.slice(0, 2) === '--') {
-                            value = this.permissiveValue(/[;}]/);
+                            if (parserInput.$char(';')) {
+                                value = new Anonymous('');
+                            } else {
+                                value = this.permissiveValue(/[;}]/);
+                            }
                         }
                         // Try to store values as anonymous
                         // If we need the value later we'll re-parse it in ruleset.parseValue

--- a/packages/test-data/css/_main/variables.css
+++ b/packages/test-data/css/_main/variables.css
@@ -69,3 +69,11 @@
   mul-px-2: 140px;
   mul-px-3: 140px;
 }
+*,
+::before,
+::after {
+  --tw-pan-x: ;
+  --tw-pan-y: ;
+  --tw-pinch-zoom: ;
+  --tw-scroll-snap-strictness: proximity;
+}

--- a/packages/test-data/less/_main/variables.less
+++ b/packages/test-data/less/_main/variables.less
@@ -125,3 +125,10 @@
     mul-px-3: ((@px * 1) * @cm);
   }
 }
+
+*, ::before, ::after {
+	--tw-pan-x:  ;
+	--tw-pan-y:  ;
+	--tw-pinch-zoom:  ;
+	--tw-scroll-snap-strictness: proximity;
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes issue #3737 where blank CSS variable declarations resulted in parsing errors.

<!-- Why are these changes necessary? -->

**Why**:

Blank CSS variables are valid.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->

Existing tests are passing locally.

The following Less.js:

```css
*, ::before, ::after {
  --tw-pan-x:  ;
  --tw-pan-y:  ;
  --tw-pinch-zoom:  ;
  --tw-scroll-snap-strictness: proximity;
}
```

becomes:

```css
*,
::before,
::after {
  --tw-pan-x: ;
  --tw-pan-y: ;
  --tw-pinch-zoom: ;
  --tw-scroll-snap-strictness: proximity;
}
```