### PR TITLE
fix(issue#4343) add color operands

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -2231,6 +2231,17 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 }
                 parserInput.restore();
             },
+            colorOperand: function () {
+                parserInput.save();
+                         
+                // hsl or rgb or lch operand
+                const match = parserInput.$re(/^[lchrgbs]\s+/);
+                if (match) {
+                    return new tree.Keyword(match[0]);
+                }
+
+                parserInput.restore();
+            },
             multiplication: function () {
                 let m;
                 let a;
@@ -2495,7 +2506,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                         entities.color() || entities.variable() ||
                         entities.property() || entities.call() ||
                         entities.quoted(true) || entities.colorKeyword() ||
-                        entities.mixinLookup();
+                        this.colorOperand() || entities.mixinLookup();
 
                 if (negate) {
                     o.parensInOp = true;

--- a/packages/test-data/css/_main/colors.css
+++ b/packages/test-data/css/_main/colors.css
@@ -102,3 +102,39 @@
   --semi-transparent-dark-background: #001e00ee;
   --semi-transparent-dark-background-2: #001e00;
 }
+.color-oklch-sub {
+  background: oklch(from #0000FF calc(l - 0.1) c h);
+}
+.color-oklch-add {
+  background: oklch(from #0000FF calc(l + 0.1) c h);
+}
+.color-oklch-mult {
+  background: oklch(from #0000FF calc(l * 0.1) c h);
+}
+.color-oklch-div {
+  background: oklch(from #0000FF calc(l / 2) c h);
+}
+.color-hsl-sub {
+  background: hsl(from #0000FF calc(h - 1) s l);
+}
+.color-hsl-add {
+  background: hsl(from #0000FF calc(h + 1) s l);
+}
+.color-hsl-mult {
+  background: hsl(from #0000FF calc(h * 1) s l);
+}
+.color-hsl-div {
+  background: hsl(from #0000FF calc(h / 2) s l);
+}
+.color-rgb-sub {
+  background: rgb(from #0000FF calc(r - 1) g b);
+}
+.color-rgb-add {
+  background: rgb(from #0000FF calc(r + 1) g b);
+}
+.color-rgb-mult {
+  background: rgb(from #0000FF calc(r * 1) g b);
+}
+.color-rgb-div {
+  background: rgb(from #0000FF calc(r / 2) g b);
+}

--- a/packages/test-data/less/_main/colors.less
+++ b/packages/test-data/less/_main/colors.less
@@ -114,3 +114,51 @@
   --semi-transparent-dark-background: #001e00ee;
   --semi-transparent-dark-background-2: rgba(0, 30, 0, 238); // invalid opacity will be capped
 }
+
+.color-oklch-sub {
+  background: oklch(from #0000FF calc(l - 0.1) c h); 
+}
+
+.color-oklch-add {
+  background: oklch(from #0000FF calc(l + 0.1) c h);
+}
+
+.color-oklch-mult {
+  background: oklch(from #0000FF calc(l * 0.1) c h);
+}
+
+.color-oklch-div {
+  background: oklch(from #0000FF calc(l / 2) c h);
+}
+
+.color-hsl-sub {
+  background: hsl(from #0000FF calc(h - 1) s l);
+}
+
+.color-hsl-add {
+  background: hsl(from #0000FF calc(h + 1) s l);
+}
+
+.color-hsl-mult {
+  background: hsl(from #0000FF calc(h * 1) s l);
+}
+
+.color-hsl-div {
+  background: hsl(from #0000FF calc(h / 2) s l);
+}
+
+.color-rgb-sub {
+  background: rgb(from #0000FF calc(r - 1) g b);
+}
+
+.color-rgb-add {
+  background: rgb(from #0000FF calc(r + 1) g b);
+}
+
+.color-rgb-mult {
+  background: rgb(from #0000FF calc(r * 1) g b);
+}
+
+.color-rgb-div {
+  background: rgb(from #0000FF calc(r / 2) g b);
+}


### PR DESCRIPTION

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Add missing color operand support to resolve issue #4343.

Currently the following Less:

```css
background: oklch(from #0000FF calc(l + 0.1) c h);
```
results in the following error:

```
Error: Could not parse call arguments or missing ')'
```

because color components are not being detected as valid operands for an ```Operation```. This PR resolves that issue and also adds tests for ```oklch```, ```rgb```, and ```hsl```.
 
<!-- Why are these changes necessary? -->

**Why**:

Using color components as an operand is valid and should be supported.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->
