### PR TITLE
fix: parse scientific notation in numbers

### DIFF
--- a/packages/less/lib/less/parser/parser.js
+++ b/packages/less/lib/less/parser/parser.js
@@ -906,14 +906,17 @@ const Parser = function Parser(context, imports, fileInfo, currentIndex) {
                 //
                 // A Dimension, that is, a number and a unit
                 //
-                //     0.5em 95%
+                //     0.5em 95% 1e3px
+                //
+                // The exponent needs at least one digit, so a unit that merely starts
+                // with `e` (`1em`, `2ex`) is still read as a unit.
                 //
                 dimension: function () {
                     if (parserInput.peekNotNumeric()) {
                         return;
                     }
 
-                    const value = parserInput.$re(/^([+-]?\d*\.?\d+)(%|[a-z_]+)?/i);
+                    const value = parserInput.$re(/^([+-]?\d*\.?\d+(?:e[+-]?\d+)?)(%|[a-z_]+)?/i);
                     if (value) {
                         return new(tree.Dimension)(value[1], value[2]);
                     }

--- a/packages/test-data/tests-unit/numbers-exponent/numbers-exponent.css
+++ b/packages/test-data/tests-unit/numbers-exponent/numbers-exponent.css
@@ -1,0 +1,39 @@
+.literals {
+  width: 1e3px;
+  height: 1E3px;
+  margin: 200px;
+  padding: 0.005px;
+  top: 1e0px;
+  line-height: 1e3;
+  opacity: 0.1;
+  flex-basis: 150%;
+  transform: scale(0.01);
+  min-width: calc(1000px + 1px);
+}
+.units-starting-with-e {
+  width: 1em;
+  height: 2ex;
+  margin: 1e2em;
+  padding: 0.5em;
+  top: 3e2ex;
+}
+.arithmetic {
+  width: 1001px;
+  height: 2px;
+  margin: 25px;
+}
+.variables {
+  width: 100px;
+  height: 101px;
+}
+.mixin-argument {
+  padding: 100px;
+}
+.guard {
+  color: red;
+}
+@media (min-width: 1000px) {
+  .media-query {
+    color: red;
+  }
+}

--- a/packages/test-data/tests-unit/numbers-exponent/numbers-exponent.less
+++ b/packages/test-data/tests-unit/numbers-exponent/numbers-exponent.less
@@ -1,0 +1,50 @@
+.literals {
+  width: 1e3px;
+  height: 1E3px;
+  margin: 2e+2px;
+  padding: .5e-2px;
+  top: 1e0px;
+  line-height: 1e3;
+  opacity: 1e-1;
+  flex-basis: 1.5e2%;
+  transform: scale(1e-2);
+  min-width: calc(1e3px + 1px);
+}
+
+// a unit may start with `e`, so an exponent is only read when digits follow it
+.units-starting-with-e {
+  width: 1em;
+  height: 2ex;
+  margin: 1e2em;
+  padding: 5e-1em;
+  top: 3e2ex;
+}
+
+.arithmetic {
+  width: (1e3px + 1px);
+  height: (2e-1 * 10px);
+  margin: (1e2px / 4);
+}
+
+@size: 1e2px;
+.variables {
+  width: @size;
+  height: (@size + 1px);
+}
+
+.mixin(@value) {
+  padding: @value;
+}
+.mixin-argument {
+  .mixin(1e2px);
+}
+
+.guard when (1e2px > 50px) {
+  color: red;
+}
+
+@media (min-width: 1e3px) {
+  .media-query {
+    color: red;
+  }
+}


### PR DESCRIPTION
**What**: Teach the `dimension` parser rule about the exponent part of a CSS number, so `1e3px`, `.5e-2px` and `2e+2px` compile to the value they mean.

**Why**: CSS numbers may carry an exponent — [css-syntax-3 §4.3.12](https://drafts.csswg.org/css-syntax/#consume-a-number) defines `<number-token>` as `[+-]? (\d+ | \d*\.\d+) ([eE][+-]?\d+)?`, and a `<dimension-token>` is that number followed by an ident. The rule at `packages/less/lib/less/parser/parser.js` matched the number without the exponent:

```js
/^([+-]?\d*\.?\d+)(%|[a-z_]+)?/i
```

so in `.5e-2px` it took `.5` as the number and `e` as the unit, leaving `-2px` to be parsed as a separate term. The two then combine, and the result is neither an error nor the right value:

| input | 4.8.1 | this PR | Chrome / Safari |
|---|---|---|---|
| `padding: .5e-2px` | `-1.5e` | `0.005px` | `0.005px` |
| `margin: 2e+2px` | `4e` | `200px` | `200px` |
| `padding: 5e-1em` | `4e` | `0.5em` | `0.5em` |
| `opacity: 1e-1` | `0e` | `0.1` | `0.1` |
| `transform: scale(1e-2)` | `scale(-1e)` | `scale(0.01)` | `scale(0.01)` |
| `flex-basis: 1.5e2%` | `1.5e 2%` | `150%` | `150%` |
| `min-width: calc(1e3px + 1px)` | `calc(1e 3px + 1px)` | `calc(1000px + 1px)` | — |
| `width: (1e3px + 1px)` | `ParseError: Expected ')'` | `1001px` | — |

The last column is `el.style.width` after assigning each value, read back from Chromium 133 and WebKit 18.2.

A bare literal declaration such as `width: 1e3px;` happens to survive today because it takes the verbatim fast path for simple values and is never parsed as a dimension. That protection disappears as soon as the value meets any Less feature, which is what makes this easy to miss:

```less
@size: 1e2px;
.a { width: @size; }        // 4.8.1: width: 1e 2px
.b when (1e2px > 50px) { }  // 4.8.1: ParseError: expected condition
@media (min-width: 1e3px) { } // 4.8.1: @media (min-width: 1e 3px)
```

Exponents mostly reach Less from generated or minified CSS rather than from hand-written source, so the failure tends to show up as a rule the browser drops, or as a value that is quietly wrong, well away from the code that produced it.

The fix appends an optional `(?:e[+-]?\d+)?` to the number group. The exponent needs at least one digit after `e`, so a unit that merely begins with `e` still parses as a unit: `1em` and `2ex` are unchanged. `1e2em` now means 100em, which it did not before. No unit contains a digit, and `[a-z_]+` never matched one, so nothing that used to parse as a unit stops doing so.

**Tests**: new fixture `packages/test-data/tests-unit/numbers-exponent`, covering literal declarations, units that start with `e`, arithmetic in parens, variables, a mixin argument, a guard and an `@media` query. Every expected value in the `.css` was checked against the two browsers above. Reverting `parser.js` and keeping the fixture makes `grunt test:node` exit 6 with `ERROR: Expected ')'`.

`pnpm test` passes on this branch: `All Passed 211 run`, including the headless-Chrome browser suite. `pnpm --filter less typecheck` is clean. `pnpm lint` reports one pre-existing parse error in `benchmark/benchmark-runner.js` that is present on `master` and is unrelated to this change (#4453 appears to cover it).

**Checklist**:

- [x] Documentation — N/A, no documented behaviour changes
- [x] Added/updated unit tests
- [x] Code complete


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for scientific-notation dimension values, such as `1e3px`.
  * Preserved correct handling of units beginning with “e,” including `em` and `ex`.

* **Bug Fixes**
  * Improved exponent-number parsing across calculations, variables, mixins, guarded rules, and media queries.

* **Tests**
  * Added comprehensive coverage for exponent notation and related unit-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->