### PR TITLE
fix: add continue-on-error to copilot-review CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
   copilot-review:
     name: Request Copilot review
     runs-on: ubuntu-latest
+    continue-on-error: true
     if: github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
     permissions:
       pull-requests: write


### PR DESCRIPTION
The `copilot-review` job was failing with HTTP 422 on every PR because `copilot-pull-request-reviewer` is not a collaborator and cannot be requested via the reviewers API. Adding `continue-on-error: true` prevents this from blocking CI while we work out the correct mechanism for triggering Copilot review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal infrastructure updates to improve workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->