### PR TITLE
fix: correct push event typo in create-release-pr workflow (pus → push:)

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -7,7 +7,7 @@ name: Create Release PR
 # master → "chore: release vX.Y.Z" PR targets master
 # alpha → "chore: alpha release vX.Y.Z" PR targets alpha
 on:
-  pus
+  push:
     branches:
       - master
       - alpha


### PR DESCRIPTION
Fixes a typo in the `on:` trigger — `pus` should be `push:`. This was causing the workflow to fail immediately with a YAML parse error on every push to master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed a syntax error in the release workflow configuration to ensure proper deployment automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->