### PR TITLE
fix: use printf for PR body to avoid YAML indentation error in run block

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -199,9 +199,7 @@ jobs:
             --json number --jq '.[0].number' 2>/dev/null || echo "")
 
           if [ -z "${EXISTING}" ]; then
-            BODY="## Release v${NEXT_VERSION}
-
-This PR bumps the version to \`${NEXT_VERSION}\` and will trigger an npm publish when merged."
+            BODY=$(printf '## Release v%s\n\nThis PR bumps the version to `%s` and will trigger an npm publish when merged.' "${NEXT_VERSION}" "${NEXT_VERSION}")
 
             gh pr create \
               --title "${TITLE}" \


### PR DESCRIPTION
The multiline `BODY=` bash string spanning lines 202-204 had line 204 at column 0, which terminates YAML's block scalar early — causing a YAML parse error that prevented the workflow from running at all.

Fix: replace the multiline assignment with a single-line `printf` call so the content stays within the `run:` block's indentation level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## No User-Facing Changes

This release contains internal process improvements to release automation with no visible impact to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->