### PR TITLE
Master fix 3622

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -1320,14 +1320,18 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                         }
                         vSelectors.push(v);
 
-                        if (v && parserInput.$char(')')) {
-                            if (vSelectors.length === 1) {
-                                e = new (tree.Paren)(vSelectors[0]);
+                        if (v) {
+                            if (parserInput.$char(')')) {
+                                if (vSelectors.length === 1) {
+                                    e = new (tree.Paren)(vSelectors[0]);
+                                } else {
+                                    e = new (tree.ListParen)(vSelectors);
+                                }
                             } else {
-                                e = new (tree.ListParen)(vSelectors);
+                                parserInput.restore('Missing closing \')\'');
                             }
                         } else {
-                            parserInput.restore('Missing closing \')\'');
+                            parserInput.restore('Could not find valid selector');
                         }
                     } else {
                         parserInput.forget();

--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -1410,7 +1410,9 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     } else {
                         if (allExtends) { error('Extend can only be used at the end of selector'); }
                         c = parserInput.currentChar();
-                        if (elements) {
+                        if (Array.isArray(e)){
+                            e.forEach(ele => elements.push(ele));
+                        } if (elements) {
                             elements.push(e);
                         } else {
                             elements = [ e ];

--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -5,7 +5,6 @@ import getParserInput from './parser-input';
 import * as utils from '../utils';
 import functionRegistry from '../functions/function-registry';
 import { ContainerSyntaxOptions, MediaSyntaxOptions } from '../tree/atrule-syntax';
-import Selector from '../tree/selector';
 import Anonymous from '../tree/anonymous';
 
 //
@@ -1314,24 +1313,18 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 if (!e) {
                     parserInput.save();
                     if (parserInput.$char('(')) {
-                        if ((v = this.selector(false))) {
-                            let selectors = [];
-                            while (parserInput.$char(',')) {
-                                selectors.push(v);
-                                selectors.push(new Anonymous(','));
-                                v = this.selector(false);
-                            }
-                            selectors.push(v);
-                                                        
-                            if (parserInput.$char(')')) {
-                                if (selectors.length > 1) {
-                                    e = new (tree.Paren)(new Selector(selectors));
-                                } else {
-                                    e = new(tree.Paren)(v);
-                                }
-                                parserInput.forget();
+                        let vSelectors = [];
+                        while ((v = this.selector(false)) && parserInput.$char(',')) {
+                            vSelectors.push(v);
+                            vSelectors.push(new Anonymous(','));
+                        }
+                        vSelectors.push(v);
+
+                        if (v && parserInput.$char(')')) {
+                            if (vSelectors.length === 1) {
+                                e = new (tree.Paren)(vSelectors[0]);
                             } else {
-                                parserInput.restore('Missing closing \')\'');
+                                e = new (tree.ListParen)(vSelectors);
                             }
                         } else {
                             parserInput.restore('Missing closing \')\'');

--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -1410,9 +1410,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     } else {
                         if (allExtends) { error('Extend can only be used at the end of selector'); }
                         c = parserInput.currentChar();
-                        if (Array.isArray(e)){
-                            e.forEach(ele => elements.push(ele));
-                        } if (elements) {
+                        if (elements) {
                             elements.push(e);
                         } else {
                             elements = [ e ];

--- a/packages/less/src/less/tree/index.js
+++ b/packages/less/src/less/tree/index.js
@@ -38,6 +38,7 @@ import NamespaceValue from './namespace-value';
 // mixins
 import MixinCall from './mixin-call';
 import MixinDefinition from './mixin-definition';
+import ListParen from './list-paren';
 
 export default {
     Node, Color, AtRule, DetachedRuleset, Operation,
@@ -47,7 +48,7 @@ export default {
     Comment, Anonymous, Value, JavaScript, Assignment,
     Condition, Paren, Media, Container, QueryInParens, 
     UnicodeDescriptor, Negative, Extend, VariableCall, 
-    NamespaceValue,
+    NamespaceValue, ListParen,
     mixin: {
         Call: MixinCall,
         Definition: MixinDefinition

--- a/packages/less/src/less/tree/list-paren.js
+++ b/packages/less/src/less/tree/list-paren.js
@@ -1,0 +1,21 @@
+import Node from './node';
+
+const ListParen = function(node) {
+    this.value = node;
+};
+
+ListParen.prototype = Object.assign(new Node(), {
+    type: 'ListParen',
+
+    genCSS(context, output) {
+        output.add('(');
+        this.value.forEach(val => val.genCSS(context, output));
+        output.add(')');
+    },
+
+    eval(context) {
+        return new ListParen(this.value.map(val => val.eval(context)));
+    }
+});
+
+export default ListParen;

--- a/packages/test-data/css/_main/selectors.css
+++ b/packages/test-data/css/_main/selectors.css
@@ -189,3 +189,24 @@ a:is(.b, :is(.c)) {
 a:is(.b, :is(.c), :has(div)) {
   color: red;
 }
+@-moz-document domain("example.com") {
+  :is(
+    [a1],
+    [a2]
+  ):is( [a3], [a4]:not( :is([a5],[a6])):is( [a7]:not(:is([a8],[a9])), [b1]:not(:is([b2],[b3]))):is(
+      [b4],[b5]
+    ), [b6], [b7]) {
+    color: red;
+  }
+}
+@-moz-document domain("example.com") {
+  :is([foo], [bar], [baz]) {
+    color: red;
+  }
+}
+:is(.color-1, .focus-color-1:focus, .hover-color-1:hover) {
+  color: red !important;
+}
+:is(.color-2, .focus-color-2:focus, .hover-color-2:hover) {
+  color: green !important;
+}

--- a/packages/test-data/less/_main/selectors.less
+++ b/packages/test-data/less/_main/selectors.less
@@ -208,3 +208,39 @@ a:is(.b, :is(.c)) {
 a:is(.b, :is(.c), :has(div)) {
   color: red;
 }
+
+@-moz-document domain("example.com") {
+  :is(
+    [a1],
+    [a2]
+  ):is(
+    [a3],
+    [a4]:not(
+      :is([a5],[a6])
+    ):is(
+      [a7]:not(:is([a8],[a9])),
+      [b1]:not(:is([b2],[b3]))
+    ):is(
+      [b4],[b5]
+    ),
+    [b6],
+    [b7]
+  ) {
+    color: red; }
+
+}
+
+@-moz-document domain("example.com") {
+	:is([foo], [bar] /* :is(a, b) */, [baz]) {
+		color: red; }
+}
+
+@color: red green;
+
+each(@color, {
+  :is(.color-@{key},
+  .focus-color-@{key}:focus,
+  .hover-color-@{key}:hover) {
+    color: @value !important;
+  }
+});


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Contains fixes for a variety of syntax raised in https://github.com/less/less.js/issues/3622

<!-- Why are these changes necessary? -->

**Why**:

Existing less code was too rigid and expected ```)``` where a list of selectors was possible.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->

The following Less.js:

```css
@-moz-document domain("example.com") {
  :is(
    [a1],
    [a2]
  ):is(
    [a3],
    [a4]:not(
      :is([a5],[a6])
    ):is(
      [a7]:not(:is([a8],[a9])),
      [b1]:not(:is([b2],[b3]))
    ):is(
      [b4],[b5]
    ),
    [b6],
    [b7]
  ) {
    color: red; }

}

@-moz-document domain("example.com") {
	:is([foo], [bar] /* :is(a, b) */, [baz]) {
		color: red; }
}

@color: red green;

each(@color, {
  :is(.color-@{key},
  .focus-color-@{key}:focus,
  .hover-color-@{key}:hover) {
    color: @value !important;
  }
});
```

becomes the following CSS:

```css
@-moz-document domain("example.com") {
  :is(
    [a1],
    [a2]
  ):is( [a3], [a4]:not( :is([a5],[a6])):is( [a7]:not(:is([a8],[a9])), [b1]:not(:is([b2],[b3]))):is(
      [b4],[b5]
    ), [b6], [b7]) {
    color: red;
  }
}
@-moz-document domain("example.com") {
  :is([foo], [bar], [baz]) {
    color: red;
  }
}
:is(.color-1, .focus-color-1:focus, .hover-color-1:hover) {
  color: red !important;
}
:is(.color-2, .focus-color-2:focus, .hover-color-2:hover) {
  color: green !important;
}
```