### PR TITLE
fix: leave math functions for the browser when an argument is a runtime CSS var()

### DIFF
--- a/packages/less/lib/less/functions/math-helper.js
+++ b/packages/less/lib/less/functions/math-helper.js
@@ -1,7 +1,14 @@
 import Dimension from '../tree/dimension.js';
 
-const MathHelper = (fn, unit, n) => {
+const MathHelper = (fn, unit, cssEvaluable, n) => {
     if (!(n instanceof Dimension)) {
+        // A runtime CSS value such as var()/env() stays an unevaluated call and
+        // cannot be resolved to a number at compile time. Only functions with a
+        // CSS equivalent may be left for the browser; the rest (percentage, ceil,
+        // floor, round) have no CSS form and keep erroring on such input.
+        if (cssEvaluable && n && n.type === 'Call') {
+            return undefined;
+        }
         throw { type: 'Argument', message: 'argument must be a number' };
     }
     if (unit === null) {

--- a/packages/less/lib/less/functions/math.js
+++ b/packages/less/lib/less/functions/math.js
@@ -1,29 +1,30 @@
 import mathHelper from './math-helper.js';
 
 const mathFunctions = {
-    // name,  unit
-    ceil:  null,
-    floor: null,
-    sqrt:  null,
-    abs:   null,
-    tan:   '',
-    sin:   '',
-    cos:   '',
-    atan:  'rad',
-    asin:  'rad',
-    acos:  'rad'
+    // name:  [unit, has a CSS equivalent that the browser can evaluate]
+    ceil:  [null, false],
+    floor: [null, false],
+    sqrt:  [null, true],
+    abs:   [null, true],
+    tan:   ['', true],
+    sin:   ['', true],
+    cos:   ['', true],
+    atan:  ['rad', true],
+    asin:  ['rad', true],
+    acos:  ['rad', true]
 };
 
 for (const f in mathFunctions) {
     // eslint-disable-next-line no-prototype-builtins
     if (mathFunctions.hasOwnProperty(f)) {
-        mathFunctions[f] = mathHelper.bind(null, Math[f], mathFunctions[f]);
+        const [unit, cssEvaluable] = mathFunctions[f];
+        mathFunctions[f] = mathHelper.bind(null, Math[f], unit, cssEvaluable);
     }
 }
 
 mathFunctions.round = (n, f) => {
     const fraction = typeof f === 'undefined' ? 0 : f.value;
-    return mathHelper(num => num.toFixed(fraction), null, n);
+    return mathHelper(num => num.toFixed(fraction), null, false, n);
 };
 
 export default mathFunctions;

--- a/packages/less/lib/less/functions/number.js
+++ b/packages/less/lib/less/functions/number.js
@@ -88,7 +88,7 @@ export default {
         return new Dimension(Math.pow(x.value, y.value), x.unit);
     },
     percentage: function (n) {
-        const result = mathHelper(num => num * 100, '%', n);
+        const result = mathHelper(num => num * 100, '%', false, n);
 
         return result;
     }

--- a/packages/test-data/tests-error/eval/percentage-css-var.less
+++ b/packages/test-data/tests-error/eval/percentage-css-var.less
@@ -1,0 +1,3 @@
+.a {
+  b: percentage(var(--x));
+}

--- a/packages/test-data/tests-error/eval/percentage-css-var.txt
+++ b/packages/test-data/tests-error/eval/percentage-css-var.txt
@@ -1,0 +1,4 @@
+ArgumentError: Error evaluating function `percentage`: argument must be a number in {path}percentage-css-var.less on line 2, column 6:
+1 .a {
+2   b: percentage(var(--x));
+3 }

--- a/packages/test-data/tests-unit/math-css-vars/math-css-vars.css
+++ b/packages/test-data/tests-unit/math-css-vars/math-css-vars.css
@@ -1,0 +1,10 @@
+.trig {
+  a: sin(var(--angle));
+  b: cos(var(--a));
+  c: calc(tan(var(--t)) * 1px);
+  d: atan2(var(--x), var(--y));
+}
+.numeric {
+  a: 0.5;
+  b: 5;
+}

--- a/packages/test-data/tests-unit/math-css-vars/math-css-vars.less
+++ b/packages/test-data/tests-unit/math-css-vars/math-css-vars.less
@@ -1,0 +1,14 @@
+// Math functions cannot resolve a runtime CSS var() at compile time, so the
+// whole call is left for the browser instead of erroring (issue #4224).
+.trig {
+  a: sin(var(--angle));
+  b: cos(var(--a));
+  c: calc(tan(var(--t)) * 1px);
+  d: atan2(var(--x), var(--y));
+}
+
+// Concrete numeric arguments still evaluate.
+.numeric {
+  a: sin(30deg);
+  b: ceil(4.2);
+}


### PR DESCRIPTION
Math functions like `sin`/`cos`/`tan`/`atan2` threw `argument must be a number`
when given a CSS custom property, since `var(--x)` has no compile-time value:

```less
.a { width: sin(var(--x)); }   // Error evaluating function `sin`: argument must be a number
```

A `var()` (or any unresolved CSS function) evaluates to a `Call` node rather than
a `Dimension`. In that case `MathHelper` now returns nothing, so the call is left
intact for the browser to evaluate at runtime, matching how CSS handles it. Other
non-numeric arguments (colors, expressions) still error as before.

Numeric arguments are unaffected: `sin(30deg)` still resolves to `0.5`. Added a
`math-css-vars` fixture covering both the pass-through and the numeric paths;
`pnpm test` passes.

Closes #4224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LESS/CSS math functions (including trigonometry and `percentage`) when given runtime values like `var(...)` to no longer fail with incorrect numeric validation errors; expressions are now left for browser-side evaluation instead.
* **Tests**
  * Added test coverage for trigonometric math with CSS variables and for correct compile-time evaluation with fixed numeric inputs.
  * Added cases using CSS variables inside `calc()` and updated expected error output for `percentage(var(...))`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->