### PR TITLE
fix(#4358): resolve parent selectors in comma-separated pseudo-selector lists

### DIFF
--- a/packages/less/src/less/tree/ruleset.js
+++ b/packages/less/src/less/tree/ruleset.js
@@ -740,12 +740,40 @@ Ruleset.prototype = Object.assign(new Node(), {
                         const nestedPaths = [];
                         let replaced;
                         const replacedNewSelectors = [];
-                        replaced = replaceParentSelector(nestedPaths, context, nestedSelector);
-                        hadParentSelector = hadParentSelector || replaced;
-                        // the nestedPaths array should have only one member - replaceParentSelector does not multiply selectors
-                        for (k = 0; k < nestedPaths.length; k++) {
-                            const replacementSelector = createSelector(createParenthesis(nestedPaths[k], el), el);
+
+                        // Check if this is a comma-separated selector list inside the paren
+                        // e.g. :not(&.a, &.b) produces Selector([Selector, Anonymous(','), Selector])
+                        const hasSubSelectors = nestedSelector.elements.some(e => e instanceof Selector);
+
+                        if (hasSubSelectors) {
+                            // Process each sub-selector individually
+                            const resolvedElements = [];
+                            for (const subEl of nestedSelector.elements) {
+                                if (subEl instanceof Selector) {
+                                    const subPaths = [];
+                                    const subReplaced = replaceParentSelector(subPaths, context, subEl);
+                                    replaced = replaced || subReplaced;
+                                    if (subPaths.length > 0 && subPaths[0].length > 0) {
+                                        resolvedElements.push(subPaths[0][0]);
+                                    } else {
+                                        resolvedElements.push(subEl);
+                                    }
+                                } else {
+                                    resolvedElements.push(subEl);
+                                }
+                            }
+                            hadParentSelector = hadParentSelector || replaced;
+                            const resolvedNestedSelector = new Selector(resolvedElements);
+                            const replacementSelector = createSelector(createParenthesis([resolvedNestedSelector], el), el);
                             addAllReplacementsIntoPath(newSelectors, [replacementSelector], el, inSelector, replacedNewSelectors);
+                        } else {
+                            replaced = replaceParentSelector(nestedPaths, context, nestedSelector);
+                            hadParentSelector = hadParentSelector || replaced;
+                            // the nestedPaths array should have only one member - replaceParentSelector does not multiply selectors
+                            for (k = 0; k < nestedPaths.length; k++) {
+                                const replacementSelector = createSelector(createParenthesis(nestedPaths[k], el), el);
+                                addAllReplacementsIntoPath(newSelectors, [replacementSelector], el, inSelector, replacedNewSelectors);
+                            }
                         }
                         newSelectors = replacedNewSelectors;
                         currentElements = [];

--- a/packages/test-data/tests-unit/selectors/selectors.css
+++ b/packages/test-data/tests-unit/selectors/selectors.css
@@ -182,6 +182,15 @@ blank blank blank blank blank blank blank blank blank blank blank blank blank bl
 .first-level .second-level.active2 {
   content: '\2661';
 }
+.x:is(.x.a) {
+  color: red;
+}
+.x:not(.x.b, .x.c) {
+  color: green;
+}
+.x:is(.x.d, .x.e, .x.f) {
+  color: blue;
+}
 a:is(.b, :is(.c)) {
   color: blue;
 }

--- a/packages/test-data/tests-unit/selectors/selectors.less
+++ b/packages/test-data/tests-unit/selectors/selectors.less
@@ -202,6 +202,13 @@ blank blank blank blank blank blank blank blank blank blank blank blank blank bl
   }
 }
 
+// https://github.com/less/less.js/issues/4358
+.x {
+    &:is(&.a) { color: red; }
+    &:not(&.b, &.c) { color: green; }
+    &:is(&.d, &.e, &.f) { color: blue; }
+}
+
 a:is(.b, :is(.c)) {
   color: blue;
 }


### PR DESCRIPTION
## Summary
- Fixes #4358 - `&` not replaced inside `:not(&.a, &.b)` and similar comma-separated pseudo-selector lists
- When `replaceParentSelector` encounters a nested selector containing sub-Selectors (comma-separated list), it now processes each sub-Selector individually with recursive calls
- Added test cases for `:is()` and `:not()` with single and multiple comma-separated parent selectors

## Test plan
- [x] Added test cases for `:is()` and `:not()` with single and multiple comma-separated parent selectors
- [x] All existing selector tests pass
- [x] Full test suite passes