### PR TITLE
Follow-up to #4462: migrate remaining @var fixtures, DRY the prelude bare-@var scan, add warnings coverage

### DIFF
--- a/packages/less/lib/less/parser/parser-input.js
+++ b/packages/less/lib/less/parser/parser-input.js
@@ -204,12 +204,23 @@ export default () => {
     /**
      * Permissive parsing. Ignores everything except matching {} [] () and quotes
      * until matching token (outside of blocks)
+     *
+     * @param {string|RegExp} tok - stop token
+     * @param {boolean} [detectBareVar] - when set, also record the position of the
+     *   first bare `@variable` reference (not `@{interpolation}`) that appears at
+     *   PAREN depth 0 — i.e. a structural reference, not a declaration value inside
+     *   `(...)`. Reuses this single pass (which already skips strings/comments) so
+     *   callers don't re-scan the text. Exposed as `.bareVarIndex` on the returned
+     *   group array (or null). `[...]`/`{...}` do NOT shield a reference — only
+     *   `(...)` (a declaration-value group) does.
      */
-    parserInput.$parseUntil = tok => {
+    parserInput.$parseUntil = (tok, detectBareVar) => {
         let quote = '';
         let returnVal = null;
         let inComment = false;
         let blockDepth = 0;
+        let parenDepth = 0;
+        let bareVarIndex = null;
         const blockStack = [];
         const parseGroups = [];
         const length = input.length;
@@ -249,6 +260,12 @@ export default () => {
                     i++;
                     continue;
                 }
+                if (detectBareVar && bareVarIndex === null && nextChar === '@' && parenDepth === 0) {
+                    // A bare `@ident` (not `@{interpolation}`) outside any `(...)` —
+                    // a structural reference. Strings/comments are already skipped above.
+                    const after = input.charAt(i + 1);
+                    if (after && /[-\w]/.test(after)) { bareVarIndex = i; }
+                }
                 switch (nextChar) {
                     case '\\':
                         i++;
@@ -284,6 +301,7 @@ export default () => {
                     case '(':
                         blockStack.push(')');
                         blockDepth++;
+                        parenDepth++;
                         break;
                     case '[':
                         blockStack.push(']');
@@ -295,6 +313,7 @@ export default () => {
                         const expected = blockStack.pop();
                         if (nextChar === expected) {
                             blockDepth--;
+                            if (nextChar === ')' && parenDepth > 0) { parenDepth--; }
                         } else {
                             // move the parser to the error and return expected
                             skipWhitespace(i - startPos);
@@ -310,6 +329,7 @@ export default () => {
             }
         } while (loop);
 
+        if (Array.isArray(returnVal)) { returnVal.bareVarIndex = bareVarIndex; }
         return returnVal ? returnVal : null;
     }
 

--- a/packages/less/lib/less/parser/parser.js
+++ b/packages/less/lib/less/parser/parser.js
@@ -106,31 +106,6 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
         warn('A bare @variable in an at-rule prelude is deprecated. Use @{variable} interpolation instead.', index, 'DEPRECATED', 'variable-in-at-rule-prelude');
     }
 
-    /**
-     * Whether `text` contains a bare `@variable` at the top level — i.e. outside
-     * any `(...)` group. A `@variable` inside parentheses is a declaration value
-     * (e.g. the `@v` in `@supports (display: @v)`) and remains valid; only a bare
-     * `@variable` in a structural position is deprecated.
-     *
-     * @param {string} text
-     * @returns {boolean}
-     */
-    function hasTopLevelBareVariable(text) {
-        let depth = 0;
-        for (let j = 0; j < text.length; j++) {
-            const c = text.charAt(j);
-            if (c === '(') {
-                depth++;
-            } else if (c === ')') {
-                if (depth > 0) { depth--; }
-            } else if (c === '@' && depth === 0) {
-                // a bare `@ident`, not `@{ident}` interpolation
-                if (/[\w-]/.test(text.charAt(j + 1))) { return true; }
-            }
-        }
-        return false;
-    }
-
     function expect(arg, msg) {
         // some older browsers return typeof 'function' for RegExp
         const result = (arg instanceof Function) ? arg.call(parsers) : parserInput.$re(arg);
@@ -1812,7 +1787,7 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 }
                 parserInput.save();
 
-                value = parserInput.$parseUntil(tok);
+                value = parserInput.$parseUntil(tok, deprecateVariables);
 
                 if (value) {
                     if (typeof value === 'string') {
@@ -1821,6 +1796,14 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                     if (value.length === 1 && value[0] === ' ') {
                         parserInput.forget();
                         return new tree.Anonymous('', index);
+                    }
+                    // At-rule prelude: `$parseUntil` (deprecateVariables) records the
+                    // first bare `@var` it saw outside any `(...)` in its single pass —
+                    // a structural reference (`[...]`/`{...}` don't shield it, only a
+                    // declaration-value `(...)` does). Warn once here rather than
+                    // re-scanning the text.
+                    if (deprecateVariables && value.bareVarIndex !== null && value.bareVarIndex !== undefined) {
+                        warnBareAtRuleVariable(value.bareVarIndex);
                     }
                     /** @type {string} */
                     let item;
@@ -1838,14 +1821,10 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                             const quote = new tree.Quoted('\'', item, true, index, fileInfo);
                             const variableRegex = /@([\w-]+)/g;
                             const propRegex = /\$([\w-]+)/g;
-                            if (deprecateVariables) {
-                                // At-rule prelude: only a bare @var in a structural
-                                // (top-level) position is deprecated; @vars inside
-                                // `(...)` are declaration values and stay valid.
-                                if (hasTopLevelBareVariable(item)) {
-                                    warnBareAtRuleVariable(index);
-                                }
-                            } else if (variableRegex.test(item)) {
+                            // At-rule preludes are handled once above via
+                            // `value.bareVarIndex`; the `variable-in-unknown-value`
+                            // notice is for unknown declaration values only.
+                            if (!deprecateVariables && variableRegex.test(item)) {
                                 warn('@variable in unknown values will not be evaluated as variables in the future. Use @{variable}', index, 'DEPRECATED', 'variable-in-unknown-value');
                             }
                             if (propRegex.test(item)) {

--- a/packages/less/test/index.js
+++ b/packages/less/test/index.js
@@ -236,6 +236,7 @@ lessTester.testSyncronous({syncImport: true}, 'tests-config/math-strict/css');
 lessTester.testNoOptions();
 lessTester.testDisablePluginRule();
 lessTester.testJSImport();
+await lessTester.testWarnings();
 lessTester.finished();
 
 console.log('\nTesting HTTP redirect functionality...');

--- a/packages/less/test/less-test.js
+++ b/packages/less/test/less-test.js
@@ -19,8 +19,14 @@ logger.addListener({
             process.stdout.write(msg + '\n');
         }
     },
+    // Warnings (deprecation notices etc.) are SUPPRESSED from normal test output —
+    // they are noise across the fixture corpus. Their emission is asserted directly
+    // in testWarnings() (below), which installs its own capturing listener. Set
+    // LESS_TEST_SHOW_WARNINGS=1 to print them anyway when debugging.
     warn(msg) {
-        process.stdout.write(msg + '\n');
+        if (process.env.LESS_TEST_SHOW_WARNINGS) {
+            process.stdout.write(msg + '\n');
+        }
     },
     error(msg) {
         process.stdout.write(msg + '\n');
@@ -829,10 +835,57 @@ export default function(testFilter) {
         );
     }
 
+    // Assert every render-reachable warning / deprecation notice fires (and, for the
+    // at-rule-prelude deprecation, that the declaration-value exemption holds). less.js
+    // asserts errors via tests-error/*.txt but had no warning coverage, so these were
+    // previously unguarded. Warnings are suppressed from normal output (see the logger
+    // listener at the top of this file); here we install a capturing listener instead.
+    //
+    // NOT covered (documented gaps, not render-reachable):
+    //   - property-in-unknown-value: wired (parser.js), but a `$prop` ref resolves via
+    //     the entity path before reaching the permissive text scan, so no input triggers it.
+    //   - math-always, dumpLineNumbers: registered in deprecation.js but never emitted
+    //     via a warn() call (CLI help text only).
+    async function testWarnings() {
+        const captured = [];
+        const listener = { warn: m => captured.push(m), error() {}, info() {}, debug() {} };
+        less.logger.addListener(listener);
+        // [label, source, options, message-matcher, expectedCount]
+        const cases = [
+            ['bare @var in an at-rule prelude warns', '@bar: x;\n@foo @bar { a: b }', {}, /A bare @variable in an at-rule prelude is deprecated/, 1],
+            ['@var inside […] is top-level and warns', '@v: x;\n@foo bar[@v] { a: b }', {}, /A bare @variable in an at-rule prelude is deprecated/, 1],
+            ['@var inside (…) is a declaration value — no warning', '@v: 1px;\n@foo (x: @v) { a: b }', {}, /A bare @variable in an at-rule prelude is deprecated/, 0],
+            ['inline JavaScript (backtick) is deprecated', '@x: `1 + 1`;\n.a { w: @x }', { javascriptEnabled: true }, /Inline JavaScript evaluation/, 1],
+            ['whitespace before mixin-call parens is deprecated', '.m() { a: b }\n.a { .m () }', {}, /Whitespace between a mixin name and parentheses/, 1],
+            ['mixin call without parens is deprecated', '.m() { a: b }\n.a { .m }', {}, /Calling a mixin without parentheses is deprecated/, 1],
+            ['@variable in an unknown value is deprecated', '@bar: red;\n.a { --x: bar[@bar] }', {}, /@variable in unknown values will not be evaluated/, 1],
+            ['the ./ operator is deprecated', '.a { w: 2px ./ 1 }', {}, /\.\/ operator is deprecated/, 1],
+            ['targeting complex selectors with :extend warns', '.b .c { x: y }\n.a:extend(.b .c) { }', {}, /Targeting complex selectors/, 1],
+            ['an :extend with no matches warns', '.a:extend(.zzz) { }', {}, /extend '.*' has no matches/, 1],
+            ['the compress option is deprecated', '.a { b: c }', { compress: true }, /compress option has been deprecated/, 1],
+            ['the @plugin directive is deprecated', '@plugin "less-plugin-nonexistent-xyz";\n.a { b: c }', {}, /@plugin directive is deprecated/, 1],
+        ];
+        for (const [label, src, options, matcher, expected] of cases) {
+            totalTests++;
+            captured.length = 0;
+            // Some cases (e.g. @plugin with a missing plugin) throw AFTER emitting the
+            // warning; the warning is what we assert, so a throw is not itself a failure.
+            try { await less.render(src, options); } catch (e) { /* warning already captured */ }
+            const n = captured.filter(m => matcher.test(m)).length;
+            if (n === expected) {
+                ok('- Integration - warning assertions: ' + label + ' OK\n');
+            } else {
+                fail('- Integration - warning assertions: ' + label + ' — expected ' + expected + ' match(es) for ' + matcher + ', got ' + n + '\n');
+            }
+        }
+        less.logger.removeListener(listener);
+    }
+
     return {
         runTestSet: runTestSet,
         runTestSetNormalOnly: runTestSetNormalOnly,
         testSyncronous: testSyncronous,
+        testWarnings: testWarnings,
         testErrors: testErrors,
         testTypeErrors: testTypeErrors,
         testSourcemap: testSourcemap,

--- a/packages/less/test/less-test.js
+++ b/packages/less/test/less-test.js
@@ -841,7 +841,12 @@ export default function(testFilter) {
     // previously unguarded. Warnings are suppressed from normal output (see the logger
     // listener at the top of this file); here we install a capturing listener instead.
     //
-    // NOT covered (documented gaps, not render-reachable):
+    // NOT covered (documented gaps):
+    //   - variable-in-unknown-value: only reachable via an inconsistent edge — a bare
+    //     `@var` in a custom-property value warns ONLY when a bracket pushes it to the
+    //     permissive text scan (`--x: bar[@bar]`), while `--x: @bar`, `--x: 1px @bar`,
+    //     `--x: foo(@bar)` all resolve silently. Asserting it would lock in that
+    //     inconsistency, so it is deliberately not covered.
     //   - property-in-unknown-value: wired (parser.js), but a `$prop` ref resolves via
     //     the entity path before reaching the permissive text scan, so no input triggers it.
     //   - math-always, dumpLineNumbers: registered in deprecation.js but never emitted
@@ -858,7 +863,6 @@ export default function(testFilter) {
             ['inline JavaScript (backtick) is deprecated', '@x: `1 + 1`;\n.a { w: @x }', { javascriptEnabled: true }, /Inline JavaScript evaluation/, 1],
             ['whitespace before mixin-call parens is deprecated', '.m() { a: b }\n.a { .m () }', {}, /Whitespace between a mixin name and parentheses/, 1],
             ['mixin call without parens is deprecated', '.m() { a: b }\n.a { .m }', {}, /Calling a mixin without parentheses is deprecated/, 1],
-            ['@variable in an unknown value is deprecated', '@bar: red;\n.a { --x: bar[@bar] }', {}, /@variable in unknown values will not be evaluated/, 1],
             ['the ./ operator is deprecated', '.a { w: 2px ./ 1 }', {}, /\.\/ operator is deprecated/, 1],
             ['targeting complex selectors with :extend warns', '.b .c { x: y }\n.a:extend(.b .c) { }', {}, /Targeting complex selectors/, 1],
             ['an :extend with no matches warns', '.a:extend(.zzz) { }', {}, /extend '.*' has no matches/, 1],

--- a/packages/test-data/tests-unit/import/import/import-reference.less
+++ b/packages/test-data/tests-unit/import/import/import-reference.less
@@ -73,11 +73,11 @@
   }
 }
 .mixin-with-directives(@keyframeName) {
-  @keyframes @keyframeName {
+  @keyframes @{keyframeName} {
     @rules1();
   }
   @supports (animation-name: test) {
-    @keyframes @keyframeName {
+    @keyframes @{keyframeName} {
       @rules2();
     }
     .selector {

--- a/packages/test-data/tests-unit/layer/layer.less
+++ b/packages/test-data/tests-unit/layer/layer.less
@@ -18,7 +18,7 @@
 
 @layer-name: primevue;
 
-@layer @layer-name {
+@layer @{layer-name} {
     .test {
         foo: bar;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5117,7 +5117,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       once: 1.4.0
       path-is-absolute: 1.0.1
 


### PR DESCRIPTION
Follow-up to #4462 (bare-`@variable` at-rule deprecation). Four pieces:

1. **Fixture migration** — #4462 left two fixtures on the bare form (`layer.less`, `import-reference.less`); migrated to `@{…}` (byte-identical render).

2. **Warnings-assertion coverage (new)** — less.js asserted *errors* (`tests-error/*.txt`) but never that *warnings* fire, so deprecations were unguarded. Adds `testWarnings()` capturing logger warnings and asserting each render-reachable one, incl. the prelude semantics (`bar[@v]`→warns, `(x:@v)`→no warn). Warnings are now **suppressed** from normal output (`LESS_TEST_SHOW_WARNINGS=1` to see them). Documented gaps: `variable-in-unknown-value` (only fires for an inconsistent bracket edge), `property-in-unknown-value` (not render-reachable), `math-always`/`dumpLineNumbers` (registered but never emitted).

3. **DRY the prelude bare-`@var` detection** — replaced the standalone `hasTopLevelBareVariable()` (which re-scanned text `$parseUntil` had already walked, with a hand-rolled `()`-only counter and no string/comment handling) by folding an opt-in `detectBareVar` into `$parseUntil`'s single pass (it already skips strings/comments and tracks brackets; `$parseUntil` has one caller). Guarded green-to-green by the new tests.

4. **Lockfile repair** — `master`'s `pnpm-lock.yaml` had a dangling `minimatch: 3.1.2` edge failing `--frozen-lockfile` for every PR; repinned to `3.1.5`.

Full `grunt test` green; all 7 CI jobs pass.