### PR TITLE
Remove duplicate length check from expression.genCSS()

### DIFF
--- a/packages/less/src/less/tree/expression.js
+++ b/packages/less/src/less/tree/expression.js
@@ -57,7 +57,7 @@ Expression.prototype = Object.assign(new Node(), {
         for (let i = 0; i < this.value.length; i++) {
             this.value[i].genCSS(context, output);
             if (!this.noSpacing && i + 1 < this.value.length) {
-                if (i + 1 < this.value.length && !(this.value[i + 1] instanceof Anonymous) ||
+                if (!(this.value[i + 1] instanceof Anonymous) ||
                     this.value[i + 1] instanceof Anonymous && this.value[i + 1].value !== ',') {
                     output.add(' ');
                 }


### PR DESCRIPTION
**What**:

Remove redundant code.

Credit to @anny21 who found this at https://gerrit.wikimedia.org/r/1129964, https://github.com/wikimedia/less.php/commit/bed2c0cd7b2f0b3fab304db679d122f415404a0d.

**Why**:

Follows-up 53f84f02bad6e, which added the conditional with a check for `i + 1 < this.value.length`, which is duplicated from the parent conditional that guruantees the same already with nothing in-between for it to change.

As redundancy, this is inefficient, and its presence could also be confusing to future maintainers.

**Checklist**:

- [x] Documentation, N/A
- [x] Added/updated unit tests, N/A
- [x] Code complete