### PR TITLE
fix: parse CSS data-type tokens in attr() type() notation (#4371)

### DIFF
--- a/packages/less/lib/less/parser/parser.js
+++ b/packages/less/lib/less/parser/parser.js
@@ -422,6 +422,23 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 },
 
                 //
+                // A CSS data type name, used by the `type()` notation of `attr()`
+                // and as a value component in custom properties, such as:
+                //
+                //     <number>     <length-percentage>     <custom-ident>
+                //
+                // It is emitted verbatim so the surrounding CSS function is
+                // preserved instead of throwing a parse error.
+                //
+                dataType: function () {
+                    const index = parserInput.i;
+                    const k = parserInput.$re(/^<[\w-]+>/);
+                    if (k) {
+                        return new(tree.Anonymous)(k, index + currentIndex);
+                    }
+                },
+
+                //
                 // A function call
                 //
                 //     rgb(255, 0, 255)
@@ -1288,8 +1305,8 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 const entities = this.entities;
 
                 return this.comment() || entities.literal() || entities.variable() || entities.url() ||
-                    entities.property() || entities.call() || entities.keyword() || this.mixin.call(true) ||
-                    entities.javascript();
+                    entities.dataType() || entities.property() || entities.call() || entities.keyword() ||
+                    this.mixin.call(true) || entities.javascript();
             },
 
             //

--- a/packages/test-data/tests-unit/css-attr/css-attr.css
+++ b/packages/test-data/tests-unit/css-attr/css-attr.css
@@ -1,0 +1,12 @@
+img {
+  aspect-ratio: attr(width type(<number>)) / attr(height type(<number>));
+}
+.fallback {
+  width: attr(data-width type(<length>), 0px);
+}
+.string {
+  content: attr(data-text type(<string>));
+}
+.bare {
+  --my-syntax: <length-percentage>;
+}

--- a/packages/test-data/tests-unit/css-attr/css-attr.less
+++ b/packages/test-data/tests-unit/css-attr/css-attr.less
@@ -1,0 +1,13 @@
+// CSS attr() with the type() notation and bare data-type tokens (#4371)
+img {
+  aspect-ratio: attr(width type(<number>)) / attr(height type(<number>));
+}
+.fallback {
+  width: attr(data-width type(<length>), 0px);
+}
+.string {
+  content: attr(data-text type(<string>));
+}
+.bare {
+  --my-syntax: <length-percentage>;
+}


### PR DESCRIPTION
**What**:

Fixes #4371. CSS `attr()` with the level-5 `type()` notation (and bare angle-bracket data-type tokens) now parses instead of throwing.

```less
img {
  aspect-ratio: attr(width type(<number>)) / attr(height type(<number>));
}
```

Before, this threw `Could not parse call arguments or missing ')'`. Now it compiles to the same CSS.

**Why**:

Inside function-call arguments, values go through the entity parser, which had no rule for the `<...>` data-type token (e.g. `<number>`, `<length-percentage>`). So `type(<number>)` — and anything containing it, like `attr(name type(<number>))` — failed to parse even though it's valid CSS. I added a small `dataType` entity that matches `<ident>` and emits it verbatim, so the surrounding CSS function is preserved as-is. Guard conditions (`when (@x < 1)`) and media range syntax (`(200px <= width)`) are unaffected since those go through their own parsers, not `entity()`.

Added a fixture pair under `tests-unit/css-attr/` covering the `type()` notation, fallbacks, and a bare data-type value.

**Checklist**:

- [x] Documentation N/A
- [x] Added/updated unit tests
- [x] Code complete


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parser now recognizes CSS data type tokens (e.g., `<length-percentage>`) in value contexts, enabling support for advanced CSS features like custom property syntax declarations and attribute functions with type notation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->