### PR TITLE
chore(less5): rename browser-v5 -> browser-dev

### DIFF
--- a/packages/less/build/browser-dev.mjs
+++ b/packages/less/build/browser-dev.mjs
@@ -25,7 +25,7 @@ const pkg = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8'));
 const pathBrowserify = 'path-browserify';
 
 const result = await esbuild.build({
-  entryPoints: [join(pkgRoot, 'lib/browser-v5.js')],
+  entryPoints: [join(pkgRoot, 'lib/browser-dev.js')],
   bundle: true,
   format: 'iife',
   globalName: 'lessV5',

--- a/packages/less/lib/browser-dev.js
+++ b/packages/less/lib/browser-dev.js
@@ -8,7 +8,7 @@
  *
  * Bundled to an IIFE that defines `window.lessV5`.
  *
- * @module less/browser-v5
+ * @module less/browser-dev
  */
 
 import { Compiler } from '@jesscss/compiler';

--- a/packages/less/package.json
+++ b/packages/less/package.json
@@ -63,7 +63,7 @@
 		"lint:fix": "eslint '**/*.{ts,js}' --fix",
 		"typecheck": "tsc --noEmit",
 		"build": "node build/rollup.js --dist",
-		"build:browser": "node build/browser-v5.mjs --minify",
+		"build:browser": "node build/browser-dev.mjs --minify",
 		"benchmark": "node benchmark/benchmark-runner.cjs",
 		"benchmark:all": "node benchmark/run-and-compare.mjs",
 		"prepublishOnly": "npm run typecheck && npm run build && npm run build:browser && npm run test:lessc"


### PR DESCRIPTION
Cosmetic rename. The package is entirely v5, so the `-v5` suffix carried no information and did not match the `dist/less-browser-dev.js` it builds. Renames the source ESM entry (`lib/browser-dev.js`), the esbuild script (`build/browser-dev.mjs`), and the `build:browser` reference so source → build → output all read `browser-dev`. Rebuilt output is byte-identical (2829703 bytes).