### PR TITLE
fix: error when a mixin call is used as a property value

### DIFF
--- a/packages/less/lib/less/tree/declaration.js
+++ b/packages/less/lib/less/tree/declaration.js
@@ -95,7 +95,10 @@ class Declaration extends Node {
             context.importantScope.push({});
             evaldValue = /** @type {Node} */ (this.value).eval(context);
 
-            if (!this.variable && evaldValue.type === 'DetachedRuleset') {
+            // A mixin call used as a property value (without a lookup) evaluates
+            // to its ruleset, which arrives here as an array of rules; without
+            // this guard it renders as `[object Object]`.
+            if (!this.variable && (evaldValue.type === 'DetachedRuleset' || Array.isArray(evaldValue))) {
                 throw { message: 'Rulesets cannot be evaluated on a property.',
                     index: this.getIndex(), filename: this.fileInfo().filename };
             }

--- a/packages/test-data/tests-error/eval/mixin-as-value.less
+++ b/packages/test-data/tests-error/eval/mixin-as-value.less
@@ -1,0 +1,6 @@
+#rgbify(@color) {
+  @rgb: red(@color), green(@color), blue(@color);
+}
+.x {
+  color: #rgbify(#fff);
+}

--- a/packages/test-data/tests-error/eval/mixin-as-value.txt
+++ b/packages/test-data/tests-error/eval/mixin-as-value.txt
@@ -1,0 +1,4 @@
+SyntaxError: Rulesets cannot be evaluated on a property. in {path}mixin-as-value.less on line 5, column 3:
+4 .x {
+5   color: #rgbify(#fff);
+6 }


### PR DESCRIPTION
Using a mixin call directly as a property value (without a lookup) silently
emitted `[object Object]`:

```less
#rgbify(@color) { @rgb: red(@color), green(@color), blue(@color); }
.x { color: #rgbify(#fff); }   // -> color: [object Object];
```

The mixin call resolves to its ruleset, which reaches the declaration as an
array of rules and renders as `[object Object]`. `Declaration.eval` already
rejects a `DetachedRuleset` used on a property with "Rulesets cannot be
evaluated on a property."; this extends that same guard to the array case, so
the mistake surfaces as a clear error instead of invalid output.

Only non-variable (property) declarations are affected, so valid uses such as
`#ns.mixin()[@var]` lookups, statement mixin calls, and passing a ruleset to
`each()` are unchanged. Added an eval-error test; `pnpm test` passes.

Closes #4305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for mixins used directly as property values.
  * Prevented invalid mixin results from rendering as `[object Object]`.
  * Added a clearer error indicating that rulesets cannot be evaluated on a property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->