### PR TITLE
fix(release): sync release version from PR title

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -5,9 +5,14 @@ name: Create Release PR
 # version. Maintainers then merge that PR to trigger publishing.
 #
 # master → "chore: release vX.Y.Z" PR targets master
-# alpha → "chore: alpha release vX.Y.Z" PR targets alpha
+# alpha → "chore: release vX.Y.Z-alpha.N" PR targets alpha
 on:
   push:
+    branches:
+      - master
+      - alpha
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
     branches:
       - master
       - alpha
@@ -24,6 +29,7 @@ jobs:
     # infinite loop). We catch both squash-merged and regular-merged commits
     # for both the master and alpha release PR title conventions.
     if: |
+      github.event_name == 'push' &&
       github.repository == 'less/less.js' &&
       !contains(github.event.head_commit.message, 'chore: release v') &&
       !contains(github.event.head_commit.message, 'chore: alpha release v') &&
@@ -48,49 +54,47 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Determine next version
+      - name: Determine release version
         id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           BRANCH="${{ github.ref_name }}"
           CURRENT=$(node -p "require('./packages/less/package.json').version")
 
           if [ "$BRANCH" = "alpha" ]; then
-            # Alpha: increment the alpha prerelease number.
-            # X.Y.Z-alpha.N → X.Y.Z-alpha.(N+1)
-            # If package.json doesn't carry an alpha version yet, bump the
-            # major and start a fresh alpha.1 series.
-            NEXT=$(node -e "
-            const cur = process.argv[1];
-            const m = cur.match(/^(\\d+\\.\\d+\\.\\d+)-alpha\\.(\\d+)$/);
-            if (m) {
-              process.stdout.write(m[1] + '-alpha.' + (parseInt(m[2], 10) + 1));
-            } else {
-              const parts = cur.replace(/-.*/, '').split('.');
-              const nextMajor = parseInt(parts[0], 10) + 1;
-              process.stdout.write(nextMajor + '.0.0-alpha.1');
-            }
-            " "$CURRENT")
-            echo "next_version=$NEXT" >> "$GITHUB_OUTPUT"
-            echo "branch=chore/alpha-release-v$NEXT" >> "$GITHUB_OUTPUT"
-            echo "release_base=alpha" >> "$GITHUB_OUTPUT"
+            NPM_VERSION=$(npm view less dist-tags.alpha 2>/dev/null || echo "")
           else
-            # Master: patch-increment from the latest npm published version.
             NPM_VERSION=$(npm view less version 2>/dev/null || echo "")
-            NEXT=$(node -e "
-            const semver = require('semver');
-            const cur = process.argv[1];
-            const npm = process.argv[2] || null;
-            if (npm && semver.valid(cur) && semver.gt(cur, npm)) {
-              process.stdout.write(cur);
-            } else {
-              const base = npm || cur;
-              process.stdout.write(semver.inc(base, 'patch'));
-            }
-            " "$CURRENT" "$NPM_VERSION")
-            echo "next_version=$NEXT" >> "$GITHUB_OUTPUT"
-            echo "branch=chore/release-v$NEXT" >> "$GITHUB_OUTPUT"
-            echo "release_base=master" >> "$GITHUB_OUTPUT"
           fi
+
+          DEFAULT_NEXT=$(node scripts/release-metadata.js next-version "$BRANCH" "$CURRENT" "$NPM_VERSION")
+          EXISTING=$(gh pr list \
+            --state open \
+            --base "$BRANCH" \
+            --json title,headRefName \
+            --jq '[.[] | select((.headRefName | startswith("chore/release-v")) or (.headRefName | startswith("chore/alpha-release-v")))][0] // {}' \
+            2>/dev/null || echo "{}")
+
+          EXISTING_TITLE=$(node -e "const pr = JSON.parse(process.argv[1]); process.stdout.write(pr.title || '')" "$EXISTING")
+          EXISTING_BRANCH=$(node -e "const pr = JSON.parse(process.argv[1]); process.stdout.write(pr.headRefName || '')" "$EXISTING")
+
+          if [ -n "$EXISTING_TITLE" ]; then
+            NEXT=$(node scripts/release-metadata.js parse-title "$BRANCH" "$EXISTING_TITLE")
+            RELEASE_BRANCH="$EXISTING_BRANCH"
+          else
+            NEXT="$DEFAULT_NEXT"
+            RELEASE_BRANCH=$(node scripts/release-metadata.js branch "$BRANCH" "$NEXT")
+          fi
+
+          node scripts/release-metadata.js validate "$BRANCH" "$NEXT" "$NPM_VERSION"
+          TITLE=$(node scripts/release-metadata.js title "$BRANCH" "$NEXT")
+
+          echo "next_version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "release_base=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
 
       - name: Configure Git
         run: |
@@ -102,14 +106,11 @@ jobs:
           NEXT_VERSION: ${{ steps.version.outputs.next_version }}
           RELEASE_BRANCH: ${{ steps.version.outputs.branch }}
           RELEASE_BASE: ${{ steps.version.outputs.release_base }}
+          RELEASE_TITLE: ${{ steps.version.outputs.title }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if [ "$RELEASE_BASE" = "alpha" ]; then
-            TITLE="chore: alpha release v${NEXT_VERSION}"
-          else
-            TITLE="chore: release v${NEXT_VERSION}"
-          fi
+          TITLE="${RELEASE_TITLE}"
 
           # Create or reset the release branch off the latest base branch so it
           # always includes all recent commits.
@@ -120,20 +121,7 @@ jobs:
             git checkout -b "${RELEASE_BRANCH}"
           fi
 
-          # Bump version in all package.json files.
-          node -e "
-          const fs = require('fs');
-          const version = process.env.NEXT_VERSION;
-          const dirs = fs.readdirSync('packages', { withFileTypes: true })
-            .filter(d => d.isDirectory())
-            .map(d => 'packages/' + d.name + '/package.json');
-          for (const f of ['package.json', ...dirs].filter(f => fs.existsSync(f))) {
-            const pkg = JSON.parse(fs.readFileSync(f, 'utf8'));
-            if (!pkg.version) continue;
-            pkg.version = version;
-            fs.writeFileSync(f, JSON.stringify(pkg, null, '\t') + '\n');
-          }
-          "
+          node scripts/release-metadata.js sync-package-versions "${NEXT_VERSION}"
 
           git add package.json packages/*/package.json
 
@@ -199,7 +187,7 @@ jobs:
             --json number --jq '.[0].number' 2>/dev/null || echo "")
 
           if [ -z "${EXISTING}" ]; then
-            BODY=$(printf '## Release v%s\n\nThis PR bumps the version to `%s` and will trigger an npm publish when merged.' "${NEXT_VERSION}" "${NEXT_VERSION}")
+            BODY=$(node scripts/release-metadata.js body)
 
             gh pr create \
               --title "${TITLE}" \
@@ -210,3 +198,76 @@ jobs:
           else
             echo "✅ Release PR #${EXISTING} already exists; branch updated to include latest ${RELEASE_BASE} commits"
           fi
+
+  sync-release-pr-title:
+    name: Sync Release PR Title
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' &&
+      github.repository == 'less/less.js' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        startsWith(github.event.pull_request.title, 'chore: release v') ||
+        startsWith(github.event.pull_request.title, 'chore: alpha release v')
+      )
+
+    steps:
+      - name: Checkout release PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Resolve title version
+        id: title-version
+        env:
+          RELEASE_BASE: ${{ github.event.pull_request.base.ref }}
+          RELEASE_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          VERSION=$(node scripts/release-metadata.js parse-title "$RELEASE_BASE" "$RELEASE_TITLE")
+          if [ "$RELEASE_BASE" = "alpha" ]; then
+            NPM_VERSION=$(npm view less dist-tags.alpha 2>/dev/null || echo "")
+          else
+            NPM_VERSION=$(npm view less version 2>/dev/null || echo "")
+          fi
+          node scripts/release-metadata.js validate "$RELEASE_BASE" "$VERSION" "$NPM_VERSION"
+          TITLE=$(node scripts/release-metadata.js title "$RELEASE_BASE" "$VERSION")
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync release files to title version
+        env:
+          VERSION: ${{ steps.title-version.outputs.version }}
+          TITLE: ${{ steps.title-version.outputs.title }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          node scripts/release-metadata.js sync-files "$VERSION"
+          git add package.json packages/*/package.json CHANGELOG.md
+
+          if git diff --cached --quiet; then
+            echo "Release files already match v${VERSION}"
+            exit 0
+          fi
+
+          git commit -m "$TITLE"
+          git push origin "HEAD:${HEAD_REF}"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -58,9 +58,10 @@ jobs:
         id: version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          BRANCH="${{ github.ref_name }}"
+          BRANCH="$REF_NAME"
           CURRENT=$(node -p "require('./packages/less/package.json').version")
 
           if [ "$BRANCH" = "alpha" ]; then
@@ -202,6 +203,9 @@ jobs:
   sync-release-pr-title:
     name: Sync Release PR Title
     runs-on: ubuntu-latest
+    concurrency:
+      group: sync-release-pr-title-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     if: |
       github.event_name == 'pull_request' &&
       github.repository == 'less/less.js' &&
@@ -237,6 +241,7 @@ jobs:
           RELEASE_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
+          PREVIOUS_VERSION=$(node -p "require('./packages/less/package.json').version")
           VERSION=$(node scripts/release-metadata.js parse-title "$RELEASE_BASE" "$RELEASE_TITLE")
           if [ "$RELEASE_BASE" = "alpha" ]; then
             NPM_VERSION=$(npm view less dist-tags.alpha 2>/dev/null || echo "")
@@ -247,6 +252,7 @@ jobs:
           TITLE=$(node scripts/release-metadata.js title "$RELEASE_BASE" "$VERSION")
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "previous_version=$PREVIOUS_VERSION" >> "$GITHUB_OUTPUT"
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
 
       - name: Configure Git
@@ -257,11 +263,12 @@ jobs:
       - name: Sync release files to title version
         env:
           VERSION: ${{ steps.title-version.outputs.version }}
+          PREVIOUS_VERSION: ${{ steps.title-version.outputs.previous_version }}
           TITLE: ${{ steps.title-version.outputs.title }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
-          node scripts/release-metadata.js sync-files "$VERSION"
+          node scripts/release-metadata.js sync-files "$VERSION" "$PREVIOUS_VERSION"
           git add package.json packages/*/package.json CHANGELOG.md
 
           if git diff --cached --quiet; then

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -65,18 +65,17 @@ jobs:
           CURRENT=$(node -p "require('./packages/less/package.json').version")
 
           if [ "$BRANCH" = "alpha" ]; then
-            NPM_VERSION=$(npm view less dist-tags.alpha 2>/dev/null || echo "")
+            NPM_VERSION=$(npm view less dist-tags.alpha)
           else
-            NPM_VERSION=$(npm view less version 2>/dev/null || echo "")
+            NPM_VERSION=$(npm view less version)
           fi
 
           DEFAULT_NEXT=$(node scripts/release-metadata.js next-version "$BRANCH" "$CURRENT" "$NPM_VERSION")
           EXISTING=$(gh pr list \
             --state open \
             --base "$BRANCH" \
-            --json title,headRefName \
-            --jq '[.[] | select((.headRefName | startswith("chore/release-v")) or (.headRefName | startswith("chore/alpha-release-v")))][0] // {}' \
-            2>/dev/null || echo "{}")
+            --json title,headRefName,headRepository,isCrossRepository \
+            --jq '[.[] | select((.isCrossRepository | not) and .headRepository.nameWithOwner == "less/less.js" and ((.headRefName | startswith("chore/release-v")) or (.headRefName | startswith("chore/alpha-release-v"))))][0] // {}')
 
           EXISTING_TITLE=$(node -e "const pr = JSON.parse(process.argv[1]); process.stdout.write(pr.title || '')" "$EXISTING")
           EXISTING_BRANCH=$(node -e "const pr = JSON.parse(process.argv[1]); process.stdout.write(pr.headRefName || '')" "$EXISTING")
@@ -211,8 +210,19 @@ jobs:
       github.repository == 'less/less.js' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       (
-        startsWith(github.event.pull_request.title, 'chore: release v') ||
-        startsWith(github.event.pull_request.title, 'chore: alpha release v')
+        (
+          github.event.pull_request.base.ref == 'master' &&
+          startsWith(github.event.pull_request.head.ref, 'chore/release-v') &&
+          startsWith(github.event.pull_request.title, 'chore: release v')
+        ) ||
+        (
+          github.event.pull_request.base.ref == 'alpha' &&
+          startsWith(github.event.pull_request.head.ref, 'chore/alpha-release-v') &&
+          (
+            startsWith(github.event.pull_request.title, 'chore: release v') ||
+            startsWith(github.event.pull_request.title, 'chore: alpha release v')
+          )
+        )
       )
 
     steps:
@@ -222,6 +232,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -234,6 +245,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      - name: Load trusted release metadata script
+        env:
+          RELEASE_BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          git fetch origin "${RELEASE_BASE}"
+          mkdir -p .release-scripts
+          git show "origin/${RELEASE_BASE}:scripts/release-metadata.js" > .release-scripts/release-metadata.js
+
       - name: Resolve title version
         id: title-version
         env:
@@ -242,14 +262,14 @@ jobs:
         run: |
           set -euo pipefail
           PREVIOUS_VERSION=$(node -p "require('./packages/less/package.json').version")
-          VERSION=$(node scripts/release-metadata.js parse-title "$RELEASE_BASE" "$RELEASE_TITLE")
+          VERSION=$(node .release-scripts/release-metadata.js parse-title "$RELEASE_BASE" "$RELEASE_TITLE")
           if [ "$RELEASE_BASE" = "alpha" ]; then
-            NPM_VERSION=$(npm view less dist-tags.alpha 2>/dev/null || echo "")
+            NPM_VERSION=$(npm view less dist-tags.alpha)
           else
-            NPM_VERSION=$(npm view less version 2>/dev/null || echo "")
+            NPM_VERSION=$(npm view less version)
           fi
-          node scripts/release-metadata.js validate "$RELEASE_BASE" "$VERSION" "$NPM_VERSION"
-          TITLE=$(node scripts/release-metadata.js title "$RELEASE_BASE" "$VERSION")
+          node .release-scripts/release-metadata.js validate-title-sync "$RELEASE_BASE" "$VERSION" "$PREVIOUS_VERSION" "$NPM_VERSION"
+          TITLE=$(node .release-scripts/release-metadata.js title "$RELEASE_BASE" "$VERSION")
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "previous_version=$PREVIOUS_VERSION" >> "$GITHUB_OUTPUT"
@@ -266,10 +286,14 @@ jobs:
           PREVIOUS_VERSION: ${{ steps.title-version.outputs.previous_version }}
           TITLE: ${{ steps.title-version.outputs.title }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          node scripts/release-metadata.js sync-files "$VERSION" "$PREVIOUS_VERSION"
-          git add package.json packages/*/package.json CHANGELOG.md
+          node .release-scripts/release-metadata.js sync-files "$VERSION" "$PREVIOUS_VERSION"
+          git add package.json packages/*/package.json
+          if [ -f CHANGELOG.md ]; then
+            git add CHANGELOG.md
+          fi
 
           if git diff --cached --quiet; then
             echo "Release files already match v${VERSION}"
@@ -277,4 +301,4 @@ jobs:
           fi
 
           git commit -m "$TITLE"
-          git push origin "HEAD:${HEAD_REF}"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${HEAD_REF}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,9 +73,9 @@ jobs:
           fi
 
           if [ "$RELEASE_BASE" = "alpha" ]; then
-            NPM_VERSION=$(npm view less dist-tags.alpha 2>/dev/null || echo "")
+            NPM_VERSION=$(npm view less dist-tags.alpha)
           else
-            NPM_VERSION=$(npm view less version 2>/dev/null || echo "")
+            NPM_VERSION=$(npm view less version)
           fi
 
           node scripts/release-metadata.js validate "$RELEASE_BASE" "$TITLE_VERSION" "$NPM_VERSION"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,30 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      - name: Validate release title version
+        env:
+          RELEASE_BASE: ${{ github.event.pull_request.base.ref }}
+          RELEASE_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          TITLE_VERSION=$(node scripts/release-metadata.js parse-title "$RELEASE_BASE" "$RELEASE_TITLE")
+          PACKAGE_VERSION=$(node -p "require('./packages/less/package.json').version")
+
+          if [ "$TITLE_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "❌ ERROR: Release PR title requests v${TITLE_VERSION}, but package.json contains v${PACKAGE_VERSION}"
+            echo "   Edit the release PR title and wait for the release-file sync check to update the branch before merging."
+            exit 1
+          fi
+
+          if [ "$RELEASE_BASE" = "alpha" ]; then
+            NPM_VERSION=$(npm view less dist-tags.alpha 2>/dev/null || echo "")
+          else
+            NPM_VERSION=$(npm view less version 2>/dev/null || echo "")
+          fi
+
+          node scripts/release-metadata.js validate "$RELEASE_BASE" "$TITLE_VERSION" "$NPM_VERSION"
+          echo "✅ Release title, package.json, and npm version checks agree on v${TITLE_VERSION}"
+
       - name: Run node tests (ESM + CJS)
         run: pnpm run test:node
 
@@ -85,30 +109,6 @@ jobs:
             echo "npm_tag=latest" >> $GITHUB_OUTPUT
             echo "release_type=release" >> $GITHUB_OUTPUT
           fi
-
-      - name: Validate release title version
-        env:
-          RELEASE_BASE: ${{ github.event.pull_request.base.ref }}
-          RELEASE_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          set -euo pipefail
-          TITLE_VERSION=$(node scripts/release-metadata.js parse-title "$RELEASE_BASE" "$RELEASE_TITLE")
-          PACKAGE_VERSION=$(node -p "require('./packages/less/package.json').version")
-
-          if [ "$TITLE_VERSION" != "$PACKAGE_VERSION" ]; then
-            echo "❌ ERROR: Release PR title requests v${TITLE_VERSION}, but package.json contains v${PACKAGE_VERSION}"
-            echo "   Edit the release PR title and wait for the release-file sync check to update the branch before merging."
-            exit 1
-          fi
-
-          if [ "$RELEASE_BASE" = "alpha" ]; then
-            NPM_VERSION=$(npm view less dist-tags.alpha 2>/dev/null || echo "")
-          else
-            NPM_VERSION=$(npm view less version 2>/dev/null || echo "")
-          fi
-
-          node scripts/release-metadata.js validate "$RELEASE_BASE" "$TITLE_VERSION" "$NPM_VERSION"
-          echo "✅ Release title, package.json, and npm version checks agree on v${TITLE_VERSION}"
 
       - name: Validate alpha branch requirements
         if: steps.branch-info.outputs.is_alpha == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish to NPM
 on:
   # Publish when a release PR is merged:
   #   master branch: "chore: release vX.Y.Z"       PR → publishes latest
-  #   alpha branch:  "chore: alpha release vX.Y.Z"  PR → publishes alpha
+  #   alpha branch:  "chore: release vX.Y.Z-alpha.N" PR → publishes alpha
   # Both release PRs are created automatically by create-release-pr.yml.
   pull_request:
     types: [closed]
@@ -29,7 +29,10 @@ jobs:
         (github.event.pull_request.base.ref == 'master' &&
          startsWith(github.event.pull_request.title, 'chore: release v')) ||
         (github.event.pull_request.base.ref == 'alpha' &&
-         startsWith(github.event.pull_request.title, 'chore: alpha release v'))
+         (
+           startsWith(github.event.pull_request.title, 'chore: release v') ||
+           startsWith(github.event.pull_request.title, 'chore: alpha release v')
+         ))
       )
 
     steps:
@@ -82,6 +85,30 @@ jobs:
             echo "npm_tag=latest" >> $GITHUB_OUTPUT
             echo "release_type=release" >> $GITHUB_OUTPUT
           fi
+
+      - name: Validate release title version
+        env:
+          RELEASE_BASE: ${{ github.event.pull_request.base.ref }}
+          RELEASE_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          TITLE_VERSION=$(node scripts/release-metadata.js parse-title "$RELEASE_BASE" "$RELEASE_TITLE")
+          PACKAGE_VERSION=$(node -p "require('./packages/less/package.json').version")
+
+          if [ "$TITLE_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "❌ ERROR: Release PR title requests v${TITLE_VERSION}, but package.json contains v${PACKAGE_VERSION}"
+            echo "   Edit the release PR title and wait for the release-file sync check to update the branch before merging."
+            exit 1
+          fi
+
+          if [ "$RELEASE_BASE" = "alpha" ]; then
+            NPM_VERSION=$(npm view less dist-tags.alpha 2>/dev/null || echo "")
+          else
+            NPM_VERSION=$(npm view less version 2>/dev/null || echo "")
+          fi
+
+          node scripts/release-metadata.js validate "$RELEASE_BASE" "$TITLE_VERSION" "$NPM_VERSION"
+          echo "✅ Release title, package.json, and npm version checks agree on v${TITLE_VERSION}"
 
       - name: Validate alpha branch requirements
         if: steps.branch-info.outputs.is_alpha == 'true'

--- a/scripts/release-metadata.js
+++ b/scripts/release-metadata.js
@@ -90,6 +90,17 @@ function validateAgainstNpm(base, version, npmVersion) {
   }
 }
 
+function validateTitleSync(base, version, previousVersion, npmVersion) {
+  validateAgainstNpm(base, version, npmVersion);
+
+  if (!semver.valid(previousVersion)) {
+    throw new Error(`Invalid previous package version: ${previousVersion}`);
+  }
+  if (semver.lt(version, previousVersion)) {
+    throw new Error(`Release title version ${version} must not be lower than current branch version ${previousVersion}`);
+  }
+}
+
 function nextVersion(base, currentVersion, npmVersion) {
   if (!semver.valid(currentVersion)) {
     throw new Error(`Invalid current package version: ${currentVersion}`);
@@ -145,15 +156,39 @@ function replaceChangelogVersion(content, version, previousVersion) {
   };
 }
 
-function syncChangelogVersion(version, previousVersion) {
+function readChangelogUpdate(version, previousVersion) {
   const changelog = path.join(ROOT_DIR, 'CHANGELOG.md');
-  if (!fs.existsSync(changelog)) return false;
+  if (!fs.existsSync(changelog)) return { path: changelog, status: 'missing' };
 
   const original = fs.readFileSync(changelog, 'utf8');
-  const { changed, content } = replaceChangelogVersion(original, version, previousVersion);
-  if (!changed) return false;
+  if (version === previousVersion) {
+    return { path: changelog, status: 'unchanged', content: original };
+  }
 
-  fs.writeFileSync(changelog, content);
+  const { changed, content } = replaceChangelogVersion(original, version, previousVersion);
+  if (!changed) {
+    throw new Error(`CHANGELOG.md first release heading does not match previous version ${previousVersion}`);
+  }
+
+  return { path: changelog, status: 'updated', content };
+}
+
+function syncChangelogVersion(version, previousVersion) {
+  const update = readChangelogUpdate(version, previousVersion);
+  if (update.status !== 'updated') return false;
+
+  fs.writeFileSync(update.path, update.content);
+  return true;
+}
+
+function syncFiles(version, previousVersion) {
+  const changelogUpdate = readChangelogUpdate(version, previousVersion);
+
+  syncPackageVersions(version);
+  if (changelogUpdate.status === 'updated') {
+    fs.writeFileSync(changelogUpdate.path, changelogUpdate.content);
+  }
+
   return true;
 }
 
@@ -164,6 +199,7 @@ function usage() {
   node scripts/release-metadata.js body
   node scripts/release-metadata.js parse-title <base> <title>
   node scripts/release-metadata.js validate <base> <version> [npmVersion]
+  node scripts/release-metadata.js validate-title-sync <base> <version> <previousVersion> [npmVersion]
   node scripts/release-metadata.js next-version <base> <currentVersion> [npmVersion]
   node scripts/release-metadata.js sync-package-versions <version>
   node scripts/release-metadata.js sync-files <version> <previousVersion>`);
@@ -182,13 +218,14 @@ function main(argv = process.argv.slice(2)) {
       process.stdout.write(parseReleaseTitle(args[0], args.slice(1).join(' ')));
     } else if (command === 'validate') {
       validateAgainstNpm(args[0], args[1], args[2] || '');
+    } else if (command === 'validate-title-sync') {
+      validateTitleSync(args[0], args[1], args[2], args[3] || '');
     } else if (command === 'next-version') {
       process.stdout.write(nextVersion(args[0], args[1], args[2] || ''));
     } else if (command === 'sync-package-versions') {
       syncPackageVersions(args[0]);
     } else if (command === 'sync-files') {
-      syncPackageVersions(args[0]);
-      syncChangelogVersion(args[0], args[1]);
+      syncFiles(args[0], args[1]);
     } else {
       usage();
       process.exit(1);
@@ -208,12 +245,15 @@ module.exports = {
   RELEASE_TITLE_PREFIX,
   nextVersion,
   parseReleaseTitle,
+  readChangelogUpdate,
   replaceChangelogVersion,
   releaseBody,
   releaseBranch,
   releaseTitle,
+  syncFiles,
   syncChangelogVersion,
   syncPackageVersions,
   validateAgainstNpm,
+  validateTitleSync,
   validateVersionForBase,
 };

--- a/scripts/release-metadata.js
+++ b/scripts/release-metadata.js
@@ -187,7 +187,7 @@ function changelogUpdateForContent(content, version, previousVersion, date) {
 
   const heading = content.match(/^(### v)(\d+\.\d+\.\d+(?:-alpha\.\d+)?)( \(\d{4}-\d{2}-\d{2}\))$/m);
   if (!heading) {
-    return { status: 'unchanged', content };
+    return { status: 'inserted', content: insertChangelogVersion(content, version, date) };
   }
   if (heading[2] === version) {
     return { status: 'unchanged', content };

--- a/scripts/release-metadata.js
+++ b/scripts/release-metadata.js
@@ -96,11 +96,14 @@ function nextVersion(base, currentVersion, npmVersion) {
   }
 
   if (isAlphaBase(base)) {
-    const match = currentVersion.match(/^(\d+\.\d+\.\d+)-alpha\.(\d+)$/);
+    const baseVersion = npmVersion && semver.valid(npmVersion) && semver.gt(npmVersion, currentVersion)
+      ? npmVersion
+      : currentVersion;
+    const match = baseVersion.match(/^(\d+\.\d+\.\d+)-alpha\.(\d+)$/);
     if (match) {
       return `${match[1]}-alpha.${parseInt(match[2], 10) + 1}`;
     }
-    const parsed = semver.parse(currentVersion);
+    const parsed = semver.parse(baseVersion);
     return `${parsed.major + 1}.0.0-alpha.1`;
   }
 
@@ -128,15 +131,29 @@ function syncPackageVersions(version) {
   }
 }
 
-function syncChangelogVersion(version) {
+function replaceChangelogVersion(content, version, previousVersion) {
+  const heading = content.match(/^(### v)(\d+\.\d+\.\d+(?:-alpha\.\d+)?)( \(\d{4}-\d{2}-\d{2}\))$/m);
+  if (!heading || heading[2] !== previousVersion) {
+    return { changed: false, content };
+  }
+
+  return {
+    changed: true,
+    content: content.slice(0, heading.index) +
+      `${heading[1]}${version}${heading[3]}` +
+      content.slice(heading.index + heading[0].length),
+  };
+}
+
+function syncChangelogVersion(version, previousVersion) {
   const changelog = path.join(ROOT_DIR, 'CHANGELOG.md');
   if (!fs.existsSync(changelog)) return false;
 
   const original = fs.readFileSync(changelog, 'utf8');
-  const updated = original.replace(/^(### v)(\d+\.\d+\.\d+(?:-alpha\.\d+)?)( \(\d{4}-\d{2}-\d{2}\))$/m, `$1${version}$3`);
-  if (updated === original) return false;
+  const { changed, content } = replaceChangelogVersion(original, version, previousVersion);
+  if (!changed) return false;
 
-  fs.writeFileSync(changelog, updated);
+  fs.writeFileSync(changelog, content);
   return true;
 }
 
@@ -149,7 +166,7 @@ function usage() {
   node scripts/release-metadata.js validate <base> <version> [npmVersion]
   node scripts/release-metadata.js next-version <base> <currentVersion> [npmVersion]
   node scripts/release-metadata.js sync-package-versions <version>
-  node scripts/release-metadata.js sync-files <version>`);
+  node scripts/release-metadata.js sync-files <version> <previousVersion>`);
 }
 
 function main(argv = process.argv.slice(2)) {
@@ -171,7 +188,7 @@ function main(argv = process.argv.slice(2)) {
       syncPackageVersions(args[0]);
     } else if (command === 'sync-files') {
       syncPackageVersions(args[0]);
-      syncChangelogVersion(args[0]);
+      syncChangelogVersion(args[0], args[1]);
     } else {
       usage();
       process.exit(1);
@@ -191,6 +208,7 @@ module.exports = {
   RELEASE_TITLE_PREFIX,
   nextVersion,
   parseReleaseTitle,
+  replaceChangelogVersion,
   releaseBody,
   releaseBranch,
   releaseTitle,

--- a/scripts/release-metadata.js
+++ b/scripts/release-metadata.js
@@ -156,21 +156,33 @@ function replaceChangelogVersion(content, version, previousVersion) {
   };
 }
 
+function changelogUpdateForContent(content, version, previousVersion) {
+  if (version === previousVersion) {
+    return { status: 'unchanged', content };
+  }
+
+  const heading = content.match(/^(### v)(\d+\.\d+\.\d+(?:-alpha\.\d+)?)( \(\d{4}-\d{2}-\d{2}\))$/m);
+  if (!heading) {
+    return { status: 'unchanged', content };
+  }
+  if (heading[2] === version) {
+    return { status: 'unchanged', content };
+  }
+
+  const { changed, content: updated } = replaceChangelogVersion(content, version, previousVersion);
+  if (!changed) {
+    return { status: 'missing-current-heading', content };
+  }
+
+  return { status: 'updated', content: updated };
+}
+
 function readChangelogUpdate(version, previousVersion) {
   const changelog = path.join(ROOT_DIR, 'CHANGELOG.md');
   if (!fs.existsSync(changelog)) return { path: changelog, status: 'missing' };
 
   const original = fs.readFileSync(changelog, 'utf8');
-  if (version === previousVersion) {
-    return { path: changelog, status: 'unchanged', content: original };
-  }
-
-  const { changed, content } = replaceChangelogVersion(original, version, previousVersion);
-  if (!changed) {
-    throw new Error(`CHANGELOG.md first release heading does not match previous version ${previousVersion}`);
-  }
-
-  return { path: changelog, status: 'updated', content };
+  return { path: changelog, ...changelogUpdateForContent(original, version, previousVersion) };
 }
 
 function syncChangelogVersion(version, previousVersion) {
@@ -243,6 +255,7 @@ if (require.main === module) {
 module.exports = {
   LEGACY_ALPHA_RELEASE_TITLE_PREFIX,
   RELEASE_TITLE_PREFIX,
+  changelogUpdateForContent,
   nextVersion,
   parseReleaseTitle,
   readChangelogUpdate,

--- a/scripts/release-metadata.js
+++ b/scripts/release-metadata.js
@@ -156,7 +156,31 @@ function replaceChangelogVersion(content, version, previousVersion) {
   };
 }
 
-function changelogUpdateForContent(content, version, previousVersion) {
+function currentDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function insertChangelogVersion(content, version, date = currentDate()) {
+  const heading = `### v${version} (${date})`;
+  const firstReleaseHeading = content.match(/^### v\d+\.\d+\.\d+(?:-alpha\.\d+)? \(\d{4}-\d{2}-\d{2}\)$/m);
+
+  if (firstReleaseHeading) {
+    return content.slice(0, firstReleaseHeading.index) +
+      `${heading}\n\n` +
+      content.slice(firstReleaseHeading.index);
+  }
+
+  const firstLineEnd = content.indexOf('\n');
+  if (firstLineEnd === -1) {
+    return `${content}\n\n${heading}\n`;
+  }
+
+  return content.slice(0, firstLineEnd + 1) +
+    `\n${heading}\n` +
+    content.slice(firstLineEnd + 1);
+}
+
+function changelogUpdateForContent(content, version, previousVersion, date) {
   if (version === previousVersion) {
     return { status: 'unchanged', content };
   }
@@ -171,7 +195,7 @@ function changelogUpdateForContent(content, version, previousVersion) {
 
   const { changed, content: updated } = replaceChangelogVersion(content, version, previousVersion);
   if (!changed) {
-    return { status: 'missing-current-heading', content };
+    return { status: 'inserted', content: insertChangelogVersion(content, version, date) };
   }
 
   return { status: 'updated', content: updated };
@@ -187,7 +211,7 @@ function readChangelogUpdate(version, previousVersion) {
 
 function syncChangelogVersion(version, previousVersion) {
   const update = readChangelogUpdate(version, previousVersion);
-  if (update.status !== 'updated') return false;
+  if (update.status !== 'updated' && update.status !== 'inserted') return false;
 
   fs.writeFileSync(update.path, update.content);
   return true;
@@ -197,7 +221,7 @@ function syncFiles(version, previousVersion) {
   const changelogUpdate = readChangelogUpdate(version, previousVersion);
 
   syncPackageVersions(version);
-  if (changelogUpdate.status === 'updated') {
+  if (changelogUpdate.status === 'updated' || changelogUpdate.status === 'inserted') {
     fs.writeFileSync(changelogUpdate.path, changelogUpdate.content);
   }
 
@@ -256,6 +280,7 @@ module.exports = {
   LEGACY_ALPHA_RELEASE_TITLE_PREFIX,
   RELEASE_TITLE_PREFIX,
   changelogUpdateForContent,
+  insertChangelogVersion,
   nextVersion,
   parseReleaseTitle,
   readChangelogUpdate,

--- a/scripts/release-metadata.js
+++ b/scripts/release-metadata.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const semver = require('semver');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+const PACKAGES_DIR = path.join(ROOT_DIR, 'packages');
+const RELEASE_TITLE_PREFIX = 'chore: release v';
+const LEGACY_ALPHA_RELEASE_TITLE_PREFIX = 'chore: alpha release v';
+
+function isAlphaBase(base) {
+  return base === 'alpha';
+}
+
+function releaseTitle(base, version) {
+  validateVersionForBase(base, version);
+  return `${RELEASE_TITLE_PREFIX}${version}`;
+}
+
+function releaseBranch(base, version) {
+  validateVersionForBase(base, version);
+  return isAlphaBase(base) ? `chore/alpha-release-v${version}` : `chore/release-v${version}`;
+}
+
+function releaseBody() {
+  return 'Merging this PR publishes the version named in the PR title.';
+}
+
+function parseReleaseTitle(base, title) {
+  if (typeof title !== 'string') {
+    throw new Error('Release title must be a string');
+  }
+
+  let version = null;
+  if (title.startsWith(RELEASE_TITLE_PREFIX)) {
+    version = title.slice(RELEASE_TITLE_PREFIX.length).trim();
+  } else if (isAlphaBase(base) && title.startsWith(LEGACY_ALPHA_RELEASE_TITLE_PREFIX)) {
+    version = title.slice(LEGACY_ALPHA_RELEASE_TITLE_PREFIX.length).trim();
+  }
+
+  if (!version) {
+    throw new Error(
+      isAlphaBase(base)
+        ? `Release title must start with "${RELEASE_TITLE_PREFIX}" or "${LEGACY_ALPHA_RELEASE_TITLE_PREFIX}"`
+        : `Release title must start with "${RELEASE_TITLE_PREFIX}"`,
+    );
+  }
+
+  validateVersionForBase(base, version);
+  return version;
+}
+
+function validateVersionForBase(base, version) {
+  const normalized = semver.valid(version);
+  if (!normalized || normalized !== version) {
+    throw new Error(`Invalid semver version: ${version}`);
+  }
+
+  const parsed = semver.parse(version);
+  const prerelease = parsed.prerelease;
+  if (isAlphaBase(base)) {
+    if (
+      prerelease.length !== 2 ||
+      prerelease[0] !== 'alpha' ||
+      typeof prerelease[1] !== 'number'
+    ) {
+      throw new Error(`Alpha releases must use X.Y.Z-alpha.N, got: ${version}`);
+    }
+  } else if (base === 'master') {
+    if (prerelease.length > 0) {
+      throw new Error(`Master releases must not use a prerelease version, got: ${version}`);
+    }
+  } else {
+    throw new Error(`Release base must be "master" or "alpha", got: ${base}`);
+  }
+}
+
+function validateAgainstNpm(base, version, npmVersion) {
+  validateVersionForBase(base, version);
+  if (!npmVersion) return;
+  if (!semver.valid(npmVersion)) {
+    throw new Error(`Invalid npm version: ${npmVersion}`);
+  }
+  if (!semver.gt(version, npmVersion)) {
+    const tag = isAlphaBase(base) ? 'alpha' : 'latest';
+    throw new Error(`Release version ${version} must be greater than npm ${tag} version ${npmVersion}`);
+  }
+}
+
+function nextVersion(base, currentVersion, npmVersion) {
+  if (!semver.valid(currentVersion)) {
+    throw new Error(`Invalid current package version: ${currentVersion}`);
+  }
+
+  if (isAlphaBase(base)) {
+    const match = currentVersion.match(/^(\d+\.\d+\.\d+)-alpha\.(\d+)$/);
+    if (match) {
+      return `${match[1]}-alpha.${parseInt(match[2], 10) + 1}`;
+    }
+    const parsed = semver.parse(currentVersion);
+    return `${parsed.major + 1}.0.0-alpha.1`;
+  }
+
+  if (npmVersion && semver.valid(npmVersion) && semver.gt(currentVersion, npmVersion)) {
+    return currentVersion;
+  }
+  return semver.inc(npmVersion || currentVersion, 'patch');
+}
+
+function packageFiles() {
+  const files = [path.join(ROOT_DIR, 'package.json')];
+  const packageDirs = fs.readdirSync(PACKAGES_DIR, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => path.join(PACKAGES_DIR, dirent.name, 'package.json'));
+  return [...files, ...packageDirs].filter(file => fs.existsSync(file));
+}
+
+function syncPackageVersions(version) {
+  validateVersionForBase(version.includes('-alpha.') ? 'alpha' : 'master', version);
+  for (const file of packageFiles()) {
+    const pkg = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (!pkg.version) continue;
+    pkg.version = version;
+    fs.writeFileSync(file, JSON.stringify(pkg, null, '\t') + '\n');
+  }
+}
+
+function syncChangelogVersion(version) {
+  const changelog = path.join(ROOT_DIR, 'CHANGELOG.md');
+  if (!fs.existsSync(changelog)) return false;
+
+  const original = fs.readFileSync(changelog, 'utf8');
+  const updated = original.replace(/^(### v)(\d+\.\d+\.\d+(?:-alpha\.\d+)?)( \(\d{4}-\d{2}-\d{2}\))$/m, `$1${version}$3`);
+  if (updated === original) return false;
+
+  fs.writeFileSync(changelog, updated);
+  return true;
+}
+
+function usage() {
+  console.error(`Usage:
+  node scripts/release-metadata.js title <base> <version>
+  node scripts/release-metadata.js branch <base> <version>
+  node scripts/release-metadata.js body
+  node scripts/release-metadata.js parse-title <base> <title>
+  node scripts/release-metadata.js validate <base> <version> [npmVersion]
+  node scripts/release-metadata.js next-version <base> <currentVersion> [npmVersion]
+  node scripts/release-metadata.js sync-package-versions <version>
+  node scripts/release-metadata.js sync-files <version>`);
+}
+
+function main(argv = process.argv.slice(2)) {
+  const [command, ...args] = argv;
+  try {
+    if (command === 'title') {
+      process.stdout.write(releaseTitle(args[0], args[1]));
+    } else if (command === 'branch') {
+      process.stdout.write(releaseBranch(args[0], args[1]));
+    } else if (command === 'body') {
+      process.stdout.write(releaseBody());
+    } else if (command === 'parse-title') {
+      process.stdout.write(parseReleaseTitle(args[0], args.slice(1).join(' ')));
+    } else if (command === 'validate') {
+      validateAgainstNpm(args[0], args[1], args[2] || '');
+    } else if (command === 'next-version') {
+      process.stdout.write(nextVersion(args[0], args[1], args[2] || ''));
+    } else if (command === 'sync-package-versions') {
+      syncPackageVersions(args[0]);
+    } else if (command === 'sync-files') {
+      syncPackageVersions(args[0]);
+      syncChangelogVersion(args[0]);
+    } else {
+      usage();
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  LEGACY_ALPHA_RELEASE_TITLE_PREFIX,
+  RELEASE_TITLE_PREFIX,
+  nextVersion,
+  parseReleaseTitle,
+  releaseBody,
+  releaseBranch,
+  releaseTitle,
+  syncChangelogVersion,
+  syncPackageVersions,
+  validateAgainstNpm,
+  validateVersionForBase,
+};

--- a/scripts/test-release-automation.js
+++ b/scripts/test-release-automation.js
@@ -548,7 +548,7 @@ test('changelog title sync updates the matching current release heading only', (
   assert.ok(result.content.includes('### v4.8.0 (2026-07-25)'));
 });
 
-test('changelog title sync skips historical heading when current heading is absent', () => {
+test('changelog title sync inserts a current heading when only history exists', () => {
   const changelog = [
     '# Changelog',
     '',
@@ -560,9 +560,10 @@ test('changelog title sync skips historical heading when current heading is abse
     '',
   ].join('\n');
 
-  const result = releaseMetadata.changelogUpdateForContent(changelog, '4.9.0', '4.8.1');
-  assert.strictEqual(result.status, 'missing-current-heading');
-  assert.strictEqual(result.content, changelog);
+  const result = releaseMetadata.changelogUpdateForContent(changelog, '4.9.0', '4.8.1', '2026-07-26');
+  assert.strictEqual(result.status, 'inserted');
+  assert.ok(result.content.includes('### v4.9.0 (2026-07-26)\n\n### v4.8.0 (2026-07-25)'));
+  assert.ok(result.content.includes('- older change'));
 });
 
 test('changelog title sync is idempotent when the heading already matches the title', () => {

--- a/scripts/test-release-automation.js
+++ b/scripts/test-release-automation.js
@@ -515,6 +515,19 @@ test('npm alpha check rejects an alpha title version that is already published',
   );
 });
 
+test('title sync rejects versions lower than the release branch package version', () => {
+  assert.throws(
+    () => releaseMetadata.validateTitleSync('master', '4.8.0', '4.9.0', '4.7.0'),
+    /must not be lower than current branch version/,
+  );
+});
+
+test('title sync allows versions equal to the release branch package version', () => {
+  assert.doesNotThrow(
+    () => releaseMetadata.validateTitleSync('master', '4.9.0', '4.9.0', '4.8.0'),
+  );
+});
+
 test('changelog title sync updates the matching current release heading only', () => {
   const changelog = [
     '# Changelog',

--- a/scripts/test-release-automation.js
+++ b/scripts/test-release-automation.js
@@ -566,6 +566,20 @@ test('changelog title sync inserts a current heading when only history exists', 
   assert.ok(result.content.includes('- older change'));
 });
 
+test('changelog title sync inserts a heading when no dated release heading exists', () => {
+  const changelog = [
+    '# Changelog',
+    '',
+    'Unreleased notes without a dated release heading.',
+    '',
+  ].join('\n');
+
+  const result = releaseMetadata.changelogUpdateForContent(changelog, '4.9.0', '4.8.1', '2026-07-26');
+  assert.strictEqual(result.status, 'inserted');
+  assert.ok(result.content.includes('# Changelog\n\n### v4.9.0 (2026-07-26)\n'));
+  assert.ok(result.content.includes('Unreleased notes without a dated release heading.'));
+});
+
 test('changelog title sync is idempotent when the heading already matches the title', () => {
   const changelog = [
     '# Changelog',

--- a/scripts/test-release-automation.js
+++ b/scripts/test-release-automation.js
@@ -45,6 +45,7 @@ const fs     = require('fs');
 const os     = require('os');
 const path   = require('path');
 const { spawnSync, execSync } = require('child_process');
+const releaseMetadata = require('./release-metadata');
 
 const ROOT_DIR = path.resolve(__dirname, '..');
 
@@ -116,12 +117,15 @@ function publishShouldRun({ repo, prMerged, prBaseRef, prTitle }) {
   const isMasterRelease =
     prBaseRef === 'master' &&
     typeof prTitle === 'string' &&
-    prTitle.startsWith('chore: release v');
+    prTitle.startsWith(releaseMetadata.RELEASE_TITLE_PREFIX);
 
   const isAlphaRelease =
     prBaseRef === 'alpha' &&
     typeof prTitle === 'string' &&
-    prTitle.startsWith('chore: alpha release v');
+    (
+      prTitle.startsWith(releaseMetadata.RELEASE_TITLE_PREFIX) ||
+      prTitle.startsWith(releaseMetadata.LEGACY_ALPHA_RELEASE_TITLE_PREFIX)
+    );
 
   return isMasterRelease || isAlphaRelease;
 }
@@ -152,13 +156,7 @@ function createReleasePRShouldRun({ repo, commitMessage }) {
  *   X.Y.Z          →  (X+1).0.0-alpha.1   (no alpha suffix yet)
  */
 function nextAlphaVersion(current) {
-  const m = current.match(/^(\d+\.\d+\.\d+)-alpha\.(\d+)$/);
-  if (m) {
-    return `${m[1]}-alpha.${parseInt(m[2], 10) + 1}`;
-  }
-  const parts = current.replace(/-.*/, '').split('.');
-  const nextMajor = parseInt(parts[0], 10) + 1;
-  return `${nextMajor}.0.0-alpha.1`;
+  return releaseMetadata.nextVersion('alpha', current);
 }
 
 // ---------------------------------------------------------------------------
@@ -351,6 +349,18 @@ test('alpha release PR merged → SHOULD publish (alpha tag)', () => {
       repo: 'less/less.js',
       prMerged: true,
       prBaseRef: 'alpha',
+      prTitle: 'chore: release v5.0.0-alpha.2',
+    }),
+    true,
+  );
+});
+
+test('legacy alpha release PR title merged → SHOULD publish (alpha tag)', () => {
+  assert.strictEqual(
+    publishShouldRun({
+      repo: 'less/less.js',
+      prMerged: true,
+      prBaseRef: 'alpha',
       prTitle: 'chore: alpha release v5.0.0-alpha.2',
     }),
     true,
@@ -406,6 +416,22 @@ test('alpha release PR title used against master base → should NOT publish', (
   );
 });
 
+test('alpha-looking canonical title against master base → trigger, then validation rejects', () => {
+  assert.strictEqual(
+    publishShouldRun({
+      repo: 'less/less.js',
+      prMerged: true,
+      prBaseRef: 'master',
+      prTitle: 'chore: release v5.0.0-alpha.1',
+    }),
+    true,
+  );
+  assert.throws(
+    () => releaseMetadata.parseReleaseTitle('master', 'chore: release v5.0.0-alpha.1'),
+    /Master releases must not use a prerelease version/,
+  );
+});
+
 test('wrong repository → should NOT publish', () => {
   assert.strictEqual(
     publishShouldRun({
@@ -415,6 +441,70 @@ test('wrong repository → should NOT publish', () => {
       prTitle: 'chore: release v4.6.4',
     }),
     false,
+  );
+});
+
+// ----------------------------------------------------------------------------
+// Section 1b — release title metadata
+// ----------------------------------------------------------------------------
+
+section('1b. release title metadata — title as version source');
+
+test('master title parses the requested release version', () => {
+  assert.strictEqual(
+    releaseMetadata.parseReleaseTitle('master', 'chore: release v4.9.0'),
+    '4.9.0',
+  );
+});
+
+test('alpha title uses the same canonical title shape', () => {
+  assert.strictEqual(
+    releaseMetadata.releaseTitle('alpha', '5.0.0-alpha.3'),
+    'chore: release v5.0.0-alpha.3',
+  );
+  assert.strictEqual(
+    releaseMetadata.parseReleaseTitle('alpha', 'chore: release v5.0.0-alpha.3'),
+    '5.0.0-alpha.3',
+  );
+});
+
+test('legacy alpha title remains accepted for existing PRs', () => {
+  assert.strictEqual(
+    releaseMetadata.parseReleaseTitle('alpha', 'chore: alpha release v5.0.0-alpha.3'),
+    '5.0.0-alpha.3',
+  );
+});
+
+test('master release title rejects alpha prerelease versions', () => {
+  assert.throws(
+    () => releaseMetadata.parseReleaseTitle('master', 'chore: release v5.0.0-alpha.3'),
+    /Master releases must not use a prerelease version/,
+  );
+});
+
+test('alpha release title rejects non-alpha versions', () => {
+  assert.throws(
+    () => releaseMetadata.parseReleaseTitle('alpha', 'chore: release v5.0.0'),
+    /Alpha releases must use X\.Y\.Z-alpha\.N/,
+  );
+});
+
+test('release body does not repeat the version', () => {
+  assert.ok(!releaseMetadata.releaseBody().includes('4.9.0'));
+  assert.ok(releaseMetadata.releaseBody().includes('PR title'));
+});
+
+test('npm latest check rejects a master title version that is already published', () => {
+  assert.throws(
+    () => releaseMetadata.validateAgainstNpm('master', '4.9.0', '4.9.0'),
+    /must be greater than npm latest version/,
+  );
+});
+
+test('npm alpha check rejects an alpha title version that is already published', () => {
+  assert.throws(
+    () => releaseMetadata.validateAgainstNpm('alpha', '5.0.0-alpha.3', '5.0.0-alpha.3'),
+    /must be greater than npm alpha version/,
   );
 });
 

--- a/scripts/test-release-automation.js
+++ b/scripts/test-release-automation.js
@@ -155,8 +155,8 @@ function createReleasePRShouldRun({ repo, commitMessage }) {
  *   X.Y.Z-alpha.N  →  X.Y.Z-alpha.(N+1)
  *   X.Y.Z          →  (X+1).0.0-alpha.1   (no alpha suffix yet)
  */
-function nextAlphaVersion(current) {
-  return releaseMetadata.nextVersion('alpha', current);
+function nextAlphaVersion(current, npmVersion) {
+  return releaseMetadata.nextVersion('alpha', current, npmVersion);
 }
 
 // ---------------------------------------------------------------------------
@@ -482,6 +482,13 @@ test('master release title rejects alpha prerelease versions', () => {
   );
 });
 
+test('master release title rejects legacy alpha prefix', () => {
+  assert.throws(
+    () => releaseMetadata.parseReleaseTitle('master', 'chore: alpha release v5.0.0'),
+    /Release title must start with "chore: release v"/,
+  );
+});
+
 test('alpha release title rejects non-alpha versions', () => {
   assert.throws(
     () => releaseMetadata.parseReleaseTitle('alpha', 'chore: release v5.0.0'),
@@ -506,6 +513,43 @@ test('npm alpha check rejects an alpha title version that is already published',
     () => releaseMetadata.validateAgainstNpm('alpha', '5.0.0-alpha.3', '5.0.0-alpha.3'),
     /must be greater than npm alpha version/,
   );
+});
+
+test('changelog title sync updates the matching current release heading only', () => {
+  const changelog = [
+    '# Changelog',
+    '',
+    '### v4.8.1 (2026-07-26)',
+    '',
+    '#### Changes',
+    '',
+    '- something',
+    '',
+    '### v4.8.0 (2026-07-25)',
+    '',
+  ].join('\n');
+
+  const result = releaseMetadata.replaceChangelogVersion(changelog, '4.9.0', '4.8.1');
+  assert.strictEqual(result.changed, true);
+  assert.ok(result.content.includes('### v4.9.0 (2026-07-26)'));
+  assert.ok(result.content.includes('### v4.8.0 (2026-07-25)'));
+});
+
+test('changelog title sync skips historical heading when current heading is absent', () => {
+  const changelog = [
+    '# Changelog',
+    '',
+    '### v4.8.0 (2026-07-25)',
+    '',
+    '#### Changes',
+    '',
+    '- older change',
+    '',
+  ].join('\n');
+
+  const result = releaseMetadata.replaceChangelogVersion(changelog, '4.9.0', '4.8.1');
+  assert.strictEqual(result.changed, false);
+  assert.strictEqual(result.content, changelog);
 });
 
 // ----------------------------------------------------------------------------
@@ -597,6 +641,10 @@ test('5.x minor/patch: 5.1.2-alpha.7 → 5.1.2-alpha.8', () => {
 
 test('double-digit rollover: 5.0.0-alpha.9 → 5.0.0-alpha.10  (integer, not string comparison)', () => {
   assert.strictEqual(nextAlphaVersion('5.0.0-alpha.9'), '5.0.0-alpha.10');
+});
+
+test('npm alpha ahead of package.json: 5.0.0-alpha.1 with npm alpha.4 → 5.0.0-alpha.5', () => {
+  assert.strictEqual(nextAlphaVersion('5.0.0-alpha.1', '5.0.0-alpha.4'), '5.0.0-alpha.5');
 });
 
 test('non-alpha version on alpha branch: 4.6.3 → 5.0.0-alpha.1  (bumps major, starts fresh)', () => {

--- a/scripts/test-release-automation.js
+++ b/scripts/test-release-automation.js
@@ -560,8 +560,27 @@ test('changelog title sync skips historical heading when current heading is abse
     '',
   ].join('\n');
 
-  const result = releaseMetadata.replaceChangelogVersion(changelog, '4.9.0', '4.8.1');
-  assert.strictEqual(result.changed, false);
+  const result = releaseMetadata.changelogUpdateForContent(changelog, '4.9.0', '4.8.1');
+  assert.strictEqual(result.status, 'missing-current-heading');
+  assert.strictEqual(result.content, changelog);
+});
+
+test('changelog title sync is idempotent when the heading already matches the title', () => {
+  const changelog = [
+    '# Changelog',
+    '',
+    '### v4.9.0 (2026-07-26)',
+    '',
+    '#### Changes',
+    '',
+    '- something',
+    '',
+    '### v4.8.0 (2026-07-25)',
+    '',
+  ].join('\n');
+
+  const result = releaseMetadata.changelogUpdateForContent(changelog, '4.9.0', '4.8.1');
+  assert.strictEqual(result.status, 'unchanged');
   assert.strictEqual(result.content, changelog);
 });
 


### PR DESCRIPTION
## Summary

- centralize release title/version parsing in a shared helper
- let release PR title edits sync package versions and changelog heading after npm version validation
- validate on publish that the merged package version matches the release PR title before tagging/publishing
- use the canonical `chore: release v...` title for both master and alpha releases, while accepting legacy `chore: alpha release v...` titles

## Testing

- `node scripts/test-release-automation.js`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/create-release-pr.yml'); YAML.load_file('.github/workflows/publish.yml'); puts 'yaml ok'"`
- commit hook also ran typecheck/full test path; local browser runners reported missing Playwright browser binaries, but the hook completed and allowed the commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release PR automation now uses a centralized release-metadata CLI to compute next versions, generate titles/bodies, and synchronize package.json versions and CHANGELOG.
  * Added an additional workflow job to keep release-branch files/CHANGELOG in sync with the expected release/alpha naming.
* **Bug Fixes**
  * Publishing is more strictly validated by checking the merged PR title version against package.json and the current npm alpha dist-tag, with updated legacy-alpha title support.
* **Tests**
  * Expanded release-automation tests to cover metadata-driven title parsing/formatting, validation failures, and changelog version replacement rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->