### PR TITLE
fix(less5): browser bundle exposes window.less with 4.x-compatible render

### DIFF
--- a/packages/less/build/browser-dev.mjs
+++ b/packages/less/build/browser-dev.mjs
@@ -1,8 +1,8 @@
 /**
  * Build the single-file, browser-loadable Less v5 (jess) bundle.
  *
- * Produces `dist/less-browser-dev.js`: an IIFE exposing `window.lessV5` with
- * `.render(input, options)` / `.renderString(input, options)`.
+ * Produces `dist/less-browser-dev.js`: an IIFE exposing `window.less` with the
+ * Less 4.x browser API — `less.render(input, options?, callback?)`.
  *
  * Runtime parseman (the pure-JS table interpreter) IS bundled — it does the
  * parsing. Node file/config built-ins are aliased to browser stubs because a
@@ -28,7 +28,7 @@ const result = await esbuild.build({
   entryPoints: [join(pkgRoot, 'lib/browser-dev.js')],
   bundle: true,
   format: 'iife',
-  globalName: 'lessV5',
+  globalName: 'less',
   platform: 'browser',
   target: ['es2020'],
   outfile: join(pkgRoot, 'dist/less-browser-dev.js'),
@@ -43,9 +43,9 @@ const result = await esbuild.build({
     'process.env.JESS_PROFILE': 'undefined',
     'process.env.JESS_DEBUG': 'undefined'
   },
-  // `window.lessV5` is a live binding to the IIFE's default export.
+  // Collapse `window.less` to the IIFE's default export (the render API).
   footer: {
-    js: 'if (typeof window !== "undefined" && window.lessV5 && window.lessV5.default) { window.lessV5 = window.lessV5.default; }'
+    js: 'if (typeof window !== "undefined" && window.less && window.less.default) { window.less = window.less.default; }'
   },
   // Leading /*! …*/ marks this as the EXPERIMENTAL dev build. banner is emitted
   // verbatim (not subject to minify/legalComments), so the notice always leads

--- a/packages/less/lib/browser-dev.js
+++ b/packages/less/lib/browser-dev.js
@@ -6,7 +6,9 @@
  * config-discovery layer (cosmiconfig/env-paths/fs) is never reached. `@import`
  * / file access is unsupported here (see build/browser-stubs/fs.js).
  *
- * Bundled to an IIFE that defines `window.lessV5`.
+ * Bundled to an IIFE that defines `window.less` with the same public shape as
+ * the Less 4.x browser build: `less.render(input, options?, callback?)` returns
+ * a Promise and also invokes the err-first callback when one is given.
  *
  * @module less/browser-dev
  */
@@ -39,44 +41,46 @@ function createRenderError(result) {
 }
 
 /**
- * Render Less source to a Less-4.x-style result object ({ css, warnings }).
+ * Render Less source to CSS. Mirrors the Less 4.x API: `options` and `callback`
+ * are both optional, `callback` may be passed as the second argument, and the
+ * returned Promise resolves to a `{ css, warnings }` result. When a callback is
+ * given it is invoked err-first and the Promise is still returned.
  * @param {string} input Less source
- * @param {object} [options] Less-style options (math, collapseNesting, plugins)
+ * @param {object|Function} [options] Less-style options (math, collapseNesting, plugins) — or the callback
+ * @param {Function} [callback] err-first `(error, result)` callback
  * @returns {Promise<{ css: string, warnings?: unknown[] }>}
  */
-async function render(input, options = {}) {
-  const { configOptions } = createLessOptions(options);
-  // ponytail: fresh Compiler per call — no defaultPlugins hook, so no
-  // node-modules import plugin and no @jesscss/plugin-js. Single-file preview
-  // rarely re-renders in a hot loop; a cache map is not worth the surface.
-  const compiler = new Compiler(configOptions);
-  const result = await compiler.renderToResult(
-    { source: input, language: 'less', extension: '.less' },
-    { ...configOptions, suppressWarnings: true }
-  );
-  if (result.errors?.length) {
-    throw createRenderError(result);
+function render(input, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = {};
   }
-  return mapRenderResult(result, options);
+  options = options || {};
+  const promise = (async () => {
+    const { configOptions } = createLessOptions(options);
+    // ponytail: fresh Compiler per call — no defaultPlugins hook, so no
+    // node-modules import plugin and no @jesscss/plugin-js. Single-file preview
+    // rarely re-renders in a hot loop; a cache map is not worth the surface.
+    const compiler = new Compiler(configOptions);
+    const result = await compiler.renderToResult(
+      { source: input, language: 'less', extension: '.less' },
+      { ...configOptions, suppressWarnings: true }
+    );
+    if (result.errors?.length) {
+      throw createRenderError(result);
+    }
+    return mapRenderResult(result, options);
+  })();
+  if (typeof callback === 'function') {
+    promise.then((result) => callback(null, result), (error) => callback(error));
+  }
+  return promise;
 }
 
-/**
- * Render Less source and resolve to the CSS string only.
- * @param {string} input
- * @param {object} [options]
- * @returns {Promise<string>}
- */
-async function renderString(input, options = {}) {
-  const { css } = await render(input, options);
-  return css;
-}
-
-const lessV5 = {
+const less = {
   version: versionArray,
   render,
-  renderString,
-  Compiler,
 };
 
-export default lessV5;
-export { render, renderString, Compiler, versionArray as version };
+export default less;
+export { render, versionArray as version };


### PR DESCRIPTION
The browser dev bundle named its global `window.lessV5` and made `render` Promise-only. Both were wrong for a browser build of Less — it should **be** `window.less` and match the 4.x API so existing consumers (the playground included) work unchanged.

- global `lessV5` → `less` (there is no two-scripts scenario to avoid colliding with)
- `render(input, options?, callback?)`: returns a Promise **and** invokes an err-first callback when one is given; `options` may be omitted (callback as 2nd arg)
- trimmed the public object to Less's shape `{ version, render }` (dropped the internal `Compiler` handle and the non-4.x `renderString`)

Verified in a real browser: Promise form, callback form (options omitted), promise-returned-even-with-callback, and the error path both via callback (`err.type`/`err.line`/message) and via promise rejection.