### PR TITLE
feat(less5): dev browser bundle (dist/less-browser-dev.js)

### DIFF
--- a/packages/less/build/browser-stubs/cosmiconfig.js
+++ b/packages/less/build/browser-stubs/cosmiconfig.js
@@ -1,0 +1,29 @@
+/**
+ * Browser stub for `cosmiconfig`.
+ *
+ * `styles-config` constructs a cosmiconfig explorer at module top-level, but the
+ * search/load methods only run when a filePath is passed to the compiler. The
+ * browser build never passes one, so an inert explorer (search/load → null) is
+ * sufficient and drops the whole fs/env-paths/import-fresh/resolve-from subtree.
+ */
+
+const inertExplorer = {
+  search: () => null,
+  load: () => null,
+  clearCaches: () => {},
+  clearLoadCache: () => {},
+  clearSearchCache: () => {}
+};
+
+export function cosmiconfig() {
+  return inertExplorer;
+}
+
+export function cosmiconfigSync() {
+  return inertExplorer;
+}
+
+export const defaultLoaders = {};
+export const defaultLoadersSync = {};
+
+export default { cosmiconfig, cosmiconfigSync, defaultLoaders, defaultLoadersSync };

--- a/packages/less/build/browser-stubs/fs.js
+++ b/packages/less/build/browser-stubs/fs.js
@@ -1,0 +1,34 @@
+/**
+ * Browser stub for `fs` / `node:fs` / `fs/promises`.
+ *
+ * The single-file browser build never reads files: the entry calls
+ * renderToResult with an inline `source` and no filePath, so config discovery
+ * and the entry parse never touch fs. The ONLY way execution reaches here is an
+ * `@import` (or a file-reading function like data-uri) in the Less source —
+ * which is unsupported in the browser preview. Every method throws a clear
+ * message so that surfaces as a normal render error rather than a bundling gap.
+ */
+
+function unsupported() {
+  throw new Error(
+    'Less v5 browser preview: file access / @import is unsupported (single-file only). '
+    + 'Use the Node build (`less`) for imports and file-reading functions.'
+  );
+}
+
+// Named exports used across the jess runtime (readFile, readFileSync, etc.).
+// A Proxy returns the same throwing function for any accessed property, so we
+// don't have to enumerate the fs surface.
+const handler = {
+  get() {
+    return unsupported;
+  }
+};
+
+const fs = new Proxy({}, handler);
+
+export default fs;
+export const readFile = unsupported;
+export const readFileSync = unsupported;
+export const existsSync = unsupported;
+export const promises = new Proxy({}, handler);

--- a/packages/less/build/browser-stubs/module.js
+++ b/packages/less/build/browser-stubs/module.js
@@ -1,0 +1,22 @@
+/**
+ * Browser stub for `module` / `node:module`.
+ *
+ * `createRequire` is only used on the file/plugin-resolution path (resolving a
+ * package.json for versioning, or an `@import`ed node module). None of that runs
+ * for a single-file, no-filePath render. Return a require shim whose calls throw
+ * clearly if that path is ever reached in the browser.
+ */
+
+function unsupported() {
+  throw new Error(
+    'Less v5 browser preview: module resolution (createRequire) is unsupported (single-file only).'
+  );
+}
+
+export function createRequire() {
+  const req = () => unsupported();
+  req.resolve = () => unsupported();
+  return req;
+}
+
+export default { createRequire };

--- a/packages/less/build/browser-stubs/url.js
+++ b/packages/less/build/browser-stubs/url.js
@@ -1,0 +1,17 @@
+/**
+ * Browser stub for `node:url`'s pathToFileURL/fileURLToPath.
+ *
+ * Only reached on the file-resolution path (never for a no-filePath render).
+ * Provide inert-but-shaped helpers so any stray call degrades gracefully rather
+ * than crashing the bundle load.
+ */
+
+export function pathToFileURL(p) {
+  return { href: 'file://' + String(p) };
+}
+
+export function fileURLToPath(u) {
+  return String(u).replace(/^file:\/\//, '');
+}
+
+export default { pathToFileURL, fileURLToPath };

--- a/packages/less/build/browser-v5.mjs
+++ b/packages/less/build/browser-v5.mjs
@@ -1,0 +1,76 @@
+/**
+ * Build the single-file, browser-loadable Less v5 (jess) bundle.
+ *
+ * Produces `dist/less-browser-dev.js`: an IIFE exposing `window.lessV5` with
+ * `.render(input, options)` / `.renderString(input, options)`.
+ *
+ * Runtime parseman (the pure-JS table interpreter) IS bundled — it does the
+ * parsing. Node file/config built-ins are aliased to browser stubs because a
+ * single-file, no-filePath render never touches them (see build/browser-stubs).
+ */
+
+import * as esbuild from 'esbuild';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = resolve(here, '..');
+const stubs = join(here, 'browser-stubs');
+
+const pkg = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8'));
+
+// path-browserify is a real, browser-safe `path`. `url` is aliased to a small
+// inert stub (its helpers only fire on the file-resolution path we never hit).
+const pathBrowserify = 'path-browserify';
+
+const result = await esbuild.build({
+  entryPoints: [join(pkgRoot, 'lib/browser-v5.js')],
+  bundle: true,
+  format: 'iife',
+  globalName: 'lessV5',
+  platform: 'browser',
+  target: ['es2020'],
+  outfile: join(pkgRoot, 'dist/less-browser-dev.js'),
+  minify: process.argv.includes('--minify'),
+  sourcemap: process.argv.includes('--sourcemap'),
+  legalComments: 'none',
+  metafile: true,
+  define: {
+    __LESS_VERSION__: JSON.stringify(pkg.version),
+    // A minimal process shim; the jess runtime reads process.env.* and cwd().
+    'process.env.NODE_ENV': JSON.stringify('production'),
+    'process.env.JESS_PROFILE': 'undefined',
+    'process.env.JESS_DEBUG': 'undefined'
+  },
+  // `window.lessV5` is a live binding to the IIFE's default export.
+  footer: {
+    js: 'if (typeof window !== "undefined" && window.lessV5 && window.lessV5.default) { window.lessV5 = window.lessV5.default; }'
+  },
+  // Leading /*! …*/ marks this as the EXPERIMENTAL dev build. banner is emitted
+  // verbatim (not subject to minify/legalComments), so the notice always leads
+  // the file. Then process.cwd() and a couple of globals the jess runtime
+  // touches. Kept tiny.
+  banner: {
+    js:
+      '/*! Less v5 (alpha) browser build. For live styling in the browser, follow the Less browser guide. Compiling Less in the browser is not intended for production — compile ahead of time (Node "less") for production builds. */\n' +
+      'var process = (typeof globalThis !== "undefined" && globalThis.process) || { env: {}, cwd: function () { return "/"; }, argv: [], platform: "browser" };'
+  },
+  alias: {
+    fs: join(stubs, 'fs.js'),
+    'node:fs': join(stubs, 'fs.js'),
+    'fs/promises': join(stubs, 'fs.js'),
+    'node:fs/promises': join(stubs, 'fs.js'),
+    module: join(stubs, 'module.js'),
+    'node:module': join(stubs, 'module.js'),
+    url: join(stubs, 'url.js'),
+    'node:url': join(stubs, 'url.js'),
+    path: pathBrowserify,
+    'node:path': pathBrowserify,
+    cosmiconfig: join(stubs, 'cosmiconfig.js')
+  }
+});
+
+const outBytes = result.metafile.outputs['dist/less-browser-dev.js']?.bytes
+  ?? readFileSync(join(pkgRoot, 'dist/less-browser-dev.js')).length;
+console.log(`built dist/less-browser-dev.js — ${(outBytes / 1024 / 1024).toFixed(2)} MB (${outBytes} bytes)`);

--- a/packages/less/lib/browser-v5.js
+++ b/packages/less/lib/browser-v5.js
@@ -1,0 +1,82 @@
+/**
+ * Less.js v5 — browser build (powered by Jess).
+ *
+ * A single-file, in-browser Less→CSS compiler. It drives `@jesscss/compiler`'s
+ * `renderToResult` with an inline `source` and NO `filePath`, so the Node-only
+ * config-discovery layer (cosmiconfig/env-paths/fs) is never reached. `@import`
+ * / file access is unsupported here (see build/browser-stubs/fs.js).
+ *
+ * Bundled to an IIFE that defines `window.lessV5`.
+ *
+ * @module less/browser-v5
+ */
+
+import { Compiler } from '@jesscss/compiler';
+import { createLessOptions, mapRenderResult } from './options.js';
+
+/* Injected at build time from packages/less/package.json. */
+/* global __LESS_VERSION__ */
+const semver = typeof __LESS_VERSION__ === 'string' ? __LESS_VERSION__ : '5.0.0-alpha.0';
+const versionArray = semver.split('.').map((n) => parseInt(n, 10) || 0).slice(0, 3);
+
+/**
+ * Build a Less-4.x-shaped error from the first Jess diagnostic. No fs fallback:
+ * in the browser there is no file to re-read for the source extract.
+ * @param {import('./options.js').JessRenderResult} result
+ */
+function createRenderError(result) {
+  const diagnostic = (result?.errors || [])[0];
+  const error = new Error(diagnostic?.message || 'Less render failed');
+  error.type = diagnostic?.phase || 'Syntax';
+  error.filename = diagnostic?.filePath || 'input';
+  error.line = diagnostic?.line || 1;
+  error.column = diagnostic?.column || 1;
+  const lines = diagnostic?.lines;
+  error.extract = Array.isArray(lines) ? lines.map(String) : undefined;
+  error.jessErrors = result?.errors || [];
+  error.jessWarnings = result?.warnings || [];
+  return error;
+}
+
+/**
+ * Render Less source to a Less-4.x-style result object ({ css, warnings }).
+ * @param {string} input Less source
+ * @param {object} [options] Less-style options (math, collapseNesting, plugins)
+ * @returns {Promise<{ css: string, warnings?: unknown[] }>}
+ */
+async function render(input, options = {}) {
+  const { configOptions } = createLessOptions(options);
+  // ponytail: fresh Compiler per call — no defaultPlugins hook, so no
+  // node-modules import plugin and no @jesscss/plugin-js. Single-file preview
+  // rarely re-renders in a hot loop; a cache map is not worth the surface.
+  const compiler = new Compiler(configOptions);
+  const result = await compiler.renderToResult(
+    { source: input, language: 'less', extension: '.less' },
+    { ...configOptions, suppressWarnings: true }
+  );
+  if (result.errors?.length) {
+    throw createRenderError(result);
+  }
+  return mapRenderResult(result, options);
+}
+
+/**
+ * Render Less source and resolve to the CSS string only.
+ * @param {string} input
+ * @param {object} [options]
+ * @returns {Promise<string>}
+ */
+async function renderString(input, options = {}) {
+  const { css } = await render(input, options);
+  return css;
+}
+
+const lessV5 = {
+  version: versionArray,
+  render,
+  renderString,
+  Compiler,
+};
+
+export default lessV5;
+export { render, renderString, Compiler, versionArray as version };

--- a/packages/less/package.json
+++ b/packages/less/package.json
@@ -63,9 +63,10 @@
 		"lint:fix": "eslint '**/*.{ts,js}' --fix",
 		"typecheck": "tsc --noEmit",
 		"build": "node build/rollup.js --dist",
+		"build:browser": "node build/browser-v5.mjs --minify",
 		"benchmark": "node benchmark/benchmark-runner.cjs",
 		"benchmark:all": "node benchmark/run-and-compare.mjs",
-		"prepublishOnly": "npm run typecheck && npm run build && npm run test:lessc"
+		"prepublishOnly": "npm run typecheck && npm run build && npm run build:browser && npm run test:lessc"
 	},
 	"devDependencies": {
 		"@less/test-data": "workspace:*",
@@ -83,6 +84,7 @@
 		"chalk": "^4.1.2",
 		"cosmiconfig": "~9.0.0",
 		"cross-env": "^7.0.3",
+		"esbuild": "^0.25.0",
 		"eslint": "^7.29.0",
 		"fs-extra": "^8.1.0",
 		"glob": "~11.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
       eslint:
         specifier: ^7.29.0
         version: 7.32.0
@@ -170,7 +173,7 @@ importers:
         version: 0.11.4
       webpack:
         specifier: ^5.64.6
-        version: 5.109.0(webpack-cli@5.1.4)
+        version: 5.109.0(esbuild@0.25.12)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.109.0)
@@ -231,6 +234,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint/eslintrc@0.4.3':
     resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
@@ -1354,6 +1513,11 @@ packages:
   es-to-primitive@1.3.4:
     resolution: {integrity: sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -3302,6 +3466,84 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
   '@eslint/eslintrc@0.4.3':
     dependencies:
       ajv: 6.15.0
@@ -3809,17 +4051,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.109.0)':
     dependencies:
-      webpack: 5.109.0(webpack-cli@5.1.4)
+      webpack: 5.109.0(esbuild@0.25.12)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.109.0)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.109.0)':
     dependencies:
-      webpack: 5.109.0(webpack-cli@5.1.4)
+      webpack: 5.109.0(esbuild@0.25.12)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.109.0)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.109.0)':
     dependencies:
-      webpack: 5.109.0(webpack-cli@5.1.4)
+      webpack: 5.109.0(esbuild@0.25.12)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.109.0)
 
   '@xtuc/ieee754@1.2.0': {}
@@ -4450,6 +4692,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
 
@@ -5321,13 +5592,15 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(webpack@5.109.0):
+  minimizer-webpack-plugin@5.6.1(esbuild@0.25.12)(webpack@5.109.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.109.0(webpack-cli@5.1.4)
+      webpack: 5.109.0(esbuild@0.25.12)(webpack-cli@5.1.4)
+    optionalDependencies:
+      esbuild: 0.25.12
 
   minipass@7.1.3: {}
 
@@ -6318,7 +6591,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.109.0(webpack-cli@5.1.4)
+      webpack: 5.109.0(esbuild@0.25.12)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
   webpack-merge@5.10.0:
@@ -6331,7 +6604,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.109.0(webpack-cli@5.1.4):
+  webpack@5.109.0(esbuild@0.25.12)(webpack-cli@5.1.4):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -6347,7 +6620,7 @@ snapshots:
       events: 3.3.0
       graceful-fs: 4.2.11
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(webpack@5.109.0)
+      minimizer-webpack-plugin: 5.6.1(esbuild@0.25.12)(webpack@5.109.0)
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3


### PR DESCRIPTION
## What

Ships a single-file browser build of Less v5 (jess) as `dist/less-browser-dev.js` — an esbuild IIFE exposing global `lessV5` with `.render` / `.renderString`. A thin entry drives `@jesscss/compiler` `renderToResult` with inline source and no `filePath`, so the Node config-discovery layer never runs; Node file/config built-ins (`fs`/`module`/`url`/`cosmiconfig`) are aliased to browser stubs, `path` → `path-browserify`.

## Not an advertised production feature

Per owner decision, this is an opt-in dev file loaded only by explicit path:

- **Baked-in banner** (esbuild `banner:js`, survives minify) leads the file:
  > `/*! Less v5 (alpha) browser build. For live styling in the browser, follow the Less browser guide. Compiling Less in the browser is not intended for production — compile ahead of time (Node "less") for production builds. */`
- `package.json` **`browser` / `unpkg` / `jsdelivr` / `module`** are intentionally **not set**, and there is **no `./browser` export condition**. `less@5`'s primary surface stays Node-only.
- The file rides the existing `"dist"` `files` glob into the published tarball, so a CDN can serve it by full path.

## Publish flow builds it

`build:browser` is wired into the `less` package `prepublishOnly` (`typecheck && build && build:browser && test:lessc`), so the publish path (`bump-and-publish.js` → `npm publish` → `prepublishOnly`) produces `dist/less-browser-dev.js` before pack.

Once an alpha publishes, the file is served at:

```
https://cdn.jsdelivr.net/npm/less@<version>/dist/less-browser-dev.js
```

## Verification

- Rebased onto `alpha` @ jess `@jesscss/core@2.0.0-alpha.15`; rebuilt clean (2.70 MB).
- Browser bundle smoke-tested against alpha.15: `renderString(".a{ .b{color:red} }")` compiles to nested CSS (v5 `collapseNesting:false` default); parse errors surface.
- `dist/` is gitignored; the artifact is produced at `prepublishOnly`, not committed.
- Additive only — new browser entry + stubs + `package.json`/lockfile; the Node CLI path is unchanged.
