### PR TITLE
chore: bump make-dir to v5 without semver vulnerability

### DIFF
--- a/packages/less/package-lock.json
+++ b/packages/less/package-lock.json
@@ -70,7 +70,7 @@
 				"errno": "^0.1.1",
 				"graceful-fs": "^4.1.2",
 				"image-size": "~0.5.0",
-				"make-dir": "^2.1.0",
+				"make-dir": "^5.0.0",
 				"mime": "^1.4.1",
 				"needle": "^3.1.0",
 				"source-map": "~0.6.0"
@@ -4422,25 +4422,15 @@
 			}
 		},
 		"node_modules/make-dir": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-5.0.0.tgz",
+			"integrity": "sha512-G0yBotnlWVonPClw+tq+xi4K7DZC9n96HjGTBDdHkstAVsDkfZhi1sTvZypXLpyQTbISBkDtK0E5XlUqDsShQg==",
 			"optional": true,
-			"dependencies": {
-				"pify": "^4.0.1",
-				"semver": "^5.6.0"
-			},
 			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/make-dir/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"optional": true,
-			"bin": {
-				"semver": "bin/semver"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/make-error": {
@@ -5552,15 +5542,6 @@
 			},
 			"engines": {
 				"node": ">=0.10"
-			}
-		},
-		"node_modules/pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"optional": true,
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/pinkie": {
@@ -11162,22 +11143,10 @@
 			}
 		},
 		"make-dir": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-			"optional": true,
-			"requires": {
-				"pify": "^4.0.1",
-				"semver": "^5.6.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-					"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-					"optional": true
-				}
-			}
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-5.0.0.tgz",
+			"integrity": "sha512-G0yBotnlWVonPClw+tq+xi4K7DZC9n96HjGTBDdHkstAVsDkfZhi1sTvZypXLpyQTbISBkDtK0E5XlUqDsShQg==",
+			"optional": true
 		},
 		"make-error": {
 			"version": "1.3.6",
@@ -12026,12 +11995,6 @@
 			"resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
 			"integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
 			"dev": true
-		},
-		"pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"optional": true
 		},
 		"pinkie": {
 			"version": "2.0.4",

--- a/packages/less/package.json
+++ b/packages/less/package.json
@@ -50,7 +50,7 @@
 		"errno": "^0.1.1",
 		"graceful-fs": "^4.1.2",
 		"image-size": "~0.5.0",
-		"make-dir": "^2.1.0",
+		"make-dir": "^5.0.0",
 		"mime": "^1.4.1",
 		"needle": "^3.1.0",
 		"source-map": "~0.6.0"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: bumps make-dir from v2 to v5

<!-- Why are these changes necessary? -->

**Why**: older versions of make-dir relied on a version of semver that had a vulnerability. make-dir v5 no longer has this dependency

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Added/updated unit tests N/A
- [x] Code complete

<!-- feel free to add additional comments -->
