### PR TITLE
Fix for Browser InjectJS when no html.head especially in TamperMonkey and ViolentMonkey

### DIFF
--- a/packages/less/src/less-browser/bootstrap.js
+++ b/packages/less/src/less-browser/bootstrap.js
@@ -42,26 +42,41 @@ function resolveOrReject(data) {
         head.removeChild(style);
     }
 }
-
-if (options.onReady) {
-    if (/!watch/.test(window.location.hash)) {
-        less.watch();
-    }
-    // Simulate synchronous stylesheet loading by hiding page rendering
-    if (!options.async) {
-        css = 'body { display: none !important }';
-        head = document.head || document.getElementsByTagName('head')[0];
-        style = document.createElement('style');
-
-        style.type = 'text/css';
-        if (style.styleSheet) {
-            style.styleSheet.cssText = css;
-        } else {
-            style.appendChild(document.createTextNode(css));
-        }
-
-        head.appendChild(style);
-    }
-    less.registerStylesheetsImmediately();
-    less.pageLoadFinished = less.refresh(less.env === 'development').then(resolveOrReject, resolveOrReject);
+function waitForHTMLHead() {
+    return new Promise((resolve) => {
+        const checkHead = () => {
+            const head = document.head || document.getElementsByTagName('head')[0];
+            if (head) {
+                resolve(head);
+            } else {
+                requestAnimationFrame(checkHead);
+            }
+        };
+        checkHead();
+    });
 }
+
+waitForHTMLHead().then(() => {
+    if (options.onReady) {
+        if (/!watch/.test(window.location.hash)) {
+            less.watch();
+        }
+        // Simulate synchronous stylesheet loading by hiding page rendering
+        if (!options.async) {
+            css = 'body { display: none !important }';
+            head = document.head || document.getElementsByTagName('head')[0];
+            style = document.createElement('style');
+    
+            style.type = 'text/css';
+            if (style.styleSheet) {
+                style.styleSheet.cssText = css;
+            } else {
+                style.appendChild(document.createTextNode(css));
+            }
+    
+            head.appendChild(style);
+        }
+        less.registerStylesheetsImmediately();
+        less.pageLoadFinished = less.refresh(less.env === 'development').then(resolveOrReject, resolveOrReject);
+    }
+})


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Runtime at browser. fix for less.js is inject into browser by `TamperMonkey` or `ViolentMonkey`, but there is no head tag or even html tag.

<!-- Why are these changes necessary? -->

**Why**: without head tag, less.js won't work proplywork properly. it will throw a error `TypeError: head is undefined`
![image](https://github.com/user-attachments/assets/34c43895-1060-42e3-9edc-5bccb8ff2033)


<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation  N/A
- [ ] Added/updated unit tests  N/A - all test good, and no need for special test
- [x] Code complete

<!-- feel free to add additional comments -->
PR Reason for: when ViolentMonkey xx.user.js use less.js as a library, they will inject the script to chrome content, at that time webpage `head ` tag or even `html` tag doesn't exist, and then error happed, then all xxx.user.js won't work.
![image](https://github.com/user-attachments/assets/1eba5854-471f-4765-b634-451bbe465ca6)
