### PR TITLE
fix(issue:4267) support starting-style at-rule

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -2102,6 +2102,9 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                         hasUnknown = true;
                         isRooted = false;
                         break;
+                    case '@starting-style':
+                        isRooted = false;
+                        break;
                     default:
                         hasUnknown = true;
                         break;

--- a/packages/less/src/less/tree/atrule.js
+++ b/packages/less/src/less/tree/atrule.js
@@ -69,8 +69,8 @@ AtRule.prototype = Object.assign(new Node(), {
 
     ...NestableAtRulePrototype,
 
-    declarationsBlock(rules, mergable = false) {
-        if (!mergable) {
+    declarationsBlock(rules, mergeable = false) {
+        if (!mergeable) {
             return rules.filter(function (node) { return (node.type === 'Declaration' || node.type === 'Comment') && !node.merge}).length === rules.length;
         } else {
             return rules.filter(function (node) { return (node.type === 'Declaration' || node.type === 'Comment'); }).length === rules.length;

--- a/packages/less/src/less/tree/atrule.js
+++ b/packages/less/src/less/tree/atrule.js
@@ -21,11 +21,11 @@ const AtRule = function(
     this.value = (value instanceof Node) ? value : (value ? new Anonymous(value) : value);
     if (rules) {
         if (Array.isArray(rules)) {
-            const allDeclarations = rules.filter(function (node) { return node.type === 'Declaration' && !node.merge; }).length === rules.length;
+            const allDeclarations = rules.filter(function (node) { return (node.type === 'Declaration' || node.type === 'Comment') && !node.merge; }).length === rules.length;
            
             let allRulesetDeclarations = true;
             rules.forEach(rule => {
-                if (rule.type === 'Ruleset' && rule.rules) allRulesetDeclarations = allRulesetDeclarations && rule.rules.filter(function (node) { return node.type === 'Declaration'; }).length === rule.rules.length
+                if (rule.type === 'Ruleset' && rule.rules) allRulesetDeclarations = allRulesetDeclarations && rule.rules.filter(function (node) { return (node.type === 'Declaration' || node.type === 'Comment'); }).length === rule.rules.length
             });
 
             if (allDeclarations && !isRooted) {
@@ -38,7 +38,7 @@ const AtRule = function(
                 this.rules = rules;
             }
         } else {
-            const allDeclarations = rules.rules.filter(function (node) { return node.type === 'Declaration' && !node.merge}).length === rules.rules.length;
+            const allDeclarations = rules.rules.filter(function (node) { return (node.type === 'Declaration' || node.type === 'Comment') && !node.merge}).length === rules.rules.length;
             
             if (allDeclarations && !isRooted && !value) {
                 this.simpleBlock = true;
@@ -125,11 +125,12 @@ AtRule.prototype = Object.assign(new Node(), {
             rules = this.evalRoot(context, rules);
         }
         if (Array.isArray(rules) && rules[0].rules && Array.isArray(rules[0].rules) && rules[0].rules.length) {
-            const allMergeableDeclarations = rules[0].rules.filter(function (node) { return node.type === 'Declaration'; }).length === rules[0].rules.length;
+            const allMergeableDeclarations = rules[0].rules.filter(function (node) { return (node.type === 'Declaration' || node.type === 'Comment'); }).length === rules[0].rules.length;
             if (allMergeableDeclarations && !this.isRooted && !value) {
                 var mergeRules = context.pluginManager.less.visitors.ToCSSVisitor.prototype._mergeRules;
                 mergeRules(rules[0].rules);
                 rules = rules[0].rules;
+                rules.forEach(rule => rule.merge = false);
             }
         }
         if (this.simpleBlock && rules) {

--- a/packages/less/src/less/visitors/import-visitor.js
+++ b/packages/less/src/less/visitors/import-visitor.js
@@ -166,7 +166,18 @@ ImportVisitor.prototype = {
         }
     },
     visitAtRule: function (atRuleNode, visitArgs) {
-        this.context.frames.unshift(atRuleNode);
+        //this.context.frames.unshift(atRuleNode);
+        if (atRuleNode.value) {//}} && !atRuleNode.declarations && !atRuleNode.rules) {
+            this.context.frames.unshift(atRuleNode);
+        } else if (atRuleNode.declarations && atRuleNode.declarations.length) {
+            if (atRuleNode.isRooted) {
+                this.context.frames.unshift(atRuleNode);
+            } else {
+                this.context.frames.unshift(atRuleNode.declarations[0]);
+            }
+        } else if (atRuleNode.rules && atRuleNode.rules.length) {
+            this.context.frames.unshift(atRuleNode);
+        }
     },
     visitAtRuleOut: function (atRuleNode) {
         this.context.frames.shift();

--- a/packages/less/src/less/visitors/import-visitor.js
+++ b/packages/less/src/less/visitors/import-visitor.js
@@ -166,8 +166,7 @@ ImportVisitor.prototype = {
         }
     },
     visitAtRule: function (atRuleNode, visitArgs) {
-        //this.context.frames.unshift(atRuleNode);
-        if (atRuleNode.value) {//}} && !atRuleNode.declarations && !atRuleNode.rules) {
+        if (atRuleNode.value) {
             this.context.frames.unshift(atRuleNode);
         } else if (atRuleNode.declarations && atRuleNode.declarations.length) {
             if (atRuleNode.isRooted) {

--- a/packages/less/src/less/visitors/join-selector-visitor.js
+++ b/packages/less/src/less/visitors/join-selector-visitor.js
@@ -52,7 +52,11 @@ class JoinSelectorVisitor {
 
     visitAtRule(atRuleNode, visitArgs) {
         const context = this.contexts[this.contexts.length - 1];
-        if (atRuleNode.rules && atRuleNode.rules.length) {
+
+        if (atRuleNode.declarations && atRuleNode.declarations.length) {
+            atRuleNode.declarations[0].root = (context.length === 0 || context[0].multiMedia);
+        }
+        else if (atRuleNode.rules && atRuleNode.rules.length) {
             atRuleNode.rules[0].root = (atRuleNode.isRooted || context.length === 0 || null);
         }
     }

--- a/packages/test-data/css/_main/starting-style.css
+++ b/packages/test-data/css/_main/starting-style.css
@@ -46,3 +46,10 @@ nav > [popover]:popover-open {
     padding: 10px 8px 6px 4px;
   }
 }
+aside > [popover]:popover-open {
+  opacity: 1;
+  transform: scaleX(1);
+  @starting-style {
+    padding: 10px 20px 30px 40px;
+  }
+}

--- a/packages/test-data/css/_main/starting-style.css
+++ b/packages/test-data/css/_main/starting-style.css
@@ -1,0 +1,48 @@
+#nav {
+  transition: background-color 3.5s;
+  background-color: gray;
+}
+[popover]:popover-open {
+  opacity: 1;
+  transform: scaleX(1);
+  @starting-style {
+    opacity: 0;
+    transform: scaleX(0);
+  }
+}
+#target {
+  transition: background-color 1.5s;
+  background-color: green;
+}
+@starting-style {
+  #target {
+    background-color: transparent;
+  }
+}
+#source {
+  transition: background-color 2.5s;
+  background-color: red;
+}
+source:first {
+  opacity: 1;
+  transform: scaleX(1);
+  @starting-style {
+    opacity: 0;
+    transform: scaleX(0);
+  }
+}
+#footer {
+  color: yellow;
+}
+@starting-style {
+  #footer {
+    background-color: transparent;
+  }
+}
+nav > [popover]:popover-open {
+  opacity: 1;
+  transform: scaleX(1);
+  @starting-style {
+    padding: 10px 8px 6px 4px;
+  }
+}

--- a/packages/test-data/less/_main/starting-style.less
+++ b/packages/test-data/less/_main/starting-style.less
@@ -60,3 +60,15 @@ nav > [popover]:popover-open {
     padding+_: 4px;
   }
 }
+
+aside > [popover]:popover-open {
+  opacity: 1;
+  transform: scaleX(1);
+
+  @starting-style {
+    // vector math
+    each(1 2 3 4, {
+        padding+_: (@value * 10px);
+    });
+  }
+}

--- a/packages/test-data/less/_main/starting-style.less
+++ b/packages/test-data/less/_main/starting-style.less
@@ -1,0 +1,62 @@
+#nav {
+    transition: background-color 3.5s;
+    background-color: gray;
+}
+
+[popover]:popover-open {
+    opacity: 1;
+    transform: scaleX(1);
+
+    @starting-style {
+        opacity: 0;
+        transform: scaleX(0);
+    }
+}
+
+#target {
+    transition: background-color 1.5s;
+    background-color: green;
+}
+
+@starting-style {
+    #target {
+        background-color: transparent;
+    }
+}
+
+#source {
+    transition: background-color 2.5s;
+    background-color: red;
+}
+
+source:first {
+    opacity: 1;
+    transform: scaleX(1);
+
+    @starting-style {
+        opacity: 0;
+        transform: scaleX(0);
+    }
+}
+
+#footer {
+    color: yellow;
+}
+
+@starting-style {
+    #footer {
+        background-color: transparent;
+    }
+}
+
+nav > [popover]:popover-open {
+  opacity: 1;
+  transform: scaleX(1);
+
+  @starting-style {
+    padding+_: 10px;
+    padding+_: 8px;
+    padding+_: 6px;
+    padding+_: 4px;
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This pull request resolves issue https://github.com/less/less.js/issues/4267 by fixing @starting-style at-rule nesting.

<!-- Why are these changes necessary? -->

**Why**:

Users of Less.js may wish to use newer features of CSS supported by newer versions of most browsers. Estimated support for @starting-style is 86.48%+ (https://caniuse.com/mdn-css_at-rules_starting-style).

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->

Per comment on https://github.com/less/less.js/pull/4289 I worked to add support for the ```starting-style``` at-rule by bolstering base ```AtRule``` tree node capabilities.

The following Less:

```css
[popover]:popover-open {
    opacity: 1;
    transform: scaleX(1);

    @starting-style {
        opacity: 0;
        transform: scaleX(0);
    }
}
```

becomes:

```css
[popover]:popover-open {
  opacity: 1;
  transform: scaleX(1);
  @starting-style {
    opacity: 0;
    transform: scaleX(0);
  }
}
```