### PR TITLE
fix(release): sync release version from PR title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
         run: node --version && pnpm --version
       - name: Run node tests (ESM + CJS)
         run: pnpm run test:node
+      - name: Run release automation tests
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 'lts/*'
+        run: pnpm run test:release
 
   copilot-review:
     name: Request Copilot review

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -5,9 +5,14 @@ name: Create Release PR
 # version. Maintainers then merge that PR to trigger publishing.
 #
 # master → "chore: release vX.Y.Z" PR targets master
-# alpha → "chore: alpha release vX.Y.Z" PR targets alpha
+# alpha → "chore: release vX.Y.Z-alpha.N" PR targets alpha
 on:
   push:
+    branches:
+      - master
+      - alpha
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
     branches:
       - master
       - alpha
@@ -24,6 +29,7 @@ jobs:
     # infinite loop). We catch both squash-merged and regular-merged commits
     # for both the master and alpha release PR title conventions.
     if: |
+      github.event_name == 'push' &&
       github.repository == 'less/less.js' &&
       !contains(github.event.head_commit.message, 'chore: release v') &&
       !contains(github.event.head_commit.message, 'chore: alpha release v') &&
@@ -48,49 +54,47 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Determine next version
+      - name: Determine release version
         id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          BRANCH="${{ github.ref_name }}"
+          set -euo pipefail
+          BRANCH="$REF_NAME"
           CURRENT=$(node -p "require('./packages/less/package.json').version")
 
           if [ "$BRANCH" = "alpha" ]; then
-            # Alpha: increment the alpha prerelease number.
-            # X.Y.Z-alpha.N → X.Y.Z-alpha.(N+1)
-            # If package.json doesn't carry an alpha version yet, bump the
-            # major and start a fresh alpha.1 series.
-            NEXT=$(node -e "
-            const cur = process.argv[1];
-            const m = cur.match(/^(\\d+\\.\\d+\\.\\d+)-alpha\\.(\\d+)$/);
-            if (m) {
-              process.stdout.write(m[1] + '-alpha.' + (parseInt(m[2], 10) + 1));
-            } else {
-              const parts = cur.replace(/-.*/, '').split('.');
-              const nextMajor = parseInt(parts[0], 10) + 1;
-              process.stdout.write(nextMajor + '.0.0-alpha.1');
-            }
-            " "$CURRENT")
-            echo "next_version=$NEXT" >> "$GITHUB_OUTPUT"
-            echo "branch=chore/alpha-release-v$NEXT" >> "$GITHUB_OUTPUT"
-            echo "release_base=alpha" >> "$GITHUB_OUTPUT"
+            NPM_VERSION=$(npm view less dist-tags.alpha)
           else
-            # Master: patch-increment from the latest npm published version.
-            NPM_VERSION=$(npm view less version 2>/dev/null || echo "")
-            NEXT=$(node -e "
-            const semver = require('semver');
-            const cur = process.argv[1];
-            const npm = process.argv[2] || null;
-            if (npm && semver.valid(cur) && semver.gt(cur, npm)) {
-              process.stdout.write(cur);
-            } else {
-              const base = npm || cur;
-              process.stdout.write(semver.inc(base, 'patch'));
-            }
-            " "$CURRENT" "$NPM_VERSION")
-            echo "next_version=$NEXT" >> "$GITHUB_OUTPUT"
-            echo "branch=chore/release-v$NEXT" >> "$GITHUB_OUTPUT"
-            echo "release_base=master" >> "$GITHUB_OUTPUT"
+            NPM_VERSION=$(npm view less version)
           fi
+
+          DEFAULT_NEXT=$(node scripts/release-metadata.js next-version "$BRANCH" "$CURRENT" "$NPM_VERSION")
+          EXISTING=$(gh pr list \
+            --state open \
+            --base "$BRANCH" \
+            --json title,headRefName,headRepository,isCrossRepository \
+            --jq '[.[] | select((.isCrossRepository | not) and .headRepository.nameWithOwner == "less/less.js" and ((.headRefName | startswith("chore/release-v")) or (.headRefName | startswith("chore/alpha-release-v"))))][0] // {}')
+
+          EXISTING_TITLE=$(node -e "const pr = JSON.parse(process.argv[1]); process.stdout.write(pr.title || '')" "$EXISTING")
+          EXISTING_BRANCH=$(node -e "const pr = JSON.parse(process.argv[1]); process.stdout.write(pr.headRefName || '')" "$EXISTING")
+
+          if [ -n "$EXISTING_TITLE" ]; then
+            NEXT=$(node scripts/release-metadata.js parse-title "$BRANCH" "$EXISTING_TITLE")
+            RELEASE_BRANCH="$EXISTING_BRANCH"
+          else
+            NEXT="$DEFAULT_NEXT"
+            RELEASE_BRANCH=$(node scripts/release-metadata.js branch "$BRANCH" "$NEXT")
+          fi
+
+          node scripts/release-metadata.js validate "$BRANCH" "$NEXT" "$NPM_VERSION"
+          TITLE=$(node scripts/release-metadata.js title "$BRANCH" "$NEXT")
+
+          echo "next_version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "release_base=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
 
       - name: Configure Git
         run: |
@@ -102,14 +106,11 @@ jobs:
           NEXT_VERSION: ${{ steps.version.outputs.next_version }}
           RELEASE_BRANCH: ${{ steps.version.outputs.branch }}
           RELEASE_BASE: ${{ steps.version.outputs.release_base }}
+          RELEASE_TITLE: ${{ steps.version.outputs.title }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if [ "$RELEASE_BASE" = "alpha" ]; then
-            TITLE="chore: alpha release v${NEXT_VERSION}"
-          else
-            TITLE="chore: release v${NEXT_VERSION}"
-          fi
+          TITLE="${RELEASE_TITLE}"
 
           # Create or reset the release branch off the latest base branch so it
           # always includes all recent commits.
@@ -120,20 +121,7 @@ jobs:
             git checkout -b "${RELEASE_BRANCH}"
           fi
 
-          # Bump version in all package.json files.
-          node -e "
-          const fs = require('fs');
-          const version = process.env.NEXT_VERSION;
-          const dirs = fs.readdirSync('packages', { withFileTypes: true })
-            .filter(d => d.isDirectory())
-            .map(d => 'packages/' + d.name + '/package.json');
-          for (const f of ['package.json', ...dirs].filter(f => fs.existsSync(f))) {
-            const pkg = JSON.parse(fs.readFileSync(f, 'utf8'));
-            if (!pkg.version) continue;
-            pkg.version = version;
-            fs.writeFileSync(f, JSON.stringify(pkg, null, '\t') + '\n');
-          }
-          "
+          node scripts/release-metadata.js sync-package-versions "${NEXT_VERSION}"
 
           git add package.json packages/*/package.json
 
@@ -199,7 +187,7 @@ jobs:
             --json number --jq '.[0].number' 2>/dev/null || echo "")
 
           if [ -z "${EXISTING}" ]; then
-            BODY=$(printf '## Release v%s\n\nThis PR bumps the version to `%s` and will trigger an npm publish when merged.' "${NEXT_VERSION}" "${NEXT_VERSION}")
+            BODY=$(node scripts/release-metadata.js body)
 
             gh pr create \
               --title "${TITLE}" \
@@ -210,3 +198,107 @@ jobs:
           else
             echo "✅ Release PR #${EXISTING} already exists; branch updated to include latest ${RELEASE_BASE} commits"
           fi
+
+  sync-release-pr-title:
+    name: Sync Release PR Title
+    runs-on: ubuntu-latest
+    concurrency:
+      group: sync-release-pr-title-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    if: |
+      github.event_name == 'pull_request' &&
+      github.repository == 'less/less.js' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        (
+          github.event.pull_request.base.ref == 'master' &&
+          startsWith(github.event.pull_request.head.ref, 'chore/release-v') &&
+          startsWith(github.event.pull_request.title, 'chore: release v')
+        ) ||
+        (
+          github.event.pull_request.base.ref == 'alpha' &&
+          startsWith(github.event.pull_request.head.ref, 'chore/alpha-release-v') &&
+          (
+            startsWith(github.event.pull_request.title, 'chore: release v') ||
+            startsWith(github.event.pull_request.title, 'chore: alpha release v')
+          )
+        )
+      )
+
+    steps:
+      - name: Checkout release PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Load trusted release metadata script
+        env:
+          RELEASE_BASE: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          git fetch origin "${RELEASE_BASE}"
+          mkdir -p .release-scripts
+          git show "origin/${RELEASE_BASE}:scripts/release-metadata.js" > .release-scripts/release-metadata.js
+
+      - name: Resolve title version
+        id: title-version
+        env:
+          RELEASE_BASE: ${{ github.event.pull_request.base.ref }}
+          RELEASE_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          PREVIOUS_VERSION=$(node -p "require('./packages/less/package.json').version")
+          VERSION=$(node .release-scripts/release-metadata.js parse-title "$RELEASE_BASE" "$RELEASE_TITLE")
+          if [ "$RELEASE_BASE" = "alpha" ]; then
+            NPM_VERSION=$(npm view less dist-tags.alpha)
+          else
+            NPM_VERSION=$(npm view less version)
+          fi
+          node .release-scripts/release-metadata.js validate-title-sync "$RELEASE_BASE" "$VERSION" "$PREVIOUS_VERSION" "$NPM_VERSION"
+          TITLE=$(node .release-scripts/release-metadata.js title "$RELEASE_BASE" "$VERSION")
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "previous_version=$PREVIOUS_VERSION" >> "$GITHUB_OUTPUT"
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync release files to title version
+        env:
+          VERSION: ${{ steps.title-version.outputs.version }}
+          PREVIOUS_VERSION: ${{ steps.title-version.outputs.previous_version }}
+          TITLE: ${{ steps.title-version.outputs.title }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          node .release-scripts/release-metadata.js sync-files "$VERSION" "$PREVIOUS_VERSION"
+          git add package.json packages/*/package.json
+          if [ -f CHANGELOG.md ]; then
+            git add CHANGELOG.md
+          fi
+
+          if git diff --cached --quiet; then
+            echo "Release files already match v${VERSION}"
+            exit 0
+          fi
+
+          git commit -m "$TITLE"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${HEAD_REF}"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -227,7 +227,7 @@ jobs:
 
     steps:
       - name: Checkout release PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -235,9 +235,9 @@ jobs:
           persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 'lts/*'
           cache: 'pnpm'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish to NPM
 on:
   # Publish when a release PR is merged:
   #   master branch: "chore: release vX.Y.Z"       PR → publishes latest
-  #   alpha branch:  "chore: alpha release vX.Y.Z"  PR → publishes alpha
+  #   alpha branch:  "chore: release vX.Y.Z-alpha.N" PR → publishes alpha
   # Both release PRs are created automatically by create-release-pr.yml.
   pull_request:
     types: [closed]
@@ -29,7 +29,10 @@ jobs:
         (github.event.pull_request.base.ref == 'master' &&
          startsWith(github.event.pull_request.title, 'chore: release v')) ||
         (github.event.pull_request.base.ref == 'alpha' &&
-         startsWith(github.event.pull_request.title, 'chore: alpha release v'))
+         (
+           startsWith(github.event.pull_request.title, 'chore: release v') ||
+           startsWith(github.event.pull_request.title, 'chore: alpha release v')
+         ))
       )
 
     steps:
@@ -53,6 +56,30 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Validate release title version
+        env:
+          RELEASE_BASE: ${{ github.event.pull_request.base.ref }}
+          RELEASE_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          TITLE_VERSION=$(node scripts/release-metadata.js parse-title "$RELEASE_BASE" "$RELEASE_TITLE")
+          PACKAGE_VERSION=$(node -p "require('./packages/less/package.json').version")
+
+          if [ "$TITLE_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "❌ ERROR: Release PR title requests v${TITLE_VERSION}, but package.json contains v${PACKAGE_VERSION}"
+            echo "   Edit the release PR title and wait for the release-file sync check to update the branch before merging."
+            exit 1
+          fi
+
+          if [ "$RELEASE_BASE" = "alpha" ]; then
+            NPM_VERSION=$(npm view less dist-tags.alpha)
+          else
+            NPM_VERSION=$(npm view less version)
+          fi
+
+          node scripts/release-metadata.js validate "$RELEASE_BASE" "$TITLE_VERSION" "$NPM_VERSION"
+          echo "✅ Release title, package.json, and npm version checks agree on v${TITLE_VERSION}"
 
       - name: Run node tests (ESM + CJS)
         run: pnpm run test:node

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"changelog": "github-changes -o less -r less.js -a --only-pulls --use-commit-body -m \"(YYYY-MM-DD)\"",
 		"test": "cd packages/less && npm test",
 		"test:node": "cd packages/less && npm run test:node",
+		"test:release": "node scripts/test-release-automation.js",
 		"postinstall": "npx only-allow pnpm"
 	},
 	"author": "Alexis Sellier <self@cloudhead.net>",

--- a/scripts/release-metadata.js
+++ b/scripts/release-metadata.js
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const semver = require('semver');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+const PACKAGES_DIR = path.join(ROOT_DIR, 'packages');
+const RELEASE_TITLE_PREFIX = 'chore: release v';
+const LEGACY_ALPHA_RELEASE_TITLE_PREFIX = 'chore: alpha release v';
+
+function isAlphaBase(base) {
+  return base === 'alpha';
+}
+
+function releaseTitle(base, version) {
+  validateVersionForBase(base, version);
+  return `${RELEASE_TITLE_PREFIX}${version}`;
+}
+
+function releaseBranch(base, version) {
+  validateVersionForBase(base, version);
+  return isAlphaBase(base) ? `chore/alpha-release-v${version}` : `chore/release-v${version}`;
+}
+
+function releaseBody() {
+  return 'Merging this PR publishes the version named in the PR title.';
+}
+
+function parseReleaseTitle(base, title) {
+  if (typeof title !== 'string') {
+    throw new Error('Release title must be a string');
+  }
+
+  let version = null;
+  if (title.startsWith(RELEASE_TITLE_PREFIX)) {
+    version = title.slice(RELEASE_TITLE_PREFIX.length).trim();
+  } else if (isAlphaBase(base) && title.startsWith(LEGACY_ALPHA_RELEASE_TITLE_PREFIX)) {
+    version = title.slice(LEGACY_ALPHA_RELEASE_TITLE_PREFIX.length).trim();
+  }
+
+  if (!version) {
+    throw new Error(
+      isAlphaBase(base)
+        ? `Release title must start with "${RELEASE_TITLE_PREFIX}" or "${LEGACY_ALPHA_RELEASE_TITLE_PREFIX}"`
+        : `Release title must start with "${RELEASE_TITLE_PREFIX}"`,
+    );
+  }
+
+  validateVersionForBase(base, version);
+  return version;
+}
+
+function validateVersionForBase(base, version) {
+  const normalized = semver.valid(version);
+  if (!normalized || normalized !== version) {
+    throw new Error(`Invalid semver version: ${version}`);
+  }
+
+  const parsed = semver.parse(version);
+  const prerelease = parsed.prerelease;
+  if (isAlphaBase(base)) {
+    if (
+      prerelease.length !== 2 ||
+      prerelease[0] !== 'alpha' ||
+      typeof prerelease[1] !== 'number'
+    ) {
+      throw new Error(`Alpha releases must use X.Y.Z-alpha.N, got: ${version}`);
+    }
+  } else if (base === 'master') {
+    if (prerelease.length > 0) {
+      throw new Error(`Master releases must not use a prerelease version, got: ${version}`);
+    }
+  } else {
+    throw new Error(`Release base must be "master" or "alpha", got: ${base}`);
+  }
+}
+
+function validateAgainstNpm(base, version, npmVersion) {
+  validateVersionForBase(base, version);
+  if (!npmVersion) return;
+  if (!semver.valid(npmVersion)) {
+    throw new Error(`Invalid npm version: ${npmVersion}`);
+  }
+  if (!semver.gt(version, npmVersion)) {
+    const tag = isAlphaBase(base) ? 'alpha' : 'latest';
+    throw new Error(`Release version ${version} must be greater than npm ${tag} version ${npmVersion}`);
+  }
+}
+
+function validateTitleSync(base, version, previousVersion, npmVersion) {
+  validateAgainstNpm(base, version, npmVersion);
+
+  if (!semver.valid(previousVersion)) {
+    throw new Error(`Invalid previous package version: ${previousVersion}`);
+  }
+  if (semver.lt(version, previousVersion)) {
+    throw new Error(`Release title version ${version} must not be lower than current branch version ${previousVersion}`);
+  }
+}
+
+function nextVersion(base, currentVersion, npmVersion) {
+  if (!semver.valid(currentVersion)) {
+    throw new Error(`Invalid current package version: ${currentVersion}`);
+  }
+
+  if (isAlphaBase(base)) {
+    const baseVersion = npmVersion && semver.valid(npmVersion) && semver.gt(npmVersion, currentVersion)
+      ? npmVersion
+      : currentVersion;
+    const match = baseVersion.match(/^(\d+\.\d+\.\d+)-alpha\.(\d+)$/);
+    if (match) {
+      return `${match[1]}-alpha.${parseInt(match[2], 10) + 1}`;
+    }
+    const parsed = semver.parse(baseVersion);
+    return `${parsed.major + 1}.0.0-alpha.1`;
+  }
+
+  if (npmVersion && semver.valid(npmVersion) && semver.gt(currentVersion, npmVersion)) {
+    return currentVersion;
+  }
+  return semver.inc(npmVersion || currentVersion, 'patch');
+}
+
+function packageFiles() {
+  const files = [path.join(ROOT_DIR, 'package.json')];
+  const packageDirs = fs.readdirSync(PACKAGES_DIR, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => path.join(PACKAGES_DIR, dirent.name, 'package.json'));
+  return [...files, ...packageDirs].filter(file => fs.existsSync(file));
+}
+
+function syncPackageVersions(version) {
+  validateVersionForBase(version.includes('-alpha.') ? 'alpha' : 'master', version);
+  for (const file of packageFiles()) {
+    const pkg = JSON.parse(fs.readFileSync(file, 'utf8'));
+    if (!pkg.version) continue;
+    pkg.version = version;
+    fs.writeFileSync(file, JSON.stringify(pkg, null, '\t') + '\n');
+  }
+}
+
+function replaceChangelogVersion(content, version, previousVersion) {
+  const heading = content.match(/^(### v)(\d+\.\d+\.\d+(?:-alpha\.\d+)?)( \(\d{4}-\d{2}-\d{2}\))$/m);
+  if (!heading || heading[2] !== previousVersion) {
+    return { changed: false, content };
+  }
+
+  return {
+    changed: true,
+    content: content.slice(0, heading.index) +
+      `${heading[1]}${version}${heading[3]}` +
+      content.slice(heading.index + heading[0].length),
+  };
+}
+
+function currentDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function insertChangelogVersion(content, version, date = currentDate()) {
+  const heading = `### v${version} (${date})`;
+  const firstReleaseHeading = content.match(/^### v\d+\.\d+\.\d+(?:-alpha\.\d+)? \(\d{4}-\d{2}-\d{2}\)$/m);
+
+  if (firstReleaseHeading) {
+    return content.slice(0, firstReleaseHeading.index) +
+      `${heading}\n\n` +
+      content.slice(firstReleaseHeading.index);
+  }
+
+  const firstLineEnd = content.indexOf('\n');
+  if (firstLineEnd === -1) {
+    return `${content}\n\n${heading}\n`;
+  }
+
+  return content.slice(0, firstLineEnd + 1) +
+    `\n${heading}\n` +
+    content.slice(firstLineEnd + 1);
+}
+
+function changelogUpdateForContent(content, version, previousVersion, date) {
+  if (version === previousVersion) {
+    return { status: 'unchanged', content };
+  }
+
+  const heading = content.match(/^(### v)(\d+\.\d+\.\d+(?:-alpha\.\d+)?)( \(\d{4}-\d{2}-\d{2}\))$/m);
+  if (!heading) {
+    return { status: 'inserted', content: insertChangelogVersion(content, version, date) };
+  }
+  if (heading[2] === version) {
+    return { status: 'unchanged', content };
+  }
+
+  const { changed, content: updated } = replaceChangelogVersion(content, version, previousVersion);
+  if (!changed) {
+    return { status: 'inserted', content: insertChangelogVersion(content, version, date) };
+  }
+
+  return { status: 'updated', content: updated };
+}
+
+function readChangelogUpdate(version, previousVersion) {
+  const changelog = path.join(ROOT_DIR, 'CHANGELOG.md');
+  if (!fs.existsSync(changelog)) return { path: changelog, status: 'missing' };
+
+  const original = fs.readFileSync(changelog, 'utf8');
+  return { path: changelog, ...changelogUpdateForContent(original, version, previousVersion) };
+}
+
+function syncChangelogVersion(version, previousVersion) {
+  const update = readChangelogUpdate(version, previousVersion);
+  if (update.status !== 'updated' && update.status !== 'inserted') return false;
+
+  fs.writeFileSync(update.path, update.content);
+  return true;
+}
+
+function syncFiles(version, previousVersion) {
+  const changelogUpdate = readChangelogUpdate(version, previousVersion);
+
+  syncPackageVersions(version);
+  if (changelogUpdate.status === 'updated' || changelogUpdate.status === 'inserted') {
+    fs.writeFileSync(changelogUpdate.path, changelogUpdate.content);
+  }
+
+  return true;
+}
+
+function usage() {
+  console.error(`Usage:
+  node scripts/release-metadata.js title <base> <version>
+  node scripts/release-metadata.js branch <base> <version>
+  node scripts/release-metadata.js body
+  node scripts/release-metadata.js parse-title <base> <title>
+  node scripts/release-metadata.js validate <base> <version> [npmVersion]
+  node scripts/release-metadata.js validate-title-sync <base> <version> <previousVersion> [npmVersion]
+  node scripts/release-metadata.js next-version <base> <currentVersion> [npmVersion]
+  node scripts/release-metadata.js sync-package-versions <version>
+  node scripts/release-metadata.js sync-files <version> <previousVersion>`);
+}
+
+function main(argv = process.argv.slice(2)) {
+  const [command, ...args] = argv;
+  try {
+    if (command === 'title') {
+      process.stdout.write(releaseTitle(args[0], args[1]));
+    } else if (command === 'branch') {
+      process.stdout.write(releaseBranch(args[0], args[1]));
+    } else if (command === 'body') {
+      process.stdout.write(releaseBody());
+    } else if (command === 'parse-title') {
+      process.stdout.write(parseReleaseTitle(args[0], args.slice(1).join(' ')));
+    } else if (command === 'validate') {
+      validateAgainstNpm(args[0], args[1], args[2] || '');
+    } else if (command === 'validate-title-sync') {
+      validateTitleSync(args[0], args[1], args[2], args[3] || '');
+    } else if (command === 'next-version') {
+      process.stdout.write(nextVersion(args[0], args[1], args[2] || ''));
+    } else if (command === 'sync-package-versions') {
+      syncPackageVersions(args[0]);
+    } else if (command === 'sync-files') {
+      syncFiles(args[0], args[1]);
+    } else {
+      usage();
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  LEGACY_ALPHA_RELEASE_TITLE_PREFIX,
+  RELEASE_TITLE_PREFIX,
+  changelogUpdateForContent,
+  insertChangelogVersion,
+  nextVersion,
+  parseReleaseTitle,
+  readChangelogUpdate,
+  replaceChangelogVersion,
+  releaseBody,
+  releaseBranch,
+  releaseTitle,
+  syncFiles,
+  syncChangelogVersion,
+  syncPackageVersions,
+  validateAgainstNpm,
+  validateTitleSync,
+  validateVersionForBase,
+};

--- a/scripts/test-release-automation.js
+++ b/scripts/test-release-automation.js
@@ -1,0 +1,1037 @@
+#!/usr/bin/env node
+/**
+ * Release-automation test suite
+ *
+ * Tests four components of the release flow without requiring a live
+ * GitHub token or npm credentials:
+ *
+ *   1. publish.yml `if:` expression
+ *      - master release PR merged → publish
+ *      - alpha release PR merged  → publish (alpha tag)
+ *      - other PRs / direct pushes → skip
+ *
+ *   2. create-release-pr.yml `if:` expression
+ *      - normal merges to master or alpha → trigger
+ *      - release PR merges (both flavours) → skip (loop guard)
+ *
+ *   3. Alpha version increment logic (from create-release-pr.yml)
+ *      - Works for any X.Y.Z-alpha.N regardless of major version
+ *      - Double-digit rollover (alpha.9 → alpha.10)
+ *      - Non-alpha package.json on alpha branch → bump major, start alpha.1
+ *
+ *   4. bump-and-publish.js behaviour (subprocess, DRY_RUN=true)
+ *      - master path: uses package.json version as-is, no commit, no branch push
+ *      - master path: rejects when package.json version ≤ npm latest version
+ *      - alpha path:  uses package.json version as-is, no commit, no branch push
+ *      - alpha path:  rejects when package.json alpha version lacks '-alpha.'
+ *
+ *   5. create-release-pr no-op safety (isolated temp git repo)
+ *      - when a version bump produces changes → a commit is created
+ *      - when no version changes are needed  → exits cleanly with no commit
+ *
+ * Run:
+ *   node scripts/test-release-automation.js
+ *
+ * Uses only Node.js built-ins.  semver is resolved from the workspace
+ * node_modules (present after `pnpm install`).  In sandboxes where pnpm
+ * install hasn't run, install it manually:
+ *   npm install --prefix /tmp/test-deps semver
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs     = require('fs');
+const os     = require('os');
+const path   = require('path');
+const { spawnSync, execSync } = require('child_process');
+const releaseMetadata = require('./release-metadata');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+// ---------------------------------------------------------------------------
+// Resolve semver — works both after `pnpm install` and in a bare sandbox
+// ---------------------------------------------------------------------------
+
+function resolveSemverPath() {
+  const candidates = [
+    path.join(ROOT_DIR, 'node_modules', 'semver'),
+    '/tmp/test-deps/node_modules/semver',
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+const SEMVER_PATH = resolveSemverPath();
+
+// ---------------------------------------------------------------------------
+// Tiny test harness (no external dependencies)
+// ---------------------------------------------------------------------------
+
+let passed = 0;
+let failed = 0;
+const failures = [];
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✅ ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  ❌ ${name}`);
+    console.error(`     ${err.message}`);
+    failures.push({ name, message: err.message });
+    failed++;
+  }
+}
+
+function section(title) {
+  console.log(`\n── ${title}`);
+}
+
+// ---------------------------------------------------------------------------
+// Workflow condition helpers
+//
+// These replicate the job-level `if:` expressions from the YAML files
+// verbatim in JavaScript so the tests are authoritative.
+// ---------------------------------------------------------------------------
+
+/**
+ * publish.yml `if:` condition:
+ *
+ *   github.repository == 'less/less.js' &&
+ *   github.event.pull_request.merged == true &&
+ *   (
+ *     (github.event.pull_request.base.ref == 'master' &&
+ *      startsWith(github.event.pull_request.title, 'chore: release v')) ||
+ *     (github.event.pull_request.base.ref == 'alpha' &&
+ *      startsWith(github.event.pull_request.title, 'chore: alpha release v'))
+ *   )
+ */
+function publishShouldRun({ repo, prMerged, prBaseRef, prTitle }) {
+  if (repo !== 'less/less.js') return false;
+  if (!prMerged) return false;
+
+  const isMasterRelease =
+    prBaseRef === 'master' &&
+    typeof prTitle === 'string' &&
+    prTitle.startsWith(releaseMetadata.RELEASE_TITLE_PREFIX);
+
+  const isAlphaRelease =
+    prBaseRef === 'alpha' &&
+    typeof prTitle === 'string' &&
+    (
+      prTitle.startsWith(releaseMetadata.RELEASE_TITLE_PREFIX) ||
+      prTitle.startsWith(releaseMetadata.LEGACY_ALPHA_RELEASE_TITLE_PREFIX)
+    );
+
+  return isMasterRelease || isAlphaRelease;
+}
+
+/**
+ * create-release-pr.yml `if:` condition:
+ *
+ *   github.repository == 'less/less.js' &&
+ *   !contains(github.event.head_commit.message, 'chore: release v') &&
+ *   !contains(github.event.head_commit.message, 'chore: alpha release v') &&
+ *   !contains(github.event.head_commit.message, '/release-v') &&
+ *   !contains(github.event.head_commit.message, '/alpha-release-v')
+ */
+function createReleasePRShouldRun({ repo, commitMessage }) {
+  if (repo !== 'less/less.js') return false;
+  if (commitMessage.includes('chore: release v')) return false;
+  if (commitMessage.includes('chore: alpha release v')) return false;
+  if (commitMessage.includes('/release-v')) return false;
+  if (commitMessage.includes('/alpha-release-v')) return false;
+  return true;
+}
+
+/**
+ * Alpha version increment — mirrors the inline Node script in
+ * create-release-pr.yml "Determine next version" step for the alpha branch.
+ *
+ *   X.Y.Z-alpha.N  →  X.Y.Z-alpha.(N+1)
+ *   X.Y.Z          →  (X+1).0.0-alpha.1   (no alpha suffix yet)
+ */
+function nextAlphaVersion(current, npmVersion) {
+  return releaseMetadata.nextVersion('alpha', current, npmVersion);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: temporary git repo
+// ---------------------------------------------------------------------------
+
+function makeFakeRepo({ packageVersion }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'less-release-test-'));
+
+  // root package.json (private monorepo root)
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: '@less/root', private: true, version: packageVersion }, null, '\t') + '\n',
+  );
+
+  // packages/less/package.json (the publishable package)
+  const pkgDir = path.join(dir, 'packages', 'less');
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: 'less', version: packageVersion }, null, '\t') + '\n',
+  );
+
+  // Minimal git repo
+  execSync('git init -b master', { cwd: dir, stdio: 'ignore' });
+  execSync('git config user.email "test@test.com"', { cwd: dir, stdio: 'ignore' });
+  execSync('git config user.name "Test"', { cwd: dir, stdio: 'ignore' });
+  execSync('git add .', { cwd: dir, stdio: 'ignore' });
+  execSync('git commit -m "initial"', { cwd: dir, stdio: 'ignore' });
+  const remoteDir = `${dir}-origin.git`;
+  execSync(`git init --bare ${JSON.stringify(remoteDir)}`, { stdio: 'ignore' });
+  execSync(`git remote add origin ${JSON.stringify(remoteDir)}`, { cwd: dir, stdio: 'ignore' });
+
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// Run bump-and-publish.js in a fake repo
+//
+// Strategy: copy the script into the temp repo with ROOT_DIR patched so it
+// reads/writes from the temp dir.  semver is resolved via NODE_PATH.
+// ---------------------------------------------------------------------------
+
+function runBumpAndPublish(fakeRoot, extraEnv = {}) {
+  const scriptsDir = path.join(fakeRoot, 'scripts');
+  fs.mkdirSync(scriptsDir, { recursive: true });
+
+  // Read the production script and patch the ROOT_DIR line.
+  let src = fs.readFileSync(path.join(ROOT_DIR, 'scripts', 'bump-and-publish.js'), 'utf8');
+
+  // Remove shebang so Node can require() it without SyntaxError
+  src = src.replace(/^#!.*\n/, '');
+
+  // Override ROOT_DIR to point at fakeRoot
+  src = src.replace(
+    /const ROOT_DIR\s*=\s*path\.resolve\(__dirname,\s*'\.\.'\s*\);/,
+    `const ROOT_DIR = ${JSON.stringify(fakeRoot)};`,
+  );
+
+  // Redirect require('semver') to the resolved absolute path so the patched
+  // script works even when run from an isolated temp directory that has no
+  // node_modules of its own.
+  if (SEMVER_PATH) {
+    src = src.replace(
+      /require\('semver'\)/g,
+      `require(${JSON.stringify(SEMVER_PATH)})`,
+    );
+  }
+
+  const patchedScript = path.join(scriptsDir, '_bap_patched.cjs');
+  fs.writeFileSync(patchedScript, src);
+
+  const result = spawnSync('node', [patchedScript], {
+    cwd: fakeRoot,
+    env: {
+      ...process.env,
+      ...extraEnv,
+    },
+    encoding: 'utf8',
+  });
+
+  // Clean up patched script; ENOENT is fine if it was never written
+  try { fs.unlinkSync(patchedScript); } catch (e) { if (e.code !== 'ENOENT') throw e; }
+
+  return {
+    exitCode: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Run the core shell logic from create-release-pr.yml in an isolated repo.
+//
+// We run everything up to (but not including) `git push` and `gh pr create`
+// so we don't need network access.  The critical behaviour under test is
+// whether a commit is created when there are (or aren't) version changes.
+// ---------------------------------------------------------------------------
+
+function runCreateReleasePRStep({ repoDir, nextVersion, releaseBranch }) {
+  // Stub `gh` binary so any calls are recorded but do nothing
+  const binDir = path.join(repoDir, '.test-bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  const ghLog = path.join(repoDir, 'gh-calls.log');
+  fs.writeFileSync(path.join(binDir, 'gh'), `#!/bin/sh\necho "$@" >> "${ghLog}"\n`);
+  fs.chmodSync(path.join(binDir, 'gh'), 0o755);
+
+  const initialHead = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf8' }).trim();
+
+  const script = `
+set -euo pipefail
+NEXT_VERSION=${JSON.stringify(nextVersion)}
+RELEASE_BRANCH=${JSON.stringify(releaseBranch)}
+TITLE="chore: release v\${NEXT_VERSION}"
+
+git checkout -b "\${RELEASE_BRANCH}"
+
+node -e "
+  const fs = require('fs');
+  const version = process.env.NEXT_VERSION;
+  const dirs = fs.readdirSync('packages', { withFileTypes: true })
+    .filter(d => d.isDirectory())
+    .map(d => 'packages/' + d.name + '/package.json');
+  for (const f of ['package.json', ...dirs].filter(f => fs.existsSync(f))) {
+    const pkg = JSON.parse(fs.readFileSync(f, 'utf8'));
+    if (!pkg.version) continue;
+    pkg.version = version;
+    fs.writeFileSync(f, JSON.stringify(pkg, null, '\\t') + '\\n');
+  }
+"
+
+git add package.json packages/*/package.json
+COMMITTED=false
+if git diff --cached --quiet; then
+  echo "STATUS:NO_CHANGES"
+else
+  git commit -m "\${TITLE}"
+  COMMITTED=true
+fi
+echo "STATUS:COMMITTED=\${COMMITTED}"
+`;
+
+  const result = spawnSync('bash', ['-c', script], {
+    cwd: repoDir,
+    env: {
+      ...process.env,
+      NEXT_VERSION: nextVersion,
+      GH_TOKEN: 'fake-token',
+      PATH: `${binDir}:${process.env.PATH}`,
+    },
+    encoding: 'utf8',
+  });
+
+  const finalHead = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf8' }).trim();
+  const ghCalls = fs.existsSync(ghLog) ? fs.readFileSync(ghLog, 'utf8').trim() : '';
+
+  return {
+    exitCode: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+    initialHead,
+    finalHead,
+    newCommitCreated: finalHead !== initialHead,
+    ghCalls,
+  };
+}
+
+// ============================================================================
+// TEST SUITE
+// ============================================================================
+
+// ----------------------------------------------------------------------------
+// Section 1 — publish.yml trigger conditions
+// ----------------------------------------------------------------------------
+
+section('1. publish.yml — workflow trigger conditions');
+
+test('master release PR merged → SHOULD publish', () => {
+  assert.strictEqual(
+    publishShouldRun({
+      repo: 'less/less.js',
+      prMerged: true,
+      prBaseRef: 'master',
+      prTitle: 'chore: release v4.6.4',
+    }),
+    true,
+  );
+});
+
+test('alpha release PR merged → SHOULD publish (alpha tag)', () => {
+  assert.strictEqual(
+    publishShouldRun({
+      repo: 'less/less.js',
+      prMerged: true,
+      prBaseRef: 'alpha',
+      prTitle: 'chore: release v5.0.0-alpha.2',
+    }),
+    true,
+  );
+});
+
+test('legacy alpha release PR title merged → SHOULD publish (alpha tag)', () => {
+  assert.strictEqual(
+    publishShouldRun({
+      repo: 'less/less.js',
+      prMerged: true,
+      prBaseRef: 'alpha',
+      prTitle: 'chore: alpha release v5.0.0-alpha.2',
+    }),
+    true,
+  );
+});
+
+test('non-release PR merged into master → should NOT publish', () => {
+  assert.strictEqual(
+    publishShouldRun({
+      repo: 'less/less.js',
+      prMerged: true,
+      prBaseRef: 'master',
+      prTitle: 'fix: some bug fix',
+    }),
+    false,
+  );
+});
+
+test('non-release PR merged into alpha → should NOT publish', () => {
+  assert.strictEqual(
+    publishShouldRun({
+      repo: 'less/less.js',
+      prMerged: true,
+      prBaseRef: 'alpha',
+      prTitle: 'feat: add something for next major',
+    }),
+    false,
+  );
+});
+
+test('release PR closed but NOT merged → should NOT publish', () => {
+  assert.strictEqual(
+    publishShouldRun({
+      repo: 'less/less.js',
+      prMerged: false,
+      prBaseRef: 'master',
+      prTitle: 'chore: release v4.6.4',
+    }),
+    false,
+  );
+});
+
+test('alpha release PR title used against master base → should NOT publish', () => {
+  // Wrong convention: "chore: alpha release v" into master should not trigger
+  assert.strictEqual(
+    publishShouldRun({
+      repo: 'less/less.js',
+      prMerged: true,
+      prBaseRef: 'master',
+      prTitle: 'chore: alpha release v5.0.0-alpha.1',
+    }),
+    false,
+  );
+});
+
+test('alpha-looking canonical title against master base → trigger, then validation rejects', () => {
+  assert.strictEqual(
+    publishShouldRun({
+      repo: 'less/less.js',
+      prMerged: true,
+      prBaseRef: 'master',
+      prTitle: 'chore: release v5.0.0-alpha.1',
+    }),
+    true,
+  );
+  assert.throws(
+    () => releaseMetadata.parseReleaseTitle('master', 'chore: release v5.0.0-alpha.1'),
+    /Master releases must not use a prerelease version/,
+  );
+});
+
+test('wrong repository → should NOT publish', () => {
+  assert.strictEqual(
+    publishShouldRun({
+      repo: 'fork/less.js',
+      prMerged: true,
+      prBaseRef: 'master',
+      prTitle: 'chore: release v4.6.4',
+    }),
+    false,
+  );
+});
+
+// ----------------------------------------------------------------------------
+// Section 1b — release title metadata
+// ----------------------------------------------------------------------------
+
+section('1b. release title metadata — title as version source');
+
+test('master title parses the requested release version', () => {
+  assert.strictEqual(
+    releaseMetadata.parseReleaseTitle('master', 'chore: release v4.9.0'),
+    '4.9.0',
+  );
+});
+
+test('alpha title uses the same canonical title shape', () => {
+  assert.strictEqual(
+    releaseMetadata.releaseTitle('alpha', '5.0.0-alpha.3'),
+    'chore: release v5.0.0-alpha.3',
+  );
+  assert.strictEqual(
+    releaseMetadata.parseReleaseTitle('alpha', 'chore: release v5.0.0-alpha.3'),
+    '5.0.0-alpha.3',
+  );
+});
+
+test('legacy alpha title remains accepted for existing PRs', () => {
+  assert.strictEqual(
+    releaseMetadata.parseReleaseTitle('alpha', 'chore: alpha release v5.0.0-alpha.3'),
+    '5.0.0-alpha.3',
+  );
+});
+
+test('master release title rejects alpha prerelease versions', () => {
+  assert.throws(
+    () => releaseMetadata.parseReleaseTitle('master', 'chore: release v5.0.0-alpha.3'),
+    /Master releases must not use a prerelease version/,
+  );
+});
+
+test('master release title rejects legacy alpha prefix', () => {
+  assert.throws(
+    () => releaseMetadata.parseReleaseTitle('master', 'chore: alpha release v5.0.0'),
+    /Release title must start with "chore: release v"/,
+  );
+});
+
+test('alpha release title rejects non-alpha versions', () => {
+  assert.throws(
+    () => releaseMetadata.parseReleaseTitle('alpha', 'chore: release v5.0.0'),
+    /Alpha releases must use X\.Y\.Z-alpha\.N/,
+  );
+});
+
+test('release body does not repeat the version', () => {
+  assert.ok(!releaseMetadata.releaseBody().includes('4.9.0'));
+  assert.ok(releaseMetadata.releaseBody().includes('PR title'));
+});
+
+test('npm latest check rejects a master title version that is already published', () => {
+  assert.throws(
+    () => releaseMetadata.validateAgainstNpm('master', '4.9.0', '4.9.0'),
+    /must be greater than npm latest version/,
+  );
+});
+
+test('npm alpha check rejects an alpha title version that is already published', () => {
+  assert.throws(
+    () => releaseMetadata.validateAgainstNpm('alpha', '5.0.0-alpha.3', '5.0.0-alpha.3'),
+    /must be greater than npm alpha version/,
+  );
+});
+
+test('title sync rejects versions lower than the release branch package version', () => {
+  assert.throws(
+    () => releaseMetadata.validateTitleSync('master', '4.8.0', '4.9.0', '4.7.0'),
+    /must not be lower than current branch version/,
+  );
+});
+
+test('title sync allows versions equal to the release branch package version', () => {
+  assert.doesNotThrow(
+    () => releaseMetadata.validateTitleSync('master', '4.9.0', '4.9.0', '4.8.0'),
+  );
+});
+
+test('changelog title sync updates the matching current release heading only', () => {
+  const changelog = [
+    '# Changelog',
+    '',
+    '### v4.8.1 (2026-07-26)',
+    '',
+    '#### Changes',
+    '',
+    '- something',
+    '',
+    '### v4.8.0 (2026-07-25)',
+    '',
+  ].join('\n');
+
+  const result = releaseMetadata.replaceChangelogVersion(changelog, '4.9.0', '4.8.1');
+  assert.strictEqual(result.changed, true);
+  assert.ok(result.content.includes('### v4.9.0 (2026-07-26)'));
+  assert.ok(result.content.includes('### v4.8.0 (2026-07-25)'));
+});
+
+test('changelog title sync inserts a current heading when only history exists', () => {
+  const changelog = [
+    '# Changelog',
+    '',
+    '### v4.8.0 (2026-07-25)',
+    '',
+    '#### Changes',
+    '',
+    '- older change',
+    '',
+  ].join('\n');
+
+  const result = releaseMetadata.changelogUpdateForContent(changelog, '4.9.0', '4.8.1', '2026-07-26');
+  assert.strictEqual(result.status, 'inserted');
+  assert.ok(result.content.includes('### v4.9.0 (2026-07-26)\n\n### v4.8.0 (2026-07-25)'));
+  assert.ok(result.content.includes('- older change'));
+});
+
+test('changelog title sync inserts a heading when no dated release heading exists', () => {
+  const changelog = [
+    '# Changelog',
+    '',
+    'Unreleased notes without a dated release heading.',
+    '',
+  ].join('\n');
+
+  const result = releaseMetadata.changelogUpdateForContent(changelog, '4.9.0', '4.8.1', '2026-07-26');
+  assert.strictEqual(result.status, 'inserted');
+  assert.ok(result.content.includes('# Changelog\n\n### v4.9.0 (2026-07-26)\n'));
+  assert.ok(result.content.includes('Unreleased notes without a dated release heading.'));
+});
+
+test('changelog title sync is idempotent when the heading already matches the title', () => {
+  const changelog = [
+    '# Changelog',
+    '',
+    '### v4.9.0 (2026-07-26)',
+    '',
+    '#### Changes',
+    '',
+    '- something',
+    '',
+    '### v4.8.0 (2026-07-25)',
+    '',
+  ].join('\n');
+
+  const result = releaseMetadata.changelogUpdateForContent(changelog, '4.9.0', '4.8.1');
+  assert.strictEqual(result.status, 'unchanged');
+  assert.strictEqual(result.content, changelog);
+});
+
+// ----------------------------------------------------------------------------
+// Section 2 — create-release-pr.yml trigger conditions
+// ----------------------------------------------------------------------------
+
+section('2. create-release-pr.yml — workflow trigger conditions');
+
+test('normal merge to master → SHOULD trigger', () => {
+  assert.strictEqual(
+    createReleasePRShouldRun({ repo: 'less/less.js', commitMessage: 'fix: correct color parsing' }),
+    true,
+  );
+});
+
+test('normal merge to alpha → SHOULD trigger', () => {
+  assert.strictEqual(
+    createReleasePRShouldRun({ repo: 'less/less.js', commitMessage: 'feat: new feature for next major' }),
+    true,
+  );
+});
+
+test('master release PR merge → should NOT trigger (loop guard)', () => {
+  assert.strictEqual(
+    createReleasePRShouldRun({ repo: 'less/less.js', commitMessage: 'chore: release v4.6.4' }),
+    false,
+  );
+});
+
+test('alpha release PR merge → should NOT trigger (loop guard)', () => {
+  assert.strictEqual(
+    createReleasePRShouldRun({ repo: 'less/less.js', commitMessage: 'chore: alpha release v5.0.0-alpha.2' }),
+    false,
+  );
+});
+
+test('release branch ref in commit message → should NOT trigger (loop guard for master)', () => {
+  assert.strictEqual(
+    createReleasePRShouldRun({
+      repo: 'less/less.js',
+      commitMessage: 'Merge chore/release-v4.6.4 into master',
+    }),
+    false,
+  );
+});
+
+test('alpha release branch ref in commit message → should NOT trigger (loop guard for alpha)', () => {
+  assert.strictEqual(
+    createReleasePRShouldRun({
+      repo: 'less/less.js',
+      commitMessage: 'Merge chore/alpha-release-v5.0.0-alpha.2 into alpha',
+    }),
+    false,
+  );
+});
+
+test('wrong repository → should NOT trigger', () => {
+  assert.strictEqual(
+    createReleasePRShouldRun({ repo: 'fork/less.js', commitMessage: 'fix: something' }),
+    false,
+  );
+});
+
+// ----------------------------------------------------------------------------
+// Section 3 — Alpha version increment logic (from create-release-pr.yml)
+//
+// These are pure-logic tests of the nextAlphaVersion() helper, which mirrors
+// the inline Node script in the "Determine next version" step of the workflow.
+// This directly answers: "does this work for 5.x alphas as well?"
+// ----------------------------------------------------------------------------
+
+section('3. create-release-pr.yml — alpha version increment logic');
+
+test('4.x: 4.6.3-alpha.1 → 4.6.3-alpha.2', () => {
+  assert.strictEqual(nextAlphaVersion('4.6.3-alpha.1'), '4.6.3-alpha.2');
+});
+
+test('5.x: 5.0.0-alpha.1 → 5.0.0-alpha.2  (answers the original question)', () => {
+  assert.strictEqual(nextAlphaVersion('5.0.0-alpha.1'), '5.0.0-alpha.2');
+});
+
+test('5.x: 5.0.0-alpha.3 → 5.0.0-alpha.4  (preserves major, not 4.x)', () => {
+  assert.strictEqual(nextAlphaVersion('5.0.0-alpha.3'), '5.0.0-alpha.4');
+});
+
+test('5.x minor/patch: 5.1.2-alpha.7 → 5.1.2-alpha.8', () => {
+  assert.strictEqual(nextAlphaVersion('5.1.2-alpha.7'), '5.1.2-alpha.8');
+});
+
+test('double-digit rollover: 5.0.0-alpha.9 → 5.0.0-alpha.10  (integer, not string comparison)', () => {
+  assert.strictEqual(nextAlphaVersion('5.0.0-alpha.9'), '5.0.0-alpha.10');
+});
+
+test('npm alpha ahead of package.json: 5.0.0-alpha.1 with npm alpha.4 → 5.0.0-alpha.5', () => {
+  assert.strictEqual(nextAlphaVersion('5.0.0-alpha.1', '5.0.0-alpha.4'), '5.0.0-alpha.5');
+});
+
+test('non-alpha version on alpha branch: 4.6.3 → 5.0.0-alpha.1  (bumps major, starts fresh)', () => {
+  assert.strictEqual(nextAlphaVersion('4.6.3'), '5.0.0-alpha.1');
+});
+
+test('non-alpha 5.x version: 5.0.0 → 6.0.0-alpha.1', () => {
+  assert.strictEqual(nextAlphaVersion('5.0.0'), '6.0.0-alpha.1');
+});
+
+// ----------------------------------------------------------------------------
+// Section 4 — bump-and-publish.js master path
+// ----------------------------------------------------------------------------
+
+section('4. bump-and-publish.js — master path (DRY_RUN=true)');
+
+// A version clearly higher than any real npm publish so validation passes
+const MASTER_TEST_VERSION = '999.0.0';
+
+test('master: uses package.json version as-is (no auto-increment)', () => {
+  const fakeDir = makeFakeRepo({ packageVersion: MASTER_TEST_VERSION });
+  try {
+    const { exitCode, stdout, stderr } = runBumpAndPublish(fakeDir, {
+      GITHUB_REF_NAME: 'master',
+      DRY_RUN: 'true',
+    });
+    assert.strictEqual(exitCode, 0, `Expected exit 0.\nSTDOUT: ${stdout}\nSTDERR: ${stderr}`);
+    assert.ok(
+      stdout.includes(MASTER_TEST_VERSION),
+      `Expected version ${MASTER_TEST_VERSION} in output.\nSTDOUT: ${stdout}`,
+    );
+    assert.ok(
+      stdout.includes('no auto-increment on master') || stdout.includes('Using package.json version'),
+      `Expected "no auto-increment" message.\nSTDOUT: ${stdout}`,
+    );
+  } finally {
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+test('master: no commit step (version bump is skipped)', () => {
+  const fakeDir = makeFakeRepo({ packageVersion: MASTER_TEST_VERSION });
+  try {
+    const { stdout, stderr } = runBumpAndPublish(fakeDir, {
+      GITHUB_REF_NAME: 'master',
+      DRY_RUN: 'true',
+    });
+    assert.ok(
+      !stdout.includes('[DRY RUN] Would commit'),
+      `Expected no commit step on master path.\nSTDOUT: ${stdout}\nSTDERR: ${stderr}`,
+    );
+  } finally {
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+test('master: no branch push step', () => {
+  const fakeDir = makeFakeRepo({ packageVersion: MASTER_TEST_VERSION });
+  try {
+    const { stdout, stderr } = runBumpAndPublish(fakeDir, {
+      GITHUB_REF_NAME: 'master',
+      DRY_RUN: 'true',
+    });
+    assert.ok(
+      !stdout.includes('Would push to: origin master'),
+      `Expected no branch push on master path.\nSTDOUT: ${stdout}\nSTDERR: ${stderr}`,
+    );
+  } finally {
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+test('master: rejects when package.json version ≤ npm published version', () => {
+  // 0.0.1 is well below the real npm "less" version, so validation should fail
+  const fakeDir = makeFakeRepo({ packageVersion: '0.0.1' });
+  try {
+    const { exitCode, stdout, stderr } = runBumpAndPublish(fakeDir, {
+      GITHUB_REF_NAME: 'master',
+      DRY_RUN: 'true',
+    });
+    assert.notStrictEqual(exitCode, 0, `Expected non-zero exit.\nSTDOUT: ${stdout}\nSTDERR: ${stderr}`);
+    const combined = stdout + stderr;
+    assert.ok(
+      combined.includes('must be greater than NPM version') || combined.includes('ERROR'),
+      `Expected error message about version being too low.\nCombined: ${combined}`,
+    );
+  } finally {
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+// ----------------------------------------------------------------------------
+// Section 5 — bump-and-publish.js alpha path
+//
+// Alpha now uses the same PR-based flow as master: the version bump is applied
+// by the release PR, and bump-and-publish.js uses the existing version as-is.
+// ----------------------------------------------------------------------------
+
+section('5. bump-and-publish.js — alpha path (DRY_RUN=true)');
+
+test('alpha: uses package.json version as-is (no auto-increment)', () => {
+  const fakeDir = makeFakeRepo({ packageVersion: '5.0.0-alpha.2' });
+  try {
+    const { exitCode, stdout, stderr } = runBumpAndPublish(fakeDir, {
+      GITHUB_REF_NAME: 'alpha',
+      DRY_RUN: 'true',
+    });
+    assert.strictEqual(exitCode, 0, `Expected exit 0.\nSTDOUT: ${stdout}\nSTDERR: ${stderr}`);
+    assert.ok(
+      stdout.includes('5.0.0-alpha.2'),
+      `Expected version 5.0.0-alpha.2 in output.\nSTDOUT: ${stdout}`,
+    );
+    assert.ok(
+      stdout.includes('no auto-increment on alpha') || stdout.includes('Using package.json version'),
+      `Expected "no auto-increment" message.\nSTDOUT: ${stdout}`,
+    );
+  } finally {
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+test('alpha: no commit step (same as master)', () => {
+  const fakeDir = makeFakeRepo({ packageVersion: '5.0.0-alpha.2' });
+  try {
+    const { stdout, stderr } = runBumpAndPublish(fakeDir, {
+      GITHUB_REF_NAME: 'alpha',
+      DRY_RUN: 'true',
+    });
+    assert.ok(
+      !stdout.includes('[DRY RUN] Would commit'),
+      `Expected no commit step on alpha path.\nSTDOUT: ${stdout}\nSTDERR: ${stderr}`,
+    );
+  } finally {
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+test('alpha: no branch push step (same as master)', () => {
+  const fakeDir = makeFakeRepo({ packageVersion: '5.0.0-alpha.2' });
+  try {
+    const { stdout, stderr } = runBumpAndPublish(fakeDir, {
+      GITHUB_REF_NAME: 'alpha',
+      DRY_RUN: 'true',
+    });
+    assert.ok(
+      !stdout.includes('Would push to: origin alpha'),
+      `Expected no branch push on alpha path.\nSTDOUT: ${stdout}\nSTDERR: ${stderr}`,
+    );
+  } finally {
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+test('alpha: publishes with "alpha" npm tag (not "latest")', () => {
+  const fakeDir = makeFakeRepo({ packageVersion: '5.0.0-alpha.2' });
+  try {
+    const { exitCode, stdout, stderr } = runBumpAndPublish(fakeDir, {
+      GITHUB_REF_NAME: 'alpha',
+      DRY_RUN: 'true',
+    });
+    assert.strictEqual(exitCode, 0, `Expected exit 0.\nSTDOUT: ${stdout}\nSTDERR: ${stderr}`);
+    assert.ok(
+      stdout.includes('tag: alpha'),
+      `Expected npm tag "alpha" in output.\nSTDOUT: ${stdout}`,
+    );
+    assert.ok(
+      !stdout.includes('tag: latest'),
+      `Expected no "latest" npm tag for alpha versions.\nSTDOUT: ${stdout}`,
+    );
+  } finally {
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+test('alpha: rejects when package.json version lacks "-alpha." suffix', () => {
+  // If somehow the alpha release PR bumped to a non-alpha version, the script
+  // must fail fast before publishing.
+  const fakeDir = makeFakeRepo({ packageVersion: '5.0.0' });
+  try {
+    const { exitCode, stdout, stderr } = runBumpAndPublish(fakeDir, {
+      GITHUB_REF_NAME: 'alpha',
+      DRY_RUN: 'true',
+    });
+    assert.notStrictEqual(exitCode, 0, `Expected non-zero exit.\nSTDOUT: ${stdout}\nSTDERR: ${stderr}`);
+    const combined = stdout + stderr;
+    assert.ok(
+      combined.includes('-alpha.') || combined.includes('ERROR'),
+      `Expected error about missing '-alpha.' suffix.\nCombined: ${combined}`,
+    );
+  } finally {
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+test('alpha: 4.x alpha version also accepted (4.6.3-alpha.2)', () => {
+  const fakeDir = makeFakeRepo({ packageVersion: '4.6.3-alpha.2' });
+  try {
+    const { exitCode, stdout, stderr } = runBumpAndPublish(fakeDir, {
+      GITHUB_REF_NAME: 'alpha',
+      DRY_RUN: 'true',
+    });
+    assert.strictEqual(exitCode, 0, `Expected exit 0.\nSTDOUT: ${stdout}\nSTDERR: ${stderr}`);
+    assert.ok(
+      stdout.includes('4.6.3-alpha.2'),
+      `Expected version 4.6.3-alpha.2 in output.\nSTDOUT: ${stdout}`,
+    );
+  } finally {
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
+});
+
+// ----------------------------------------------------------------------------
+// Section 6 — create-release-pr no-op safety
+// ----------------------------------------------------------------------------
+
+section('6. create-release-pr — no-op safety');
+
+test('version bump needed: creates a commit on the release branch', () => {
+  // Repo starts at 4.6.3; bump target is 4.6.4 → files change → commit
+  const repoDir = makeFakeRepo({ packageVersion: '4.6.3' });
+  try {
+    const res = runCreateReleasePRStep({
+      repoDir,
+      nextVersion: '4.6.4',
+      releaseBranch: 'chore/release-v4.6.4',
+    });
+    assert.strictEqual(res.exitCode, 0, `Script exited ${res.exitCode}.\nSTDOUT: ${res.stdout}\nSTDERR: ${res.stderr}`);
+    assert.ok(res.newCommitCreated, 'Expected a new commit when versions differ');
+    assert.ok(
+      res.stdout.includes('STATUS:COMMITTED=true'),
+      `Expected COMMITTED=true status.\nSTDOUT: ${res.stdout}`,
+    );
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+test('no version bump needed: exits cleanly, no new commit, no gh calls', () => {
+  // Repo starts at 4.6.4 (target version) → no diff → no commit
+  const repoDir = makeFakeRepo({ packageVersion: '4.6.4' });
+  try {
+    const res = runCreateReleasePRStep({
+      repoDir,
+      nextVersion: '4.6.4',
+      releaseBranch: 'chore/release-v4.6.4',
+    });
+    assert.strictEqual(res.exitCode, 0, `Script exited ${res.exitCode}.\nSTDOUT: ${res.stdout}\nSTDERR: ${res.stderr}`);
+    assert.ok(!res.newCommitCreated, 'Expected NO new commit when version is already at target');
+    assert.ok(
+      res.stdout.includes('STATUS:NO_CHANGES'),
+      `Expected NO_CHANGES status.\nSTDOUT: ${res.stdout}`,
+    );
+    assert.strictEqual(
+      res.ghCalls, '',
+      `Expected no gh commands to be invoked.\ngh calls log: ${res.ghCalls}`,
+    );
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+test('alpha version bump needed: commit created for alpha release branch', () => {
+  // Repo at 5.0.0-alpha.1; bump target is 5.0.0-alpha.2 → diff → commit
+  const repoDir = makeFakeRepo({ packageVersion: '5.0.0-alpha.1' });
+  try {
+    const res = runCreateReleasePRStep({
+      repoDir,
+      nextVersion: '5.0.0-alpha.2',
+      releaseBranch: 'chore/alpha-release-v5.0.0-alpha.2',
+    });
+    assert.strictEqual(res.exitCode, 0, `Script exited ${res.exitCode}.\nSTDOUT: ${res.stdout}\nSTDERR: ${res.stderr}`);
+    assert.ok(res.newCommitCreated, 'Expected a new commit for alpha version bump');
+    assert.ok(
+      res.stdout.includes('STATUS:COMMITTED=true'),
+      `Expected COMMITTED=true status.\nSTDOUT: ${res.stdout}`,
+    );
+  } finally {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+  }
+});
+
+// ----------------------------------------------------------------------------
+// Section 7 — pnpm version / lockfile compatibility
+//
+// Guards against the recurring breakage where a contributor regenerates
+// pnpm-lock.yaml with a newer pnpm but forgets to update the "packageManager"
+// field in package.json.  When the two are out of sync, pnpm/action-setup@v4
+// installs the (stale) version from packageManager, which then rejects the
+// lockfile with ERR_PNPM_NO_LOCKFILE and the entire workflow fails.
+//
+// Compatibility rule (based on pnpm changelog):
+//   lockfileVersion 6.x  →  generated by pnpm 6/7/8 (pnpm <9 cannot read v9)
+//   lockfileVersion 9.x  →  generated by pnpm 9+; pnpm 8 treats it as absent
+// ----------------------------------------------------------------------------
+
+section('7. pnpm version / lockfile compatibility');
+
+test('packageManager in package.json is compatible with pnpm-lock.yaml lockfileVersion', () => {
+  const rootPkg = JSON.parse(fs.readFileSync(path.join(ROOT_DIR, 'package.json'), 'utf8'));
+  const packageManager = rootPkg.packageManager || '';
+
+  const pmMatch = packageManager.match(/^pnpm@(\d+)\./);
+  assert.ok(
+    pmMatch,
+    `packageManager field should be "pnpm@X.Y.Z", got: "${packageManager}"`,
+  );
+  const pnpmMajor = parseInt(pmMatch[1], 10);
+
+  const lockfilePath = path.join(ROOT_DIR, 'pnpm-lock.yaml');
+  const lockfileContent = fs.readFileSync(lockfilePath, 'utf8');
+  const lockVersionMatch = lockfileContent.match(/^lockfileVersion:\s+'?(\d+)/m);
+  assert.ok(lockVersionMatch, 'Could not find lockfileVersion in pnpm-lock.yaml');
+  const lockfileMajor = parseInt(lockVersionMatch[1], 10);
+
+  // lockfileVersion 9 was introduced in pnpm 9.  pnpm 8 ignores it entirely
+  // (ERR_PNPM_NO_LOCKFILE), which is what broke create-release-pr.yml.
+  if (lockfileMajor >= 9) {
+    assert.ok(
+      pnpmMajor >= 9,
+      `pnpm-lock.yaml uses lockfileVersion ${lockVersionMatch[1]} which requires pnpm 9+, ` +
+        `but packageManager is "${packageManager}". ` +
+        `Update packageManager in package.json to match the pnpm version used to generate the lockfile.`,
+    );
+  }
+});
+
+// ============================================================================
+// Summary
+// ============================================================================
+
+console.log(`\n${'─'.repeat(60)}`);
+console.log(`Results: ${passed} passed, ${failed} failed`);
+
+if (failures.length > 0) {
+  console.error('\nFailed tests:');
+  failures.forEach(f => console.error(`  ✗ ${f.name}\n    ${f.message}`));
+  process.exit(1);
+} else {
+  console.log('All release automation tests passed! ✅');
+}


### PR DESCRIPTION
Ports the merged master release-title automation from #4483 to the alpha branch.

This keeps alpha using the PR title as the version source for release package files, changelog heading sync, publish validation, tags, and npm alpha publishing.

Alpha-specific note: the release automation test fixture now creates an empty local origin so alpha's existing remote tag idempotency check can run in dry-run tests.