### PR TITLE
chore: add test for number with underscore parsing

### DIFF
--- a/packages/test-data/css/_main/variables.css
+++ b/packages/test-data/css/_main/variables.css
@@ -95,3 +95,6 @@ div#carrot {
 div#potato {
   color: blue;
 }
+.icon-5_large {
+  background-image: url(/img/icon/5_large.svg);
+}

--- a/packages/test-data/less/_main/variables.less
+++ b/packages/test-data/less/_main/variables.less
@@ -159,3 +159,9 @@ each(@items, {
     color: blue;
   }
 })
+
+// https://github.com/less/less.js/issues/2462
+@type: 5_large;
+.icon-@{type} {
+  background-image: ~"url(/img/icon/@{type}.svg)";
+}


### PR DESCRIPTION
**What**:

Add the test case from https://github.com/less/less.js/issues/2462, as inpired by downstream https://gerrit.wikimedia.org/r/1197310.

**Why**:

Follows-up https://github.com/less/less.js/pull/2485.

In Less.js 2.6.0, parsing of dimensions changed so that `5_large` is seen as one value, instead of as a list containing "5" and "_large".

In maintaining the [wikimedia/less.php](https://github.com/wikimedia/less.php) port, I recently found that we never applied this change because none of the Less.js 3.13 tests covered this behavior.

**Checklist**:

- [x] Documentation
- [x] Added/updated unit tests
- [x] Code complete

