### PR TITLE
Preserve spacing for container feature functions

### DIFF
--- a/packages/less/lib/less/parser/parser.js
+++ b/packages/less/lib/less/parser/parser.js
@@ -1878,7 +1878,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 parserInput.save();
                 do {
                     parserInput.save();
-                    if (parserInput.$re(/^[0-9a-z-]*\s+\(/)) {
+                    if (parserInput.$re(/^(?:--|-?(?:[_a-zA-Z0-9]|[^\0-\x7F]|\\[0-9a-fA-F]{1,6}\s?|\\[^\n\r\f0-9a-fA-F]))(?:[-_a-zA-Z0-9]|[^\0-\x7F]|\\[0-9a-fA-F]{1,6}\s?|\\[^\n\r\f0-9a-fA-F])*\s+\(/)) {
                         spacing = true;
                     }
                     parserInput.restore();
@@ -1920,7 +1920,11 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                         }
                         if (closed) {
                             if (p && !e) {
-                                nodes.push(new (tree.Paren)(new (tree.QueryInParens)(p.op, p.lvalue, p.rvalue, rangeP ? rangeP.op : null, rangeP ? rangeP.rvalue : null, p._index)));
+                                const paren = new (tree.Paren)(new (tree.QueryInParens)(p.op, p.lvalue, p.rvalue, rangeP ? rangeP.op : null, rangeP ? rangeP.rvalue : null, p._index));
+                                if (!spacing) {
+                                    paren.noSpacing = true;
+                                }
+                                nodes.push(paren);
                                 e = p;
                             } else if (p && e) {
                                 nodes.push(new (tree.Paren)(new (tree.Declaration)(p, e, null, null, parserInput.i + currentIndex, fileInfo, true)));
@@ -1929,7 +1933,11 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                                 }
                                 spacing = false;
                             } else if (e) {
-                                nodes.push(new(tree.Paren)(e));
+                                const paren = new(tree.Paren)(e);
+                                if (!spacing) {
+                                    paren.noSpacing = true;
+                                }
+                                nodes.push(paren);
                                 spacing = false;
                             } else {
                                 error('badly formed media feature definition');
@@ -1942,7 +1950,14 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
 
                 parserInput.forget();
                 if (nodes.length > 0) {
-                    return new(tree.Expression)(nodes);
+                    const expression = new(tree.Expression)(nodes);
+                    if (nodes.length === 2
+                        && (nodes[0].type === 'Keyword' || nodes[0].type === 'Variable')
+                        && nodes[1].type === 'Paren'
+                        && nodes[1].noSpacing) {
+                        expression.noSpacing = true;
+                    }
+                    return expression;
                 }
             },
 

--- a/packages/less/lib/less/parser/parser.js
+++ b/packages/less/lib/less/parser/parser.js
@@ -1875,6 +1875,12 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 let p;
                 let rangeP;
                 let spacing = false;
+                const cssKeyword = () => {
+                    const k = parserInput.$re(/^(?:--|-?(?:[_a-zA-Z0-9]|[^\0-\x7F]|\\[0-9a-fA-F]{1,6}\s?|\\[^\n\r\f0-9a-fA-F]))(?:[-_a-zA-Z0-9]|[^\0-\x7F]|\\[0-9a-fA-F]{1,6}\s?|\\[^\n\r\f0-9a-fA-F])*/);
+                    if (k) {
+                        return tree.Color.fromKeyword(k) || new(tree.Keyword)(k);
+                    }
+                };
                 parserInput.save();
                 do {
                     parserInput.save();
@@ -1883,7 +1889,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     }
                     parserInput.restore();
 
-                    e = entities.declarationCall.bind(this)() || entities.keyword() || entities.variable() || entities.mixinLookup()
+                    e = entities.declarationCall.bind(this)() || cssKeyword() || entities.keyword() || entities.variable() || entities.mixinLookup()
                     if (e) {
                         nodes.push(e);
                         if (e.type === 'Variable' ||

--- a/packages/test-data/tests-unit/container/container.css
+++ b/packages/test-data/tests-unit/container/container.css
@@ -130,6 +130,41 @@
     margin: 0.5em 0 0 0;
   }
 }
+@container card (width > 400px), style(--responsive: true), scroll-state(stuck: top) {
+  h2 {
+    font-size: 1.5em;
+  }
+}
+@container style(--theme) {
+  .style-query {
+    color: red;
+  }
+}
+@container style((--theme: one) or (--theme: two)) {
+  .style-query-list {
+    color: blue;
+  }
+}
+@container contactBody (min-width: 1300px) {
+  .named-container {
+    width: 25%;
+  }
+}
+@container _body (min-width: 1300px) {
+  .underscored-container {
+    width: 25%;
+  }
+}
+@container --body (min-width: 1300px) {
+  .custom-ident-container {
+    width: 25%;
+  }
+}
+@container contact\.body (min-width: 1300px) {
+  .escaped-container {
+    width: 25%;
+  }
+}
 @container (width < 500px) or (height < 500px) and (orientation: portrait) {
   .card-content p {
     padding: 0;
@@ -266,6 +301,11 @@
 @container scroll-state(scrollable: top) {
   #sticky-child {
     font-size: 75%;
+  }
+}
+@container sidebar (min-width: 400px), scroll-state(stuck: top) {
+  #sticky-child {
+    font-size: 80%;
   }
 }
 @container foo (min-width: 400px) {

--- a/packages/test-data/tests-unit/container/container.css
+++ b/packages/test-data/tests-unit/container/container.css
@@ -165,6 +165,11 @@
     width: 25%;
   }
 }
+@container café (min-width: 1300px) {
+  .nonascii-container {
+    width: 25%;
+  }
+}
 @container (width < 500px) or (height < 500px) and (orientation: portrait) {
   .card-content p {
     padding: 0;

--- a/packages/test-data/tests-unit/container/container.less
+++ b/packages/test-data/tests-unit/container/container.less
@@ -201,6 +201,12 @@
     }
 }
 
+@container café (min-width: 1300px) {
+    .nonascii-container {
+        width: 25%;
+    }
+}
+
 @container ( width < 500px ) or (height<500px) and (orientation: portrait) {
     .card-content p {
         padding: 0;

--- a/packages/test-data/tests-unit/container/container.less
+++ b/packages/test-data/tests-unit/container/container.less
@@ -159,6 +159,48 @@
     }
 }
 
+@container card (width > 400px), style(--responsive: true), scroll-state(stuck: top) {
+    h2 {
+        font-size: 1.5em;
+    }
+}
+
+@container style(--theme) {
+    .style-query {
+        color: red;
+    }
+}
+
+@container style((--theme: one) or (--theme: two)) {
+    .style-query-list {
+        color: blue;
+    }
+}
+
+@container contactBody (min-width: 1300px) {
+    .named-container {
+        width: 25%;
+    }
+}
+
+@container _body (min-width: 1300px) {
+    .underscored-container {
+        width: 25%;
+    }
+}
+
+@container --body (min-width: 1300px) {
+    .custom-ident-container {
+        width: 25%;
+    }
+}
+
+@container contact\.body (min-width: 1300px) {
+    .escaped-container {
+        width: 25%;
+    }
+}
+
 @container ( width < 500px ) or (height<500px) and (orientation: portrait) {
     .card-content p {
         padding: 0;
@@ -316,6 +358,12 @@
 @container scroll-state(scrollable: top) {
     #sticky-child {
       font-size: 75%;
+    }
+}
+
+@container sidebar (min-width: 400px), scroll-state(stuck: top) {
+    #sticky-child {
+      font-size: 80%;
     }
 }
 


### PR DESCRIPTION
Fixes #4235

## Summary
- preserve function-style spacing for container style and scroll-state queries
- recognize CSS custom identifiers, uppercase names, underscores, escapes, and non-ASCII names when deciding whether a container feature had source spacing
- add container fixture coverage for boolean style queries, query lists, scroll-state lists, and named containers

## Testing
- `COREPACK_HOME=$PWD/.corepack PNPM_HOME=$PWD/.pnpm-home pnpm install --frozen-lockfile --store-dir $PWD/.pnpm-store`
- `COREPACK_HOME=$PWD/.corepack PNPM_HOME=$PWD/.pnpm-home pnpm --dir packages/less exec node test/index.js container`
- `COREPACK_HOME=$PWD/.corepack PNPM_HOME=$PWD/.pnpm-home pnpm --dir packages/less exec eslint --no-ignore lib/less/parser/parser.js`
- `COREPACK_HOME=$PWD/.corepack PNPM_HOME=$PWD/.pnpm-home pnpm --dir packages/less run typecheck`
- `COREPACK_HOME=$PWD/.corepack PNPM_HOME=$PWD/.pnpm-home pnpm --dir packages/less run test:node`
- `git diff --check`

Note: the commit hook also ran the repo `npm test` path. Node/build portions passed; the browser runner reported missing local Playwright browser binaries and therefore did not execute those browser pages in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of container queries and media-feature spacing so combined queries and parenthesized conditions render and apply consistently.

* **Tests**
  * Added extensive unit tests for container queries: combined conditions, scroll-state and style() conditions, escaped and non‑ASCII identifiers, and varied container naming patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/less/less.js/pull/4441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- `COREPACK_HOME=$PWD/.corepack PNPM_HOME=$PWD/.pnpm-home pnpm --dir packages/less exec eslint --no-ignore lib/less/parser/parser.js`
- `COREPACK_HOME=$PWD/.corepack PNPM_HOME=$PWD/.pnpm-home pnpm --dir packages/less run typecheck`
- Added coverage for non-ASCII container names after `node test/index.js container` exposed the parser gap.