### PR TITLE
fix(release): drop behind-master gate blocking alpha publishes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,20 +113,15 @@ jobs:
       - name: Validate alpha branch requirements
         if: steps.branch-info.outputs.is_alpha == 'true'
         run: |
-          # Fetch master branch
+          # Fetch master branch (used by the alpha-base >= master version check)
           git fetch origin master:master || true
-          
-          # Check 1: Alpha branch must not be behind master
-          echo "🔍 Checking if alpha branch is up to date with master..."
-          MASTER_COMMITS=$(git rev-list --count alpha..master 2>/dev/null || echo "0")
-          
-          if [ "$MASTER_COMMITS" -gt 0 ]; then
-            echo "❌ ERROR: Alpha branch is behind master by $MASTER_COMMITS commit(s)"
-            echo "   Alpha branch must include all commits from master before publishing"
-            exit 1
-          fi
-          echo "✅ Alpha branch is up to date with master"
-          
+
+          # NOTE: The Less 5 alpha lives on a deliberately divergent branch (a
+          # Jess-powered rewrite). It does NOT carry every v4.x master hotfix, so
+          # a "alpha must contain all master commits" gate is the wrong invariant
+          # and blocked alpha publishes. The alpha-base >= master version check
+          # below is what actually prevents an alpha undercutting the 4.x latest.
+
           # Check 2: Get current version and validate it contains 'alpha'
           CURRENT_VERSION=$(node -p "require('./packages/less/package.json').version")
           echo "📦 Current version: $CURRENT_VERSION"

--- a/scripts/bump-and-publish.js
+++ b/scripts/bump-and-publish.js
@@ -317,14 +317,10 @@ function verifyAlphaRepositoryState(version) {
     );
   }
 
-  const missingMasterCommits = Number(execSync('git rev-list --count HEAD..origin/master', {
-    cwd: ROOT_DIR,
-    encoding: 'utf8'
-  }).trim());
-  if (missingMasterCommits > 0) {
-    throw new Error(`Alpha branch is behind origin/master by ${missingMasterCommits} commit(s)`);
-  }
-
+  // The Less 5 alpha branch is a deliberately divergent rewrite that does not
+  // carry every v4.x master hotfix, so we intentionally do NOT gate on the alpha
+  // branch being "behind" master. The alpha-base >= master version check below
+  // is the real guard against an alpha undercutting the published 4.x latest.
   if (!semver.valid(version) || !/-alpha\.\d+$/u.test(version)) {
     throw new Error(`Alpha release version must be X.Y.Z-alpha.N, received: ${version}`);
   }
@@ -573,26 +569,10 @@ function main() {
     if (dryRun) {
       console.log(`✅ Repository state checks are skipped in dry-run mode`);
     } else {
-      // Validation 3: Check if alpha is behind master. This intentionally uses
-      // HEAD, not a local branch named `alpha`; publish runs from the checked-out
-      // release commit.
-      try {
-        execSync('git fetch origin master', { cwd: ROOT_DIR, stdio: 'ignore' });
-        const masterCommits = execSync('git rev-list --count HEAD..origin/master', {
-          cwd: ROOT_DIR,
-          encoding: 'utf8'
-        }).trim();
-
-        if (parseInt(masterCommits, 10) > 0) {
-          console.error(`❌ ERROR: Alpha branch is behind master by ${masterCommits} commit(s)`);
-          console.error(`   Alpha branch must include all commits from master before publishing`);
-          console.error(`   Please merge master into alpha first`);
-          process.exit(1);
-        }
-        console.log(`✅ Alpha branch is up to date with master`);
-      } catch (e) {
-        console.log(`⚠️  Could not verify master sync status, continuing...`);
-      }
+      // NOTE: No "alpha must be caught up with master" gate here — the Less 5
+      // alpha is a divergent rewrite that does not carry every v4.x master
+      // hotfix. Validation 4 (alpha base >= master version) is the real guard.
+      execSync('git fetch origin master', { cwd: ROOT_DIR, stdio: 'ignore' });
 
       // Validation 4: Alpha base version must be >= master version
       try {

--- a/scripts/bump-and-publish.js
+++ b/scripts/bump-and-publish.js
@@ -572,7 +572,11 @@ function main() {
       // NOTE: No "alpha must be caught up with master" gate here — the Less 5
       // alpha is a divergent rewrite that does not carry every v4.x master
       // hotfix. Validation 4 (alpha base >= master version) is the real guard.
-      execSync('git fetch origin master', { cwd: ROOT_DIR, stdio: 'ignore' });
+      //
+      // origin/master is already fetched by verifyAlphaRepositoryState() during
+      // preflight (before the tag push), so we do NOT re-fetch here: a transient
+      // fetch failure at this point runs AFTER the release tag is pushed and
+      // would strand a tagged-but-unpublished release.
 
       // Validation 4: Alpha base version must be >= master version
       try {


### PR DESCRIPTION
## Problem

Merging the `chore: release v5.0.0-alpha.2` PR (#4512) into `alpha` did **not** publish `less@5.0.0-alpha.2` to npm. The `alpha` dist-tag is still stuck on `5.0.0-alpha.1`.

The `Publish to NPM` workflow **did** fire on the merge and **hard-failed 30s in** (run [33659518274](https://github.com/less/less.js/actions/runs/33659518274)) at the *Validate alpha branch requirements* step:

```
❌ ERROR: Alpha branch is behind master by 2 commit(s)
   Alpha branch must include all commits from master before publishing
```

Master had advanced by 2 commits (PR #4478, a v4.x fix) 13 minutes before the alpha.2 PR merged. The gate counted them and `exit 1`ed before the publish step ran.

## Root cause

The publish flow gated alpha releases on the `alpha` branch containing **every** `master` commit. That is the wrong invariant for Less 5: the alpha is a **deliberately divergent, Jess-powered rewrite** that intentionally does not carry each v4.x master hotfix. So the gate fails on essentially every alpha release where any master commit landed in between — this is recurring:

- **alpha.1** only published after a manual master catch-up (PR #4506 "chore(alpha): record master ancestry before alpha publish", merged ~28s before the successful alpha.1 publish).
- **alpha.2** got no manual catch-up, so it failed outright.

## Fix

Remove the behind-master gate in all **three** places it fired:

1. `.github/workflows/publish.yml` — *Validate alpha branch requirements* Check 1 (`git rev-list --count alpha..master`).
2. `scripts/bump-and-publish.js` `verifyAlphaRepositoryState()` — the `missingMasterCommits` throw.
3. `scripts/bump-and-publish.js` `main()` — the duplicate inline *Validation 3* (same invariant, also runs during a real publish).

**Retained everywhere:** the alpha-base `>=` master semver check (workflow Check 3 / script Validation 4). An alpha still can never publish under a stale base version and undercut the 4.x `latest` tag. The version-format and clean-worktree/exact-origin checks are also untouched.

## Verification

- `node --test scripts/bump-and-publish.test.mjs` → 10/10 pass.
- Full `pnpm run test:alpha` (typecheck, build, lessc-alpha, alpha-support/fixtures, publish-dry-run, packed-consumer proof) green via the pre-commit hook.

Fixes the alpha.2 publish failure; alpha.2 itself still needs a manual publish (separate from this automation fix).