### PR TITLE
fix(issue#4358): parent selector list in selector

### DIFF
--- a/packages/test-data/css/_main/selectors.css
+++ b/packages/test-data/css/_main/selectors.css
@@ -188,3 +188,15 @@ a:is(.b, :is(.c)) {
 a:is(.b, :is(.c), :has(div)) {
   color: red;
 }
+.x:is(.x.a) {
+  color: #f00;
+}
+.x:not(.x.b, .x.c) {
+  color: #0f0;
+}
+.x:is(.x-a) {
+  color: #f00;
+}
+.x:not(.x-b, .x-c) {
+  color: #0f0;
+}

--- a/packages/test-data/less/_main/selectors.less
+++ b/packages/test-data/less/_main/selectors.less
@@ -207,3 +207,17 @@ a:is(.b, :is(.c)) {
 a:is(.b, :is(.c), :has(div)) {
   color: red;
 }
+
+.x:is(.x.a) {
+  color: #f00;
+}
+.x:not(&.b, &.c) {
+  color: #0f0;
+}
+
+.x:is(.x-a) {
+  color: #f00;
+}
+.x:not(&-b, &-c) {
+  color: #0f0;
+}


### PR DESCRIPTION

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fix for issue #4358 that correctly expands parent selectors in a list in a selector.

<!-- Why are these changes necessary? -->

**Why**:

This Less:

```css
.x:is(.x.a) {
  color: #f00;
}
.x:not(&.b, &.c) {
  color: #0f0;
}

.x:is(.x-a) {
  color: #f00;
}
.x:not(&-b, &-c) {
  color: #0f0;
}
```

currently becomes:

```css
.x:is(.x.a) {
  color: #f00;
}
.x:not(&.b, &.c) {
  color: #0f0;
}
.x:is(.x-a) {
  color: #f00;
}
.x:not(&-b, &-c) {
  color: #0f0;
}
```

but should be:

```css
.x:is(.x.a) {
  color: #f00;
}
.x:not(.x.b, .x.c) {
  color: #0f0;
}
.x:is(.x-a) {
  color: #f00;
}
.x:not(.x-b, .x-c) {
  color: #0f0;
}
```

I believe one existing test:

```css
.selector:not(&:hover) {
  test: global scope;
}
```

may need to be updated to resolve to:

```css
.selector:not(.selector:hover) {
  test: global scope;
}
```

Creating PR to discuss solution and the one failing test.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->
