### PR TITLE
fix: avoid TypeError on nested @supports with dumpLineNumbers

### DIFF
--- a/packages/less/lib/less/tree/debug-info.js
+++ b/packages/less/lib/less/tree/debug-info.js
@@ -59,7 +59,9 @@ function asMediaQuery(ctx) {
  */
 function debugInfo(context, ctx, lineSeparator) {
     let result = '';
-    if (context.dumpLineNumbers && !context.compress) {
+    // Some nodes never receive a debugInfo during parsing (e.g. the implicit
+    // ruleset of a nested @supports/@document), so there is no line to emit.
+    if (context.dumpLineNumbers && !context.compress && ctx.debugInfo) {
         switch (context.dumpLineNumbers) {
             case 'comments':
                 result = asComment(ctx);

--- a/packages/test-data/tests-config/debug/all/linenumbers-all.css
+++ b/packages/test-data/tests-config/debug/all/linenumbers-all.css
@@ -47,3 +47,13 @@
   color: red;
   width: 2;
 }
+@supports (display: grid) {
+  .supports-rule {
+    color: green;
+  }
+  /* line 38, {path}linenumbers.less */
+  @media -sass-debug-info{filename{font-family:file\:\/\/{pathesc}linenumbers\.less}line{font-family:\0000338}}
+  .supports-rule .nested-supports {
+    color: blue;
+  }
+}

--- a/packages/test-data/tests-config/debug/comments/linenumbers-comments.css
+++ b/packages/test-data/tests-config/debug/comments/linenumbers-comments.css
@@ -38,3 +38,12 @@
   color: red;
   width: 2;
 }
+@supports (display: grid) {
+  .supports-rule {
+    color: green;
+  }
+  /* line 38, {path}linenumbers.less */
+  .supports-rule .nested-supports {
+    color: blue;
+  }
+}

--- a/packages/test-data/tests-config/debug/linenumbers.less
+++ b/packages/test-data/tests-config/debug/linenumbers.less
@@ -31,3 +31,12 @@
     }
   }
 }
+
+.supports-rule {
+  @supports (display: grid) {
+    color: green;
+    .nested-supports {
+      color: blue;
+    }
+  }
+}

--- a/packages/test-data/tests-config/debug/mediaquery/linenumbers-mediaquery.css
+++ b/packages/test-data/tests-config/debug/mediaquery/linenumbers-mediaquery.css
@@ -38,3 +38,12 @@
   color: red;
   width: 2;
 }
+@supports (display: grid) {
+  .supports-rule {
+    color: green;
+  }
+  @media -sass-debug-info{filename{font-family:file\:\/\/{pathesc}linenumbers\.less}line{font-family:\0000338}}
+  .supports-rule .nested-supports {
+    color: blue;
+  }
+}


### PR DESCRIPTION
**What**:

Rendering valid Less with `dumpLineNumbers` enabled throws a `TypeError` when a `@supports` (or `@document`) block is nested inside a selector, e.g.

```less
.foo {
  @supports (display: grid) {
    margin: 0;
  }
}
```

```
> less.render(src, { dumpLineNumbers: "comments" })
TypeError: Cannot read properties of undefined (reading 'lineNumber')
```

It happens in all three modes (`comments`, `mediaquery`, `all`). Top-level `@supports`, and `@media`/`@container`, are unaffected. This is the long-standing #3073.

**Why**:

A nested `@supports`/`@document` ends up as an implicit, non-root ruleset that never gets a `debugInfo` attached during parsing (unlike `@media`, which threads one through). When that ruleset renders, `debug-info.js` reads `lineNumber`/`fileName` off the missing `debugInfo` and throws instead of producing CSS.

The fix just skips emitting debug info for a node that has none — the same outcome you already get for any node without a recorded line, so nodes that do have line info are unchanged.

I added a nested `@supports` block to the shared `linenumbers.less` fixture; it reproduces the throw across the comments/mediaquery/all expectations before the change and passes after. `grunt test:node` is green.

**Checklist**:

- [ ] Documentation N/A
- [x] Added/updated unit tests
- [x] Code complete


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug information handling to prevent unnecessary output when debug context is unavailable.

* **Tests**
  * Expanded test coverage for CSS `@supports` conditional feature with enhanced line number mapping across multiple debug output formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->