### PR TITLE
fix: publish script skips stale version markers in squash merges

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,14 +88,15 @@ When code is pushed to specific branches, GitHub Actions automatically:
 
 **For patch releases (automatic):**
 1. Merge your PR into `master`
-2. The workflow auto-increments the patch version (e.g., `4.6.0` → `4.6.1`)
-3. Publishes to npm and creates a GitHub release with `less.js` and `less.min.js` attached
+2. The workflow compares `package.json` against the latest npm version
+3. If `package.json` is ahead, it uses that version; otherwise it bumps to the next patch
+4. Publishes to npm and creates a GitHub release with `less.js` and `less.min.js` attached
 
-**For minor/major releases (explicit version):**
-1. Create a release branch (e.g., `release/v4.6.0`)
-2. Update version in all `package.json` files, update `CHANGELOG.md`
-3. Merge into `master` with a commit message containing the version (see below)
-4. The workflow picks up the explicit version instead of auto-incrementing
+**For minor/major releases:**
+1. Create a release branch (e.g., `release/v4.7.0`)
+2. Update `version` in all `package.json` files and update `CHANGELOG.md`
+3. Merge into `master`
+4. The workflow detects the version is ahead of npm and publishes it directly
 
 **For alpha releases:**
 1. Make your changes on the `alpha` branch
@@ -104,20 +105,10 @@ When code is pushed to specific branches, GitHub Actions automatically:
 
 ### Version Override
 
-The publish script (`scripts/bump-and-publish.js`) auto-increments the patch version by default. To set a specific version (e.g., for minor or major releases), use one of these methods:
-
-**Option 1: Commit message** — include `version: X.Y.Z` in the commit body:
-
-```text
-feat: new feature
-
-version: 4.6.0
-```
-
-**Option 2: Environment variable** — set `EXPLICIT_VERSION` (useful for CI or manual runs):
+To force a specific version (useful for CI or manual runs), set the `EXPLICIT_VERSION` environment variable:
 
 ```bash
-EXPLICIT_VERSION=4.6.0 pnpm run publish
+EXPLICIT_VERSION=4.7.0 pnpm run publish
 ```
 
 ### Release Assets

--- a/scripts/bump-and-publish.js
+++ b/scripts/bump-and-publish.js
@@ -66,12 +66,6 @@ function parseVersion(version) {
   };
 }
 
-// Increment patch version
-function incrementPatch(version) {
-  const parsed = parseVersion(version);
-  return `${parsed.major}.${parsed.minor}.${parsed.patch + 1}`;
-}
-
 // Get current version from main package
 function getCurrentVersion() {
   const lessPkgPath = path.join(PACKAGES_DIR, 'less', 'package.json');
@@ -79,54 +73,36 @@ function getCurrentVersion() {
   return pkg.version;
 }
 
-// Check if version was explicitly set (via environment variable, git commit message,
-// or package.json already bumped beyond the last tag)
-function getExplicitVersion() {
-  // Check for explicit version in environment
+// Get the latest published version from NPM
+function getNpmVersion(packageName) {
+  try {
+    return execSync(`npm view ${packageName} version`, { encoding: 'utf8' }).trim();
+  } catch (e) {
+    // Package not yet published
+    return null;
+  }
+}
+
+// Determine the target version for publishing.
+// Priority: EXPLICIT_VERSION env > package.json (if ahead of NPM) > NPM patch bump
+function getTargetVersion(currentVersion, npmVersion) {
+  // 1. Explicit override via environment variable
   if (process.env.EXPLICIT_VERSION) {
+    console.log(`✨ Using explicit version from env: ${process.env.EXPLICIT_VERSION}`);
     return process.env.EXPLICIT_VERSION;
   }
 
-  // Check git commit message for version bump instruction.
-  // Skip if the version is already published (tag exists at or above it).
-  try {
-    const commitMsg = execSync('git log -1 --pretty=%B', { encoding: 'utf8' });
-    const versionMatch = commitMsg.match(/version[:\s]+v?(\d+\.\d+\.\d+(?:-[a-z]+\.\d+)?)/i);
-    if (versionMatch) {
-      const requestedVersion = versionMatch[1];
-      try {
-        const lastTag = execSync('git describe --tags --abbrev=0', { encoding: 'utf8' }).trim();
-        const lastTagVersion = lastTag.replace(/^v/, '');
-        if (semver.valid(requestedVersion) && semver.valid(lastTagVersion) && semver.lte(requestedVersion, lastTagVersion)) {
-          console.log(`⚠️  Commit message requests version ${requestedVersion}, but tag ${lastTag} already exists. Skipping.`);
-        } else {
-          return requestedVersion;
-        }
-      } catch (e) {
-        return requestedVersion;
-      }
-    }
-  } catch (e) {
-    // Ignore errors
+  // 2. If package.json is ahead of NPM, use it
+  if (npmVersion && semver.valid(currentVersion) && semver.gt(currentVersion, npmVersion)) {
+    console.log(`📦 package.json (${currentVersion}) is ahead of NPM (${npmVersion}), using it`);
+    return currentVersion;
   }
 
-  // Check if package.json version is already ahead of the last git tag.
-  // This handles squash merges from release branches where the version
-  // was bumped in package.json but the commit message may not contain
-  // the "version: X.Y.Z" marker.
-  try {
-    const lastTag = execSync('git describe --tags --abbrev=0', { encoding: 'utf8' }).trim();
-    const lastTagVersion = lastTag.replace(/^v/, '');
-    const currentVersion = getCurrentVersion();
-    if (semver.valid(currentVersion) && semver.valid(lastTagVersion) && semver.gt(currentVersion, lastTagVersion)) {
-      console.log(`📦 package.json version (${currentVersion}) is ahead of last tag (${lastTag}), using it directly`);
-      return currentVersion;
-    }
-  } catch (e) {
-    // No tags exist or git describe failed, fall through to auto-increment
-  }
-
-  return null;
+  // 3. Otherwise, bump from the latest NPM version
+  const base = npmVersion || currentVersion;
+  const next = semver.inc(base, 'patch');
+  console.log(`🔢 Auto-incrementing patch: ${base} → ${next}`);
+  return next;
 }
 
 // Update all package.json files with new version
@@ -262,13 +238,9 @@ function main() {
   }
   
   // Determine next version
-  const explicitVersion = getExplicitVersion();
   let nextVersion;
-  
-  if (explicitVersion) {
-    nextVersion = explicitVersion;
-    console.log(`✨ Using explicit version: ${nextVersion}`);
-  } else if (isAlpha) {
+
+  if (isAlpha) {
     // For alpha branch, use alpha versions
     const parsed = parseVersion(currentVersion);
     if (parsed.prerelease) {
@@ -290,9 +262,10 @@ function main() {
     }
     console.log(`🔢 Auto-incrementing alpha version: ${nextVersion}`);
   } else {
-    // For master, increment patch
-    nextVersion = incrementPatch(currentVersion);
-    console.log(`🔢 Auto-incrementing patch version: ${nextVersion}`);
+    // For master: compare package.json vs NPM, bump accordingly
+    const npmVersion = getNpmVersion('less');
+    console.log(`📦 NPM version: ${npmVersion || '(not published)'}`);
+    nextVersion = getTargetVersion(currentVersion, npmVersion);
   }
   
   // Update all package.json files


### PR DESCRIPTION
## Summary

- Removed commit message version parsing (`version: X.Y.Z`) — no longer needed
- Publish script now compares `package.json` version against the latest NPM version:
  - If `package.json` > NPM → use `package.json` (for minor/major releases)
  - Otherwise → auto-increment patch from latest NPM version
- `EXPLICIT_VERSION` env var still works as an override
- Updated CONTRIBUTING.md to reflect the simplified workflow

## Why

The previous approach parsed commit messages for `version: X.Y.Z` markers, which broke on squash merges (stale version markers from individual commits). Comparing directly against NPM is simpler and always correct.

## Test plan

- [ ] Merge to master triggers publish workflow
- [ ] Verify version auto-increments from NPM (e.g., 4.6.0 → 4.6.1)
- [ ] Verify `EXPLICIT_VERSION` override still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release flow now avoids reusing previously published version numbers by referencing the latest published package and auto-incrementing when appropriate.
* **Documentation**
  * Updated release instructions: branch naming examples, alpha handling, and use of EXPLICIT_VERSION env override in place of commit-message forcing.
* **Chores**
  * Improved diagnostic logging and streamlined version-determination steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->