### PR TITLE
chore: prevent dependency lifecycle scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        run: pnpm install --frozen-lockfile
       - name: Print put node & npm version
         run: node --version && pnpm --version 
       - name: Install chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,5 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Print put node & npm version
         run: node --version && pnpm --version 
-      - name: Install chromium
-        run: pnpm exec playwright install chromium
       - name: Run node tests (ESM + CJS)
         run: pnpm run test:node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Print put node & npm version
         run: node --version && pnpm --version 
       - name: Run node tests (ESM + CJS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: 'pnpm'
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Print put node & npm version
         run: node --version && pnpm --version 
       - name: Install chromium

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -46,7 +46,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Determine next version
         id: version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Run node tests (ESM + CJS)
         run: pnpm run test:node


### PR DESCRIPTION
* Prevent dependency lifecycle scripts during CI work.

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

Prevent dependency lifecycle scripts from running during CI work.

**Why**:

<!-- Have you done all of these things?  -->

Dependency lifecycle scripts should be unnecessary for Less.js CI needs.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to run `pnpm install` with lockfile consistency enforced and install-time lifecycle scripts disabled across build, release PR creation, and publishing pipelines.
  * This improves determinism and safety of dependency installs; no changes to public APIs or runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->