### PR TITLE
Fix no-prototype-builtins issue in Ruleset variables()

### DIFF
--- a/packages/less/src/less/tree/ruleset.js
+++ b/packages/less/src/less/tree/ruleset.js
@@ -295,8 +295,7 @@ Ruleset.prototype = Object.assign(new Node(), {
                 if (r.type === 'Import' && r.root && r.root.variables) {
                     const vars = r.root.variables();
                     for (const name in vars) {
-                        // eslint-disable-next-line no-prototype-builtins
-                        if (vars.hasOwnProperty(name)) {
+                        if (Object.prototype.hasOwnProperty.call(vars, name)) {
                             hash[name] = r.root.variable(name);
                         }
                     }

--- a/packages/less/src/less/visitors/to-css-visitor.js
+++ b/packages/less/src/less/visitors/to-css-visitor.js
@@ -303,19 +303,16 @@ ToCSSVisitor.prototype = {
         // remove duplicates
         const ruleCache = {};
 
-        let ruleList;
-        let rule;
-        let i;
-
-        for (i = rules.length - 1; i >= 0 ; i--) {
-            rule = rules[i];
+        for (let i = rules.length - 1; i >= 0 ; i--) {
+            let rule = rules[i];
             if (rule instanceof tree.Declaration) {
-                if (!ruleCache[rule.name]) {
+                if (!Object.prototype.hasOwnProperty.call(ruleCache, rule.name)) {
                     ruleCache[rule.name] = rule;
                 } else {
-                    ruleList = ruleCache[rule.name];
-                    if (ruleList instanceof tree.Declaration) {
-                        ruleList = ruleCache[rule.name] = [ruleCache[rule.name].toCSS(this._context)];
+                    let ruleList = ruleCache[rule.name];
+                    if (!Array.isArray(ruleList)) {
+                        const prevRuleCSS = ruleList.toCSS(this._context);
+                        ruleList = ruleCache[rule.name] = [prevRuleCSS];
                     }
                     const ruleCSS = rule.toCSS(this._context);
                     if (ruleList.indexOf(ruleCSS) !== -1) {

--- a/packages/test-data/tests-unit/rulesets/rulesets.css
+++ b/packages/test-data/tests-unit/rulesets/rulesets.css
@@ -1,5 +1,6 @@
 #first > .one {
   font-size: 2em;
+  hasOwnProperty: blue;
 }
 #first > .one > #second .two > #deux {
   width: 50%;

--- a/packages/test-data/tests-unit/rulesets/rulesets.less
+++ b/packages/test-data/tests-unit/rulesets/rulesets.less
@@ -28,4 +28,5 @@
     }
   }
   font-size: 2em;
+  hasOwnProperty: blue;
 }


### PR DESCRIPTION
Rebased version of #4272 by @Krinkle. Resolves conflicts with current master.

Original PR: https://github.com/less/less.js/pull/4272

Credit: @Krinkle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced property validation and CSS rule deduplication to prevent potential edge cases and improve compiler stability.

* **Tests**
  * Added test coverage for CSS property handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->