### PR TITLE
chore: add test for number with underscore parsing

### DIFF
--- a/packages/test-data/tests-unit/variables/variables.css
+++ b/packages/test-data/tests-unit/variables/variables.css
@@ -41,3 +41,6 @@
 .variable-pollution {
   a: 'no-pollution';
 }
+.icon-5_large {
+  background-image: url(/img/icon/5_large.svg);
+}

--- a/packages/test-data/tests-unit/variables/variables.less
+++ b/packages/test-data/tests-unit/variables/variables.less
@@ -85,3 +85,9 @@
 }
 
 
+
+// https://github.com/less/less.js/issues/2462
+@type: 5_large;
+.icon-@{type} {
+  background-image: ~"url(/img/icon/@{type}.svg)";
+}


### PR DESCRIPTION
Rebased version of #4374 by @Krinkle. Resolves conflicts with current master.

The original PR targeted the old test file locations (`packages/test-data/css/_main/variables.css` and `packages/test-data/less/_main/variables.less`), which were reorganized in #4378. This rebased version applies the same test additions to the new locations (`packages/test-data/tests-unit/variables/`).

Original PR: https://github.com/less/less.js/pull/4374

Credit: @Krinkle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added new icon styling configurations including support for large icon variants and dynamic icon type-based styling in test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->