### PR TITLE
Master fix 3767 2

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -1604,6 +1604,9 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                                 value = this.permissiveValue(/[;}]/);
                             }
                         }
+                        else if (isVariable) {
+                            value = this.variableValue();
+                        }
                         // Try to store values as anonymous
                         // If we need the value later we'll re-parse it in ruleset.parseValue
                         else {
@@ -1636,6 +1639,18 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     }
                 } else {
                     parserInput.restore();
+                }
+            },
+            variableValue: function () {
+                let match = this.anonymousValue();
+                if (match) {
+                    return match;
+                } else {
+                    const index = parserInput.i;
+                    match = parserInput.$re(/^([^#@$+/'"*`(;{}-]*);|(^[(?!.*\n)^.#@$+/'"*`(;{}-]*)(["'])((?!.*@.*)(?<!.*@.*).+?)\1;/);
+                    if (match) {
+                        return new(tree.Anonymous)(match[0].slice(0, -1), index + currentIndex);
+                    }
                 }
             },
             anonymousValue: function () {

--- a/packages/test-data/css/_main/variables.css
+++ b/packages/test-data/css/_main/variables.css
@@ -88,4 +88,6 @@
   m-5: a "a.ab" c c 'a.bc' abc d;
   m-6: a.hello;
   m-7: 'a.b' "abc" abc a.b.c 'a.b.c';
+  m-8: hello;
+  m-9: 'a.hello';
 }

--- a/packages/test-data/css/_main/variables.css
+++ b/packages/test-data/css/_main/variables.css
@@ -80,3 +80,12 @@
 .radio_checked {
   border-color: #fff;
 }
+.mixed {
+  m-1: "a.hello";
+  m-2: 'a';
+  m-3: 'a' a a "a.";
+  m-4: a "a-" a "abc";
+  m-5: a "a.ab" c c 'a.bc' abc d;
+  m-6: a.hello;
+  m-7: 'a.b' "abc" abc a.b.c 'a.b.c';
+}

--- a/packages/test-data/less/_main/variables.less
+++ b/packages/test-data/less/_main/variables.less
@@ -151,6 +151,8 @@
 @mixedThree: a "a.ab" c c 'a.bc' abc d;
 @mixedFour: a.hello;
 @mixedFive: 'a.b' "abc" abc a.b.c 'a.b.c';
+@mixedSix: hello;
+@mixedSeven: 'a.hello';
 
 .mixed {
     m-1: @doubleQuoted;
@@ -160,4 +162,6 @@
     m-5: @mixedThree;
     m-6: @mixedFour;
     m-7: @mixedFive;
+    m-8: @mixedSix;
+    m-9: @mixedSeven;
 }

--- a/packages/test-data/less/_main/variables.less
+++ b/packages/test-data/less/_main/variables.less
@@ -143,3 +143,21 @@
 .@{radio-cls-checked} {
   border-color: #fff;
 }
+
+@doubleQuoted: "a.hello";
+@quoted: 'a';
+@mixedOne: 'a' a a "a.";
+@mixedTwo: a "a-" a "abc";
+@mixedThree: a "a.ab" c c 'a.bc' abc d;
+@mixedFour: a.hello;
+@mixedFive: 'a.b' "abc" abc a.b.c 'a.b.c';
+
+.mixed {
+    m-1: @doubleQuoted;
+    m-2: @quoted;
+    m-3: @mixedOne;
+    m-4: @mixedTwo;
+    m-5: @mixedThree;
+    m-6: @mixedFour;
+    m-7: @mixedFive;
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This PR contains a proposed solution for https://github.com/less/less.js/issues/3767

Variable values with periods were working in Less.js version ```3.0.4``` but no longer worked as of version ```3.5.0``` due to a strict regex on variable values.

Instead of trying to automatically wrap Less.js CLI global variables in quotes to circumvent this issue (not sure if that would break anyone's flow), I decided to tweak to regex logic to allow periods in variable values under certain conditions.

<!-- Why are these changes necessary? -->

**Why**:

<!-- Have you done all of these things?  -->

With the fix, Less.js CLI and browser based flows become more flexible.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->

The tests are a bit esoteric but are intended to show the new logic works correctly without breaking any existing test.