### PR TITLE
fix: leave operations for the browser when an operand is a runtime CSS var()

### DIFF
--- a/packages/less/lib/less/tree/operation.js
+++ b/packages/less/lib/less/tree/operation.js
@@ -6,6 +6,48 @@ import Dimension from './dimension.js';
 import * as Constants from '../constants.js';
 const MATH = Constants.Math;
 
+/**
+ * A CSS function such as var() or env() only resolves in the browser, so an operation
+ * holding one cannot be computed here. eval() leaves such an operation intact, which
+ * makes it an operand an enclosing operator cannot compute either, so the search has
+ * to descend into nested operations rather than look at the direct operands alone.
+ * @param {Node} node
+ * @returns {boolean}
+ */
+function hasRuntimeCall(node) {
+    if (node.type === 'Call') {
+        return true;
+    }
+    return node instanceof Operation && node.operands.some(hasRuntimeCall);
+}
+
+/**
+ * Binding strength of each operator, so a nested operation left for the browser keeps
+ * the grouping its tree already has. `(a - b) * c` printed flat is `a - b * c`, which
+ * parses back the other way round.
+ * @type {Record<string, number>}
+ */
+const PRECEDENCE = { '+': 1, '-': 1, '*': 2, '/': 2, './': 2 };
+
+/**
+ * @param {Node} operand
+ * @param {string} op
+ * @param {boolean} isRight the operand sits on the right of `op`
+ * @returns {boolean}
+ */
+function needsParens(operand, op, isRight) {
+    if (!(operand instanceof Operation)) {
+        return false;
+    }
+    const outer = PRECEDENCE[op] || 0;
+    const inner = PRECEDENCE[operand.op] || 0;
+    if (inner < outer) {
+        return true;
+    }
+    // `a - (b - c)` and `a / (b / c)` do not survive losing them either.
+    return isRight && inner === outer && op !== '+' && op !== '*';
+}
+
 class Operation extends Node {
     get type() { return 'Operation'; }
 
@@ -48,6 +90,9 @@ class Operation extends Node {
                 ) {
                     return new Operation(this.op, [a, b], this.isSpaced);
                 }
+                if (hasRuntimeCall(a) || hasRuntimeCall(b)) {
+                    return new Operation(this.op, [a, b], this.isSpaced);
+                }
                 throw { type: 'Operation',
                     message: 'Operation on an invalid type' };
             }
@@ -66,7 +111,7 @@ class Operation extends Node {
      * @param {CSSOutput} output
      */
     genCSS(context, output) {
-        this.operands[0].genCSS(context, output);
+        this.genOperand(context, output, 0);
         if (this.isSpaced) {
             output.add(' ');
         }
@@ -74,7 +119,24 @@ class Operation extends Node {
         if (this.isSpaced) {
             output.add(' ');
         }
-        this.operands[1].genCSS(context, output);
+        this.genOperand(context, output, 1);
+    }
+
+    /**
+     * @param {EvalContext} context
+     * @param {CSSOutput} output
+     * @param {0 | 1} index
+     */
+    genOperand(context, output, index) {
+        const operand = this.operands[index];
+        const parens = needsParens(operand, this.op, index === 1);
+        if (parens) {
+            output.add('(');
+        }
+        operand.genCSS(context, output);
+        if (parens) {
+            output.add(')');
+        }
     }
 }
 

--- a/packages/less/lib/less/tree/operation.js
+++ b/packages/less/lib/less/tree/operation.js
@@ -48,6 +48,11 @@ class Operation extends Node {
                 ) {
                     return new Operation(this.op, [a, b], this.isSpaced);
                 }
+                // A CSS function such as var() or env() only resolves in the browser,
+                // so keep the operation intact instead of failing to compute it here.
+                if (a.type === 'Call' || b.type === 'Call') {
+                    return new Operation(this.op, [a, b], this.isSpaced);
+                }
                 throw { type: 'Operation',
                     message: 'Operation on an invalid type' };
             }

--- a/packages/test-data/tests-unit/operations-css-vars/operations-css-vars.css
+++ b/packages/test-data/tests-unit/operations-css-vars/operations-css-vars.css
@@ -1,0 +1,13 @@
+.min-max-var {
+  a: min(100% - var(--w), 10px);
+  b: max(var(--x), 40px);
+  c: min(50vh - var(--y), var(--z) + 2px, 40px);
+}
+.operation-var {
+  d: 100% - var(--w);
+  e: var(--x) + 2px;
+}
+.still-evaluates {
+  f: 10px;
+  g: 5px;
+}

--- a/packages/test-data/tests-unit/operations-css-vars/operations-css-vars.css
+++ b/packages/test-data/tests-unit/operations-css-vars/operations-css-vars.css
@@ -1,0 +1,19 @@
+.min-max-var {
+  a: min(100% - var(--w), 10px);
+  b: max(var(--x), 40px);
+  c: min(50vh - var(--y), var(--z) + 2px, 40px);
+}
+.operation-var {
+  d: 100% - var(--w);
+  e: var(--x) + 2px;
+}
+.nested-var {
+  h: 100% - var(--w) + 2px;
+  i: (100% - var(--w)) * 2;
+  j: min((100% - var(--w)) * 2, 10px);
+  k: 2 * (var(--x) + 1px);
+}
+.still-evaluates {
+  f: 10px;
+  g: 5px;
+}

--- a/packages/test-data/tests-unit/operations-css-vars/operations-css-vars.less
+++ b/packages/test-data/tests-unit/operations-css-vars/operations-css-vars.less
@@ -1,0 +1,23 @@
+// min()/max() and bare operations holding a CSS var() cannot be computed at
+// build time, so they are preserved as-is for the browser (issue #3777).
+.min-max-var {
+  a: min(100% - var(--w), 10px);
+  b: max(var(--x), 40px);
+  c: min(50vh - var(--y), var(--z) + 2px, 40px);
+}
+.operation-var {
+  d: 100% - var(--w);
+  e: var(--x) + 2px;
+}
+// A nested operation is left for the browser too, and keeps the grouping its tree
+// has: printed flat, `(a - b) * c` would parse back as `a - b * c`.
+.nested-var {
+  h: 100% - var(--w) + 2px;
+  i: (100% - var(--w)) * 2;
+  j: min((100% - var(--w)) * 2, 10px);
+  k: 2 * (var(--x) + 1px);
+}
+.still-evaluates {
+  f: min(10px, 20px);
+  g: 2px + 3px;
+}

--- a/packages/test-data/tests-unit/operations-css-vars/operations-css-vars.less
+++ b/packages/test-data/tests-unit/operations-css-vars/operations-css-vars.less
@@ -1,0 +1,15 @@
+// min()/max() and bare operations holding a CSS var() cannot be computed at
+// build time, so they are preserved as-is for the browser (issue #3777).
+.min-max-var {
+  a: min(100% - var(--w), 10px);
+  b: max(var(--x), 40px);
+  c: min(50vh - var(--y), var(--z) + 2px, 40px);
+}
+.operation-var {
+  d: 100% - var(--w);
+  e: var(--x) + 2px;
+}
+.still-evaluates {
+  f: min(10px, 20px);
+  g: 2px + 3px;
+}


### PR DESCRIPTION
`min()`, `max()` and bare arithmetic that hold a CSS `var()` (or another runtime CSS function) currently throw `Operation on an invalid type` in the default math mode, because Less tries to compute the operation at build time even though `var()` only resolves in the browser.

This keeps the operation intact when an operand is an unresolved CSS function, so the value passes through to CSS - matching how `strict` math already behaves. Concrete numeric operations still evaluate as before.

Closes #3777


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved CSS `min()`, `max()`, and arithmetic expressions containing `var()` for evaluation by the browser.
  * Prevented build-time errors when CSS variables are used in otherwise unsupported operations.
  * Preserved parentheses and expression grouping so nested calculations retain their intended meaning.
  * Continued evaluating equivalent expressions that do not contain CSS variables.
* **Tests**
  * Added coverage for variable-based functions, arithmetic, nested expressions, and constant values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->