### PR TITLE
fix:(issue#4397): container query variable names

### DIFF
--- a/packages/less/src/less/parser/parser.js
+++ b/packages/less/src/less/parser/parser.js
@@ -654,7 +654,8 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     parserInput.save();
                     if (parserInput.currentChar() === '@' && (name = parserInput.$re(/^@@?[\w-]+/))) {
                         ch = parserInput.currentChar();
-                        if (ch === '(' || ch === '[' && !parserInput.prevChar().match(/^\s/)) {
+                        if ((ch === '(' && !parserInput.prevChar().match(/^\s/))
+                            || (ch === '[' && !parserInput.prevChar().match(/^\s/))) {
                             // this may be a VariableCall lookup
                             const result = parsers.variableCall(name);
                             if (result) {
@@ -1884,6 +1885,9 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     e = entities.declarationCall.bind(this)() || entities.keyword() || entities.variable() || entities.mixinLookup()
                     if (e) {
                         nodes.push(e);
+                        if (e.type === 'Variable') {
+                            spacing = true;
+                        }
                     } else if (parserInput.$char('(')) {
                         p = this.property();
                         parserInput.save();

--- a/packages/less/src/less/tree/container.js
+++ b/packages/less/src/less/tree/container.js
@@ -2,7 +2,10 @@ import Ruleset from './ruleset';
 import Value from './value';
 import Selector from './selector';
 import AtRule from './atrule';
+import Anonymous from './anonymous';
+import Expression from './expression';
 import NestableAtRulePrototype from './nested-at-rule';
+import * as utils from '../utils';
 
 const Container = function(value, features, index, currentFileInfo, visibilityInfo) {
     this._index = index;
@@ -32,17 +35,21 @@ Container.prototype = Object.assign(new AtRule(), {
     },
 
     eval(context) {
+        if (this._evaluated) {
+            return this;
+        }
         if (!context.mediaBlocks) {
             context.mediaBlocks = [];
             context.mediaPath = [];
         }
 
         const media = new Container(null, [], this._index, this._fileInfo, this.visibilityInfo());
+        media._evaluated = true;
         if (this.debugInfo) {
             this.rules[0].debugInfo = this.debugInfo;
             media.debugInfo = this.debugInfo;
         }
-        
+
         media.features = this.features.eval(context);
 
         context.mediaPath.push(media);
@@ -57,6 +64,64 @@ Container.prototype = Object.assign(new AtRule(), {
 
         return context.mediaPath.length === 0 ? media.evalTop(context) :
             media.evalNested(context);
+    },
+
+    evalNested(context) {
+        this.evalFunction();
+
+        let i;
+        let value;
+        const path = context.mediaPath.concat([this]);
+
+        for (i = 0; i < path.length; i++) {
+            if (path[i].type !== this.type) {
+                context.mediaBlocks.splice(i, 1);
+                return this;
+            }
+
+            value = path[i].features instanceof Value ?
+                path[i].features.value : path[i].features;
+            const fragments = Array.isArray(value) ? value : [value];
+            path[i] = fragments;
+        }
+
+        this.features = new Value(this.permute(path).map(path => {
+            path = path.map(fragment => fragment.toCSS ? fragment : new Anonymous(fragment));
+
+            for (i = path.length - 1; i > 0; i--) {
+                path.splice(i, 0, new Anonymous('and'));
+            }
+
+            return new Expression(path);
+        }));
+        this.setParent(this.features, this);
+
+        return new Ruleset([], []);
+    },
+
+    permute(arr) {
+        if (arr.length === 0) {
+            return [];
+        } else if (arr.length === 1) {
+            return arr[0];
+        } else {
+            const result = [];
+            const rest = this.permute(arr.slice(1));
+            for (let i = 0; i < rest.length; i++) {
+                for (let j = 0; j < arr[0].length; j++) {
+                    result.push([arr[0][j]].concat(rest[i]));
+                }
+            }
+            return result;
+        }
+    },
+
+    bubbleSelectors(selectors) {
+        if (!selectors) {
+            return;
+        }
+        this.rules = [new Ruleset(utils.copyArray(selectors), [this.rules[0]])];
+        this.setParent(this.rules, this);
     }
 });
 

--- a/packages/less/src/less/tree/nested-at-rule.js
+++ b/packages/less/src/less/tree/nested-at-rule.js
@@ -31,7 +31,9 @@ const NestableAtRulePrototype = {
         for (let index = 0; index < exprValues.length; ++index) {
             expr = exprValues[index];
 
-            if (expr.type === 'Keyword' && index + 1 < exprValues.length && (expr.noSpacing || expr.noSpacing == null)) {
+            if ((expr.type === 'Keyword' || expr.type === 'Variable')
+                && index + 1 < exprValues.length
+                && (expr.noSpacing || expr.noSpacing == null)) {
                 paren =  exprValues[index + 1];
                 
                 if (paren.type ===  'Paren' && paren.noSpacing) {

--- a/packages/less/src/less/tree/query-in-parens.js
+++ b/packages/less/src/less/tree/query-in-parens.js
@@ -1,5 +1,4 @@
 import { copy } from 'copy-anything';
-import Declaration from './declaration';
 import Node from './node';
 
 const QueryInParens = function (op, l, m, op2, r, i) {
@@ -26,36 +25,13 @@ QueryInParens.prototype = Object.assign(new Node(), {
     eval(context) {
         this.lvalue = this.lvalue.eval(context);
         
-        let variableDeclaration;
-        let rule;
-
-        for (let i = 0; (rule = context.frames[i]); i++) {
-            if (rule.type === 'Ruleset') {
-                variableDeclaration = rule.rules.find(function (r) {
-                    if ((r instanceof Declaration) && r.variable) {
-                        return true;
-                    }
-
-                    return false;
-                });
-                
-                if (variableDeclaration) {
-                    break;
-                }
-            }
-        }
-
         if (!this.mvalueCopy) {
             this.mvalueCopy = copy(this.mvalue);
         }
-        
-        if (variableDeclaration) {
-            this.mvalue = this.mvalueCopy;
-            this.mvalue = this.mvalue.eval(context);
-            this.mvalues.push(this.mvalue);
-        } else {
-            this.mvalue = this.mvalue.eval(context);
-        }
+
+        this.mvalue = copy(this.mvalueCopy);
+        this.mvalue = this.mvalue.eval(context);
+        this.mvalues.push(this.mvalue);
 
         if (this.rvalue) {
             this.rvalue = this.rvalue.eval(context);

--- a/packages/test-data/tests-unit/container/container.css
+++ b/packages/test-data/tests-unit/container/container.css
@@ -268,3 +268,8 @@
     font-size: 75%;
   }
 }
+@container foo (min-width: 400px) {
+  #sticky-child {
+    font-size: 75%;
+  }
+}

--- a/packages/test-data/tests-unit/container/container.less
+++ b/packages/test-data/tests-unit/container/container.less
@@ -319,4 +319,10 @@
     }
 }
 
-
+@varfoo: foo;
+@threshold: 400px;
+@container @varfoo (min-width: @threshold) {
+    #sticky-child {
+      font-size: 75%;
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

* Fix for issue #4397 container query with variable names like:

```css
@varfoo: foo;
@threshold: 400px;
@container @varfoo (min-width: @threshold) {
    #sticky-child {
      font-size: 75%;
    }
}
```

<!-- Why are these changes necessary? -->

**Why**:

Current behavior results in:

```css
/* trailing space after the variable gets removed
    => 'foo' handled as a function
    => fail */
@container foo(min-width: 1024px){
    /* ... */
}
```

which is incorrect.

With the fix the output becomes:

```css
/* space chars preserved */
@container foo (min-width: 1024px){
    /* ... */
}
```

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->
