### PR TITLE
fix #2868: preserve detached ruleset definition scope

### DIFF
--- a/packages/less/lib/less/tree/declaration.js
+++ b/packages/less/lib/less/tree/declaration.js
@@ -41,6 +41,7 @@ class Declaration extends Node {
         super();
         this.name = name;
         this.value = (value instanceof Node) ? value : new Value([value ? new Anonymous(value) : null]);
+        this.evalFirst = /** @type {{ evalFirst?: boolean }} */ (this.value).evalFirst;
         this.important = important ? ` ${important.trim()}` : '';
         /** @type {string | undefined} */
         this.merge = merge;

--- a/packages/test-data/tests-unit/detached-rulesets/detached-rulesets.css
+++ b/packages/test-data/tests-unit/detached-rulesets/detached-rulesets.css
@@ -74,3 +74,9 @@ html.lt-ie9 header {
   direct: works;
   named: works;
 }
+#trigger-test {
+  width: 2px;
+}
+.detached-ruleset-scope {
+  variable: global;
+}

--- a/packages/test-data/tests-unit/detached-rulesets/detached-rulesets.less
+++ b/packages/test-data/tests-unit/detached-rulesets/detached-rulesets.less
@@ -111,4 +111,15 @@ header {
   .mixin-definition({direct: works;}; @b: {named: works;});
 }
 
-
+@trigger-value: 2px;
+#trigger-test {
+    width: @trigger-value;
+}
+@variable: global;
+@detached-ruleset: {
+    variable: @variable; 
+};
+.detached-ruleset-scope {
+    @detached-ruleset();
+    @variable: if-you-see-this-in-the-output-its-a-bug; // variables defined in caller should be ignored
+}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!
Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).
Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).
If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request
Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fix: #2868 

<!-- Why are these changes necessary? -->

**Why**:

The `DetachedRuleset` class has its `evalFirst` property set to `true`, but when it gets passed to the `Declaration` class in the parser, the `Declaration` class doesn't read and pass down the `evalFirst` property.
As a result, the `evalFirst` property is ignored.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Added/updated unit tests
- [x] Code complete

<!-- feel free to add additional comments -->
I added a unit test according to the [contributiing guildelines](https://github.com/less/less.js/blob/master/CONTRIBUTING.md)
Link to the original doc: https://lesscss.org/features/#detached-rulesets-feature-scoping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved evaluation of declarations when values require early evaluation.
  * Fixed detached ruleset scoping so captured global variables are resolved consistently, even when callers define variables with the same name.
  * Corrected variable-based width evaluation in detached ruleset scenarios.

* **Tests**
  * Added coverage for detached ruleset variable scoping and evaluation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->