### PR TITLE
fix(release): pass base to title sync files

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -297,6 +297,7 @@ jobs:
 
       - name: Sync release files to title version
         env:
+          RELEASE_BASE: ${{ github.event.pull_request.base.ref }}
           VERSION: ${{ steps.title-version.outputs.version }}
           PREVIOUS_VERSION: ${{ steps.title-version.outputs.previous_version }}
           TITLE: ${{ steps.title-version.outputs.title }}
@@ -304,7 +305,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          node .release-scripts/release-metadata.js sync-files "$VERSION" "$PREVIOUS_VERSION"
+          node .release-scripts/release-metadata.js sync-files "$RELEASE_BASE" "$VERSION" "$PREVIOUS_VERSION"
           git add package.json packages/*/package.json
           if [ -f CHANGELOG.md ]; then
             git add CHANGELOG.md

--- a/scripts/test-release-automation.js
+++ b/scripts/test-release-automation.js
@@ -1079,6 +1079,14 @@ test('release title sync no-op exits without an empty commit', () => {
   const workflow = fs.readFileSync(path.join(ROOT_DIR, '.github', 'workflows', 'create-release-pr.yml'), 'utf8');
   const syncStep = workflow.slice(workflow.indexOf('      - name: Sync release files to title version'));
   assert.ok(
+    syncStep.includes('RELEASE_BASE: ${{ github.event.pull_request.base.ref }}'),
+    'Expected sync-title step to expose the release base branch',
+  );
+  assert.ok(
+    syncStep.includes('node .release-scripts/release-metadata.js sync-files "$RELEASE_BASE" "$VERSION" "$PREVIOUS_VERSION"'),
+    'Expected sync-title step to call sync-files with base, version, and previous version',
+  );
+  assert.ok(
     syncStep.includes('echo "Release files already match v${VERSION}"\n            exit 0'),
     'Expected sync-title no-op path to exit cleanly',
   );


### PR DESCRIPTION
## Summary

- pass the release base branch to `release-metadata.js sync-files` in the release-title sync job
- add regression assertions that the workflow calls `sync-files` with `<base> <version> <previousVersion>`

## Why

The auto-created alpha release PR in #4503 failed because the title-sync job called `sync-files` with only version and previous version, causing `5.0.0-alpha.1` to be interpreted as the release base.

## Verification

- `node scripts/test-release-automation.js`
- `git diff --check`