### PR TITLE
fix(release): trigger alpha release PRs after normal merges

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -25,36 +25,58 @@ jobs:
   create-release-pr:
     name: Create or Update Release PR
     runs-on: ubuntu-latest
-    # Skip if this push is itself the merge of a release PR (prevents an
-    # infinite loop). We catch both squash-merged and regular-merged commits
-    # for both the master and alpha release PR title conventions.
+    # Skip only if this push is itself the merge of a release PR (prevents an
+    # infinite loop). Check the pushed commit subject, not historical release
+    # titles that can appear in a normal merge commit body.
     if: |
       github.event_name == 'push' &&
-      github.repository == 'less/less.js' &&
-      !contains(github.event.head_commit.message, 'chore: release v') &&
-      !contains(github.event.head_commit.message, 'chore: alpha release v') &&
-      !contains(github.event.head_commit.message, '/release-v') &&
-      !contains(github.event.head_commit.message, '/alpha-release-v')
+      github.repository == 'less/less.js'
 
     steps:
+      - name: Detect release PR merge
+        id: release-merge
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+          SUBJECT="${COMMIT_MESSAGE%%$'\n'*}"
+          IS_RELEASE_MERGE=false
+
+          case "$SUBJECT" in
+            "chore: release v"* | \
+            "chore: alpha release v"* | \
+            "Merge pull request #"*" from less/chore/release-v"* | \
+            "Merge pull request #"*" from less/chore/alpha-release-v"*)
+              IS_RELEASE_MERGE=true
+              ;;
+          esac
+
+          echo "is_release_merge=${IS_RELEASE_MERGE}" >> "$GITHUB_OUTPUT"
+          echo "commit_subject=${SUBJECT}"
+
       - name: Checkout
+        if: steps.release-merge.outputs.is_release_merge != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pnpm
+        if: steps.release-merge.outputs.is_release_merge != 'true'
         uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
+        if: steps.release-merge.outputs.is_release_merge != 'true'
         with:
           node-version: 'lts/*'
           cache: 'pnpm'
 
       - name: Install dependencies
+        if: steps.release-merge.outputs.is_release_merge != 'true'
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Determine release version
+        if: steps.release-merge.outputs.is_release_merge != 'true'
         id: version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -102,11 +124,13 @@ jobs:
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
 
       - name: Configure Git
+        if: steps.release-merge.outputs.is_release_merge != 'true'
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Create or update release branch and PR
+        if: steps.release-merge.outputs.is_release_merge != 'true'
         env:
           NEXT_VERSION: ${{ steps.version.outputs.next_version }}
           RELEASE_BRANCH: ${{ steps.version.outputs.branch }}

--- a/scripts/test-release-automation.js
+++ b/scripts/test-release-automation.js
@@ -101,8 +101,8 @@ function section(title) {
 // ---------------------------------------------------------------------------
 // Workflow condition helpers
 //
-// These replicate the job-level `if:` expressions from the YAML files
-// verbatim in JavaScript so the tests are authoritative.
+// These replicate the workflow trigger gates from the YAML files so the tests
+// are authoritative without requiring a live GitHub Actions run.
 // ---------------------------------------------------------------------------
 
 /**
@@ -141,22 +141,22 @@ function publishShouldRun({ repo, prMerged, prBaseRef, prTitle }) {
 }
 
 /**
- * create-release-pr.yml `if:` condition:
+ * create-release-pr.yml push gate:
  *
  *   github.event_name == 'push' &&
- *   github.repository == 'less/less.js' &&
- *   !contains(github.event.head_commit.message, 'chore: release v') &&
- *   !contains(github.event.head_commit.message, 'chore: alpha release v') &&
- *   !contains(github.event.head_commit.message, '/release-v') &&
- *   !contains(github.event.head_commit.message, '/alpha-release-v')
+ *   github.repository == 'less/less.js'
+ *
+ * followed by a subject-only release-merge detector. Release titles in a
+ * normal merge commit body must not suppress the next release PR.
  */
 function createReleasePRShouldRun({ repo, eventName, commitMessage }) {
   if (eventName !== 'push') return false;
   if (repo !== 'less/less.js') return false;
-  if (commitMessage.includes('chore: release v')) return false;
-  if (commitMessage.includes('chore: alpha release v')) return false;
-  if (commitMessage.includes('/release-v')) return false;
-  if (commitMessage.includes('/alpha-release-v')) return false;
+  const subject = commitMessage.split('\n', 1)[0];
+  if (subject.startsWith('chore: release v')) return false;
+  if (subject.startsWith('chore: alpha release v')) return false;
+  if (subject.includes('from less/chore/release-v')) return false;
+  if (subject.includes('from less/chore/alpha-release-v')) return false;
   return true;
 }
 
@@ -688,6 +688,38 @@ test('normal merge to alpha → SHOULD trigger', () => {
   );
 });
 
+test('normal master merge with release history in the body → SHOULD trigger', () => {
+  assert.strictEqual(
+    createReleasePRShouldRun({
+      repo: 'less/less.js',
+      eventName: 'push',
+      commitMessage: [
+        'feat: support `[...]` lookups in `@{...}` interpolation (#4488)',
+        '',
+        '* chore: release v4.8.1 (#4482)',
+        '* chore: release v4.8.0',
+      ].join('\n'),
+    }),
+    true,
+  );
+});
+
+test('normal alpha merge with release history in the body → SHOULD trigger', () => {
+  assert.strictEqual(
+    createReleasePRShouldRun({
+      repo: 'less/less.js',
+      eventName: 'push',
+      commitMessage: [
+        'Less 5 alpha.1: Jess-powered compiler preview (#4487)',
+        '',
+        '* chore: release v4.6.0 (#4415)',
+        '* chore: release v4.8.1 (#4482)',
+      ].join('\n'),
+    }),
+    true,
+  );
+});
+
 test('master release PR merge → should NOT trigger (loop guard)', () => {
   assert.strictEqual(
     createReleasePRShouldRun({ repo: 'less/less.js', eventName: 'push', commitMessage: 'chore: release v4.6.4' }),
@@ -707,7 +739,7 @@ test('release branch ref in commit message → should NOT trigger (loop guard fo
     createReleasePRShouldRun({
       repo: 'less/less.js',
       eventName: 'push',
-      commitMessage: 'Merge chore/release-v4.6.4 into master',
+      commitMessage: 'Merge pull request #123 from less/chore/release-v4.6.4',
     }),
     false,
   );
@@ -718,7 +750,7 @@ test('alpha release branch ref in commit message → should NOT trigger (loop gu
     createReleasePRShouldRun({
       repo: 'less/less.js',
       eventName: 'push',
-      commitMessage: 'Merge chore/alpha-release-v5.0.0-alpha.2 into alpha',
+      commitMessage: 'Merge pull request #124 from less/chore/alpha-release-v5.0.0-alpha.2',
     }),
     false,
   );

--- a/scripts/test-release-automation.js
+++ b/scripts/test-release-automation.js
@@ -155,8 +155,14 @@ function createReleasePRShouldRun({ repo, eventName, commitMessage }) {
   const subject = commitMessage.split('\n', 1)[0];
   if (subject.startsWith('chore: release v')) return false;
   if (subject.startsWith('chore: alpha release v')) return false;
-  if (subject.includes('from less/chore/release-v')) return false;
-  if (subject.includes('from less/chore/alpha-release-v')) return false;
+  if (
+    subject.startsWith('Merge pull request #') &&
+    subject.includes(' from less/chore/release-v')
+  ) return false;
+  if (
+    subject.startsWith('Merge pull request #') &&
+    subject.includes(' from less/chore/alpha-release-v')
+  ) return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary

- make create-release-pr skip only actual release PR merge subjects
- allow normal master/alpha PR merge commits to create/update release branches even when their body contains historical `chore: release v...` entries
- add regression coverage for normal master and alpha merges whose commit bodies include release history

## Verification

- `node scripts/test-release-automation.js`
- `git diff --check`