### PR TITLE
fix(issue:4331) and keyword treated as function

### DIFF
--- a/packages/less/src/less/functions/index.js
+++ b/packages/less/src/less/functions/index.js
@@ -13,6 +13,7 @@ import string from './string';
 import svg from './svg';
 import types from './types';
 import style from './style';
+import size from './size';
 
 export default environment => {
     const functions = { functionRegistry, functionCaller };
@@ -30,6 +31,7 @@ export default environment => {
     functionRegistry.addMultiple(svg(environment));
     functionRegistry.addMultiple(types);
     functionRegistry.addMultiple(style);
+    functionRegistry.addMultiple(size);
 
     return functions;
 };

--- a/packages/less/src/less/functions/size.js
+++ b/packages/less/src/less/functions/size.js
@@ -1,0 +1,23 @@
+import Variable from '../tree/variable';
+import Anonymous from '../tree/variable';
+
+const sizeExpression = function (args) {
+    args = Array.prototype.slice.call(args);
+    switch (args.length) {
+        case 0: throw { type: 'Argument', message: 'one or more arguments required' };
+    }
+    
+    const entityList = [new Variable(args[0].value, this.index, this.currentFileInfo).eval(this.context)];
+       
+    args = entityList.map(a => { return a.toCSS(this.context); }).join(this.context.compress ? ',' : ', ');
+    
+    return new Anonymous(`size(${args})`);
+};
+
+export default {
+    size: function(...args) {
+        try {
+            return sizeExpression.call(this, args);
+        } catch (e) {}
+    },
+};

--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -482,13 +482,20 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     const index = parserInput.i;
 
                     parserInput.save();
-
+                    
+                    let keywordEntity = this.entities.keyword();
+                    parserInput.restore();
+                    parserInput.save();
+                    
                     validCall = parserInput.$re(/^[\w]+\(/);
                     if (!validCall) {
                         parserInput.forget();
                         return;
+                    } else if (validCall && keywordEntity && !functionRegistry.get(validCall.substring(0, validCall.length - 1))) {
+                        parserInput.restore();
+                        return;
                     }
-
+                        
                     validCall = validCall.substring(0, validCall.length - 1);
 
                     let rule = this.ruleProperty();

--- a/packages/test-data/css/_main/media.css
+++ b/packages/test-data/css/_main/media.css
@@ -269,3 +269,11 @@
     padding: 0;
   }
 }
+@media screen and (max-width: 1280px) {
+  .form-process-table {
+    width: 1200px;
+  }
+  .form-process-table > div {
+    width: 960px;
+  }
+}

--- a/packages/test-data/less/_main/media.less
+++ b/packages/test-data/less/_main/media.less
@@ -297,3 +297,12 @@
     }
   }
 }
+
+@media screen and(max-width:1280px) {
+  .form-process-table {
+    width: 1200px;
+    > div {
+      width: 960px;
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fix for issue #4331 

The ```and``` keyword was being treated as a function call starting Less ```4.2.1``` which introduced selector generation problems.

<!-- Why are these changes necessary? -->

**Why**:

The following Less:

```css
@media screen and(max-width:1280px) {
  .form-process-table {
    width: 1200px;
    > div {
      width: 960px;
    }
  }
}
```

would fail to insert a space after ```and``` ```Keyword``` like it did in Less ```4.2.0```. This would cause selector issues in the resulting CSS.

I simultaneously had to add a function definition for ```size``` to avoid regressions with container queries when fixing this ```and``` issue.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->
