### PR TITLE
Fix #4460: parse comparison/range syntax in container style() queries

### DIFF
--- a/packages/less/lib/less/parser/parser.js
+++ b/packages/less/lib/less/parser/parser.js
@@ -492,11 +492,11 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
 
                     let rule = this.ruleProperty();
                     let value;
-
+                  
                     if (rule) {
                         value = this.value();
                     }
-
+                    
                     if (rule && value) {
                         args = [new (tree.Declaration)(rule, value, null, null, parserInput.i + currentIndex, fileInfo, true)];
                     }
@@ -964,7 +964,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     if (elements) {
                         parensIndex = parserInput.i;
                         parensWS = parserInput.isWhitespace(-1);
-                        if (parserInput.$char('(')) {
+                        if (parserInput.$char('(')) { 
                             args = this.args(true).args;
                             expectChar(')');
                             hasParens = true;
@@ -1320,7 +1320,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 return new tree.Quoted('', `alpha(opacity=${value})`);
             },
 
-            /**
+            /** 
              * A Selector Element
              *
              *   div
@@ -1359,7 +1359,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                                 v = this.selector(false);
                             }
                             selectors.push(v);
-
+                                                        
                             if (parserInput.$char(')')) {
                                 if (selectors.length > 1) {
                                     e = new (tree.Paren)(new Selector(selectors));
@@ -1693,7 +1693,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
              * First, it will try to parse comments and entities to reach
              * the end. This is mostly like the Expression parser except no
              * math is allowed.
-             *
+             * 
              * @param {RexExp} untilTokens - Characters to stop parsing at
              */
             permissiveValue: function (untilTokens) {
@@ -2134,7 +2134,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 else {
                     parserInput.forget();
                 }
-
+                    
                 return [rules, value, isKeywordList];
             },
             //
@@ -2219,7 +2219,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     value = unknownPackage[0];
                     hasBlock = unknownPackage[1];
                 }
-
+                    
                 if (hasBlock) {
                     let blockPackage = this.atruleBlock(rules, value, isRooted, isKeywordList);
                     rules = blockPackage[0];

--- a/packages/less/lib/less/parser/parser.js
+++ b/packages/less/lib/less/parser/parser.js
@@ -492,11 +492,11 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
 
                     let rule = this.ruleProperty();
                     let value;
-                  
+
                     if (rule) {
                         value = this.value();
                     }
-                    
+
                     if (rule && value) {
                         args = [new (tree.Declaration)(rule, value, null, null, parserInput.i + currentIndex, fileInfo, true)];
                     }
@@ -964,7 +964,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     if (elements) {
                         parensIndex = parserInput.i;
                         parensWS = parserInput.isWhitespace(-1);
-                        if (parserInput.$char('(')) { 
+                        if (parserInput.$char('(')) {
                             args = this.args(true).args;
                             expectChar(')');
                             hasParens = true;
@@ -1320,7 +1320,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 return new tree.Quoted('', `alpha(opacity=${value})`);
             },
 
-            /** 
+            /**
              * A Selector Element
              *
              *   div
@@ -1359,7 +1359,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                                 v = this.selector(false);
                             }
                             selectors.push(v);
-                                                        
+
                             if (parserInput.$char(')')) {
                                 if (selectors.length > 1) {
                                     e = new (tree.Paren)(new Selector(selectors));
@@ -1693,7 +1693,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
              * First, it will try to parse comments and entities to reach
              * the end. This is mostly like the Expression parser except no
              * math is allowed.
-             * 
+             *
              * @param {RexExp} untilTokens - Characters to stop parsing at
              */
             permissiveValue: function (untilTokens) {
@@ -1900,7 +1900,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                         let closed = false;
                         p = this.property();
                         parserInput.save();
-                        if (!p && syntaxOptions.queryInParens && parserInput.$re(/^[0-9a-z-]*\s*([<>]=|<=|>=|[<>]|=)/)) {
+                        if (!p && syntaxOptions.queryInParens && parserInput.$re(/^(?:[^()]|\([^()]*\))*\s*([<>]=|<=|>=|[<>]|=)/)) {
                             parserInput.restore();
                             p = this.condition();
 
@@ -2134,7 +2134,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 else {
                     parserInput.forget();
                 }
-                    
+
                 return [rules, value, isKeywordList];
             },
             //
@@ -2219,7 +2219,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     value = unknownPackage[0];
                     hasBlock = unknownPackage[1];
                 }
-                    
+
                 if (hasBlock) {
                     let blockPackage = this.atruleBlock(rules, value, isRooted, isKeywordList);
                     rules = blockPackage[0];

--- a/packages/test-data/tests-unit/container/container.css
+++ b/packages/test-data/tests-unit/container/container.css
@@ -336,3 +336,18 @@
     display: none;
   }
 }
+@container style(var(--n) = 3) {
+  .style-query-eq {
+    color: red;
+  }
+}
+@container style(calc(6 / 2) = var(--n)) {
+  .style-query-calc-eq {
+    color: blue;
+  }
+}
+@container style(var(--size) > 1lh) {
+  .style-query-gt {
+    color: green;
+  }
+}

--- a/packages/test-data/tests-unit/container/container.less
+++ b/packages/test-data/tests-unit/container/container.less
@@ -404,3 +404,22 @@
 .header-test {
     .container-query-mixin(header, 800px);
 }
+
+// Range/comparison syntax in @container style() queries (issue #4460)
+@container style(var(--n) = 3) {
+    .style-query-eq {
+        color: red;
+    }
+}
+
+@container style(calc(6 / 2) = var(--n)) {
+    .style-query-calc-eq {
+        color: blue;
+    }
+}
+
+@container style(var(--size) > 1lh) {
+    .style-query-gt {
+        color: green;
+    }
+}


### PR DESCRIPTION
Fixes #4460

**What**:
`mediaFeature`'s lookahead regex for range/comparison syntax inside
`@container`/`@media` parentheses only matched a bare lowercase
identifier before the operator (`=`, `>`, `<`, `>=`, `<=`). It failed
whenever the left-hand operand was a function call, such as
`var(--n)` or `calc(6/2)`, because parentheses aren't in the
character class the regex used for its lookahead. This caused a
"Missing closing ')'" parse error for CSS container style queries
using range syntax with custom-property/calc operands, e.g.:

```less
@container style(var(--n) = 3) { ... }
@container style(calc(6 / 2) = var(--n)) { ... }
@container style(var(--size) > 1lh) { ... }
```

**Why**:
This is valid CSS per the container queries spec, and the existing
comparison-parsing machinery (`condition()` / `atomicCondition()` /
`operand()`) already supports function-call operands via
`entities.call()` — the only broken piece was the lookahead regex
deciding whether to even attempt the comparison branch. Widening it
to tolerate a single level of balanced parens (`(?:[^()]|\([^()]*\))*`)
before the operator fixes all three cases in the issue without
touching any other parsing path.

**Checklist**:
- [x] Added/updated unit tests
- [x] Code complete
- [ ] Documentation (N/A — internal parser fix, no public API/docs change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of comparison operators within parentheses for media feature parsing, improving support for more complex query syntax.

* **Tests**
  * Added regression coverage for `@container style(...)` queries using equality and greater-than comparisons, including cases with `calc(...)` expressions and custom properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->