### PR TITLE
fix(issue#4348): parse layer nesting syntax

### DIFF
--- a/packages/test-data/css/_main/layer.css
+++ b/packages/test-data/css/_main/layer.css
@@ -69,3 +69,25 @@
 .parent:hover {
   background: lightgray;
 }
+@layer foo.baz {
+  .bar {
+    font-weight: bold;
+  }
+}
+@layer framework {
+  @layer layout {
+    .container {
+      display: grid;
+      gap: 2rem;
+    }
+  }
+}
+@layer framework.layout {
+  main {
+    padding: 2rem;
+  }
+  p {
+    margin-block: 1rem;
+    color: #555;
+  }
+}

--- a/packages/test-data/less/_main/layer.less
+++ b/packages/test-data/less/_main/layer.less
@@ -85,3 +85,28 @@
         background: lightgray;
     }
 }
+
+@layer foo.baz {
+   .bar {
+       font-weight: bold;
+   }
+}
+
+@layer framework {
+    @layer layout {
+        .container {
+            display: grid;
+            gap: 2rem;
+        }
+    }
+}
+
+@layer framework.layout {
+    main {
+        padding: 2rem;
+    }
+    p {
+        margin-block: 1rem;
+        color: #555;
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

* Add fixes for layer at-rule nesting syntax parsing and associated tests.

Fixes https://github.com/less/less.js/issues/4348

<!-- Why are these changes necessary? -->

**Why**:

```@layer``` nesting syntax is valid. https://developer.mozilla.org/en-US/docs/Web/CSS/@layer#nesting_layers

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->
