### PR TITLE
Fix for issue #4339 false positive deprecation notice for mixins

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -971,11 +971,8 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
 
                     if (elements) {
                         parensIndex = parserInput.i;
-                        if (parserInput.$char('(')) {
-                            parserInput.save();
-                            parensWS = parserInput.$re(/[ \t\u00A0]$/, -2);
-                            parserInput.forget();
-
+                        parensWS = parserInput.isWhitespace(-1);
+                        if (parserInput.$char('(')) { 
                             args = this.args(true).args;
                             expectChar(')');
                             hasParens = true;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes issue https://github.com/less/less.js/issues/4339

This Less:

```css
@spacing-top: 4px;
@spacing-bottom: 4px;
@border-width: 4px;
@border-color: #444;

.divider-bottom(
    @spacing-top: @spacing-top,
  @spacing-bottom: @spacing-bottom,
  @border-width: @border-width,
  @border-color: @border-color
) {
  margin-top: @spacing-top;
  margin-bottom: @spacing-bottom;
  border-bottom: @border-width solid @border-color;
}

div {
  .divider-bottom(
  @spacing-top,
  @spacing-bottom,
  @border-width,
  @border-color
);
}

div {
  .divider-bottom ( @spacing-top,
@spacing-bottom,
  @border-width,
  @border-color
);
}

div {
  .divider-bottom (@spacing-top,
@spacing-bottom,
  @border-width,
  @border-color
);
}

div {
  .divider-bottom(@spacing-top,
@spacing-bottom,
  @border-width,
  @border-color
);
}
```

yields the following deprecation notices:

```
less.js:11431 DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in http://172.25.80.1:8000/test.less on line 27, column 19:
27   .divider-bottom ( @spacing-top,

warn @ less.js:11431Understand this warning
less.js:11431 DEPRECATED WARNING: Whitespace between a mixin name and parentheses for a mixin call is deprecated in http://172.25.80.1:8000/test.less on line 35, column 19:
35   .divider-bottom (@spacing-top,
```

which should resolve false positive deprecation notices for syntax like:

```css
.divider-bottom(
  @spacing-top,
  @spacing-bottom,
  @border-width,
  @border-color
);
```

<!-- Why are these changes necessary? -->

**Why**:

Many users have reported the false positive behavior and wish to not see the notice or have to rewrite their valid Less.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->
