### PR TITLE
fix: forwarding an unset variadic no longer overrides callee defaults

### DIFF
--- a/packages/less/lib/less/tree/mixin-call.js
+++ b/packages/less/lib/less/tree/mixin-call.js
@@ -151,6 +151,10 @@ class MixinCall extends Node {
                 for (m = 0; m < expandedValues.length; m++) {
                     args.push({value: expandedValues[m]});
                 }
+            } else if (argValue.type === 'Expression' && Array.isArray(argValue.value) && argValue.value.length === 0) {
+                // an unset variadic holds no captured args; omit it so the callee
+                // falls through to its own parameter defaults instead of receiving empty
+
             } else {
                 args.push({name: arg.name, value: argValue});
             }

--- a/packages/test-data/tests-unit/mixins/mixins.css
+++ b/packages/test-data/tests-unit/mixins/mixins.css
@@ -142,3 +142,11 @@ h3 + * {
 .button.large {
   padding-left: 40em;
 }
+.rest-forwarding-empty {
+  a: 1;
+  b: fallback;
+}
+.rest-forwarding-filled {
+  a: 1;
+  b: 2;
+}

--- a/packages/test-data/tests-unit/mixins/mixins.less
+++ b/packages/test-data/tests-unit/mixins/mixins.less
@@ -143,3 +143,19 @@ h3 { .margin_between(15px, 5px); }
 .foo {
   .clearfix();
 }
+
+// Forwarding an unset variadic must fall through to the callee's default,
+// not pass an empty argument that overrides it (issue #4352).
+.rest-forward(@a, @rest...) {
+  .rest-target(@a, @rest);
+}
+.rest-target(@a, @b: fallback) {
+  a: @a;
+  b: @b;
+}
+.rest-forwarding-empty {
+  .rest-forward(1);
+}
+.rest-forwarding-filled {
+  .rest-forward(1, 2);
+}


### PR DESCRIPTION
Forwarding a variadic that captured no arguments used to pass an empty value to
the callee, which shadowed that parameter's default (and on older versions threw
`Cannot read properties of undefined`).

```less
.foo(@a, @rest...) { .bar(@a, @rest); }
.bar(@a, @b: false) { a: @a; b: @b; }

.foo(1, 2); // @rest = 2  -> .bar(1, 2)     -> b: 2
.foo(1);    // @rest unset -> .bar(1, <empty>) -> b: <empty>  (should be false)
```

When a forwarded variadic holds no captured args it evaluates to an empty
`Expression`. Skipping it lets the call fall through to the callee's own
parameter defaults, which is the documented behaviour for `1..N` variadics.

Passing a variadic that *does* carry values is unchanged: it is still forwarded
as a single list, matching current output exactly.

Added a regression case to `tests-unit/mixins` covering both the empty and the
populated forwarding paths. `pnpm test` passes.

Closes #4352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LESS mixin argument forwarding when optional variadic arguments are omitted.
  * Mixin parameter defaults are now correctly applied instead of receiving an empty placeholder value.
  * Added coverage for both empty and populated variadic argument scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->