### PR TITLE
fix: prevent reparsing escape() results

### DIFF
--- a/packages/less/lib/less/functions/string.js
+++ b/packages/less/lib/less/functions/string.js
@@ -7,9 +7,12 @@ export default {
         return new Quoted('"', str instanceof JavaScript ? str.evaluated : str.value, true);
     },
     escape: function (str) {
-        return new Anonymous(
-            encodeURI(str.value).replace(/=/g, '%3D').replace(/:/g, '%3A').replace(/#/g, '%23').replace(/;/g, '%3B')
-                .replace(/\(/g, '%28').replace(/\)/g, '%29'));
+        const escapedValue = encodeURI(str.value).replace(/=/g, '%3D').replace(/:/g, '%3A').replace(/#/g, '%23').replace(/;/g, '%3B')
+            .replace(/\(/g, '%28').replace(/\)/g, '%29');
+        const escaped = new Anonymous(escapedValue);
+        // Percent escapes are literal CSS, not Less source.
+        escaped._preventReparse = escapedValue.includes('%');
+        return escaped;
     },
     replace: function (string, pattern, replacement, flags) {
         let result = string.value;

--- a/packages/less/lib/less/tree/anonymous.js
+++ b/packages/less/lib/less/tree/anonymous.js
@@ -20,13 +20,17 @@ class Anonymous extends Node {
         this._fileInfo = currentFileInfo;
         this.mapLines = mapLines;
         this.rulesetLike = (typeof rulesetLike === 'undefined') ? false : rulesetLike;
+        /** @type {boolean} */
+        this._preventReparse = false;
         this.allowRoot = true;
         this.copyVisibilityInfo(visibilityInfo);
     }
 
     /** @returns {Anonymous} */
     eval() {
-        return new Anonymous(/** @type {string | null} */ (this.value), this._index, this._fileInfo, this.mapLines, this.rulesetLike, this.visibilityInfo());
+        const anonymous = new Anonymous(/** @type {string | null} */ (this.value), this._index, this._fileInfo, this.mapLines, this.rulesetLike, this.visibilityInfo());
+        anonymous._preventReparse = this._preventReparse;
+        return anonymous;
     }
 
     /**

--- a/packages/less/lib/less/tree/ruleset.js
+++ b/packages/less/lib/less/tree/ruleset.js
@@ -426,7 +426,9 @@ class Ruleset extends Node {
         const self = this;
         /** @param {Declaration} decl */
         function transformDeclaration(decl) {
-            if (decl.value instanceof Anonymous && !/** @type {Declaration & { parsed?: boolean }} */ (decl).parsed) {
+            if (decl.value instanceof Anonymous &&
+                !decl.value._preventReparse &&
+                !/** @type {Declaration & { parsed?: boolean }} */ (decl).parsed) {
                 if (typeof decl.value.value === 'string') {
                     new (/** @type {new (...args: [EvalContext, object, FileInfo, number]) => { parseNode: Function }} */ (/** @type {unknown} */ (Parser)))(/** @type {{ context: EvalContext, importManager: object }} */ (/** @type {Ruleset} */ (this).parse).context, /** @type {{ context: EvalContext, importManager: object }} */ (/** @type {Ruleset} */ (this).parse).importManager, decl.fileInfo(), decl.value.getIndex()).parseNode(
                         decl.value.value,

--- a/packages/test-data/tests-unit/functions/functions.css
+++ b/packages/test-data/tests-unit/functions/functions.css
@@ -8,6 +8,8 @@
 }
 #built-in {
   escaped: -Some::weird(#thing, y);
+  escaped-direct: a%20b%28c%29%3Dd%3Ae%23f%3Bg;
+  escaped-svg-literal: url("data:image/svg+xml,%3Csvg%20fill%3D%22red%22%3E%3C/svg%3E");
   lighten: #ffcccc;
   lighten-relative: #ff6666;
   darken: #330000;

--- a/packages/test-data/tests-unit/functions/functions.less
+++ b/packages/test-data/tests-unit/functions/functions.less
@@ -11,7 +11,10 @@
 
 #built-in {
   @r: 32;
+  @escaped-svg-literal: escape('<svg fill="red"></svg>');
   escaped: e("-Some::weird(#thing, y)");
+  escaped-direct: escape('a b(c)=d:e#f;g');
+  escaped-svg-literal: url("data:image/svg+xml,@{escaped-svg-literal}");
   lighten: lighten(#ff0000, 40%);
   lighten-relative: lighten(#ff0000, 40%, relative);
   darken: darken(#ff0000, 40%);


### PR DESCRIPTION
**What**:

- Mark `escape()` results that contain percent escapes as literal CSS so lazy
  declaration lookup does not parse their encoded output as Less source.
- Preserve that marker when `Anonymous` nodes are evaluated.
- Add regression coverage for direct unquoted output and literal SVG data URL
  interpolation.

**Why**:

When an `escape()` result is stored in a variable, `Ruleset.parseValue()`
treats the evaluated `Anonymous` value as unparsed source. Percent escapes such
as `%3C` are then lexed as Less and raise `Invalid % without number`.

Keeping the existing `Anonymous` node and carrying a no-reparse marker only
when encoding emits `%` fixes affected variable references while leaving
unencoded values on the existing lazy-parse path. This preserves
`escape()`'s observable node type, spacing, and `url()` rootpath behavior.

Fixes #3314.

**Checklist**:

- [x] Documentation — N/A
- [x] Added/updated unit tests
- [x] Code complete

Validation:

- `pnpm test` — 208 runs passed
- `pnpm --filter less typecheck`
- `pnpm --filter less exec eslint --no-ignore lib/less/functions/string.js lib/less/tree/anonymous.js lib/less/tree/ruleset.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of escaped strings so percent-encoded characters remain literal CSS values.
  - Fixed escaped SVG data URI processing to prevent unintended reparsing or alteration.
  - Preserved escaped values correctly when expressions are evaluated and reused.

- **Tests**
  - Added coverage for direct escaping and escaped SVG data URI literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->