### PR TITLE
fix(less5): support unitMode; strictUnits is a deprecated alias, not unsupported

### DIFF
--- a/packages/less/bin/lessc
+++ b/packages/less/bin/lessc
@@ -17,6 +17,7 @@ let output = null;
 let silent = false;
 let quiet = false;
 let verbose = false;
+let deprecatedStrictUnits = false;
 
 const unsupportedOptions = new Map([
   ['--source-map', 'source maps are not supported'],
@@ -38,7 +39,6 @@ const unsupportedOptions = new Map([
   ['--modify-var', 'modify-var injection is not supported'],
   ['--js', 'JavaScript evaluation is not supported'],
   ['--no-js', 'JavaScript evaluation flags are not supported'],
-  ['--strict-units', 'strict unit mode is not supported'],
 ]);
 
 function stripTerminalFormatting(value) {
@@ -141,6 +141,20 @@ function parseArgs() {
       options.collapseNesting = true;
       continue;
     }
+    // Deprecated 4.x spellings (--strict-units, --strict-units=on|off, -su=on|off)
+    // alias --unit-mode=strict; the warning is emitted once the logger listener
+    // is attached so --silent/--quiet are honored. `off` is the default (loose).
+    const strictUnitsMatch = arg.match(/^(?:--strict-units|-su)(?:=(on|off))?$/);
+    if (strictUnitsMatch) {
+      if (strictUnitsMatch[1] !== 'off') options.strictUnits = true;
+      deprecatedStrictUnits = true;
+      continue;
+    }
+    const unitModeMatch = arg.match(/^--unit-mode=(.+)$/);
+    if (unitModeMatch) {
+      options.unitMode = unitModeMatch[1];
+      continue;
+    }
     const optionName = arg.includes('=') ? arg.slice(0, arg.indexOf('=')) : arg;
     if (unsupportedOptions.has(optionName)) {
       failUnsupportedOption(optionName, unsupportedOptions.get(optionName));
@@ -198,6 +212,10 @@ async function run() {
       if (!silent) console.error(renderLogMessage(msg));
     },
   });
+
+  if (deprecatedStrictUnits) {
+    less.logger.warn('lessc: --strict-units is deprecated; use --unit-mode=strict (or =loose, the default)');
+  }
 
   try {
     let result;

--- a/packages/less/lib/lessc-helper.js
+++ b/packages/less/lib/lessc-helper.js
@@ -38,6 +38,8 @@ const lesscHelper = {
     console.log('  -v, --version                Prints version number and exit.');
     console.log('  --verbose                    Be verbose.');
     console.log('  --collapse-nesting           Flatten nested rules after preserving source-order cascade.');
+    console.log('  --unit-mode=MODE             Unit handling in math: loose (default), strict, or preserve.');
+    console.log('  --strict-units               Deprecated alias for --unit-mode=strict.');
     console.log('');
     console.log('This release intentionally supports a smaller CLI surface.');
     console.log('Source maps, browser compilation, legacy plugin flags, lint-only mode, and');

--- a/packages/less/lib/options.js
+++ b/packages/less/lib/options.js
@@ -15,7 +15,6 @@ const unsupportedAlphaOptions = new Map([
   ['sourceMapFileInline', 'source maps are not supported'],
   ['globalVars', 'global variable injection is not supported'],
   ['modifyVars', 'modify-var injection is not supported'],
-  ['strictUnits', 'strict unit mode is not supported'],
   ['rootpath', 'URL rootpath rewriting is not supported'],
   ['rewriteUrls', 'URL rewriting is not supported'],
   ['urlArgs', 'URL argument rewriting is not supported'],
@@ -25,7 +24,9 @@ const unsupportedAlphaOptions = new Map([
 
 function validateAlphaOptions(options) {
   for (const [name, reason] of unsupportedAlphaOptions) {
-    if (Object.prototype.hasOwnProperty.call(options, name)) {
+    // A falsy value is the 4.x default ("off") and requests nothing, so it is
+    // a no-op here; only an actual request for the feature is unsupported.
+    if (options[name]) {
       throw new Error(`${name} is not supported: ${reason}`);
     }
   }
@@ -81,6 +82,13 @@ export function createLessOptions(options) {
     math === 2 || math === 'parens' || math === 'strict' ? 'parens' :
     'parens-division';
 
+  // `unitMode` is the option ('loose' | 'preserve' | 'strict'); `strictUnits`
+  // is its deprecated boolean alias: true → 'strict', false/undefined defers
+  // to `unitMode`. Left unset so the compiler default ('loose') applies.
+  const unitMode = opts.unitMode !== undefined ? opts.unitMode
+    : opts.strictUnits === true ? 'strict'
+    : undefined;
+
   const plugins = [lessPlugin()];
   if (!skipLessCompat) {
     plugins.push(lessCompatPlugin({ plugins: lessPlugins }));
@@ -90,6 +98,7 @@ export function createLessOptions(options) {
     compile: {
       searchPaths: opts.paths || [],
       mathMode,
+      ...(unitMode !== undefined && { unitMode }),
       plugins,
     },
     // Less v5 preserves authored nesting unless its explicit compatibility

--- a/packages/less/test/alpha-support.mjs
+++ b/packages/less/test/alpha-support.mjs
@@ -161,7 +161,6 @@ async function assertUnsupportedApiOptionsReject() {
         'rewriteUrls',
         'urlArgs',
         'javascriptEnabled',
-        'strictUnits',
         'rootpath'
     ];
     for (const option of unsupported) {
@@ -177,10 +176,31 @@ async function assertUnsupportedApiOptionsReject() {
     }
 }
 
+async function assertUnitModeSupported() {
+    const source = '.x { width: 1px + 3em; }\n';
+    // `unitMode` is the option; `strictUnits` is its deprecated boolean alias.
+    for (const options of [{ unitMode: 'strict' }, { strictUnits: true }]) {
+        await assert.rejects(
+            less.render(source, options),
+            error => {
+                assert.match(error.message, /unit/i);
+                return true;
+            },
+            `${JSON.stringify(options)} must reject incompatible units`
+        );
+    }
+    // Loose is the default; the deprecated `strictUnits: false` is a no-op, not an error.
+    for (const options of [{}, { unitMode: 'loose' }, { strictUnits: false }]) {
+        const result = await less.render(source, options);
+        assert.match(result.css, /width: 4px/, `${JSON.stringify(options)} must render loosely`);
+    }
+}
+
 await assertSupportedCompileSurface();
 await assertUnsupportedSyntaxHasPreciseDiagnostic();
 await assertBareStructuralAtRuleVariablesReject();
 await assertUnsupportedApiOptionsReject();
+await assertUnitModeSupported();
 await assertFixtureRendersByteIdentical('at-rule-variable-interpolation/at-rule-variable-interpolation');
 await assertFixtureRendersByteIdentical('color-functions/modern');
 await assertFixtureRendersByteIdentical('math-css-vars/math-css-vars');


### PR DESCRIPTION
`strictUnits` was listed as unsupported, but Jess fully supports strict unit handling via `unitMode` (`loose` | `strict` | `preserve`), with `strictUnits` as its documented `@deprecated` alias (`core/src/types/config.ts:178`). The block just never wired it through — surfaced by the playground, which passes `strictUnits: false` and got rejected.

**API** — accept `unitMode` (the option) and `strictUnits` (deprecated alias: `true` → `strict`, `false`/undefined defers to `unitMode`); mapped into `compile.unitMode` alongside `mathMode`, left unset so the compiler default (`loose`) applies.

**CLI** — add `--unit-mode=MODE`; accept the 4.x spellings `--strict-units`, `--strict-units=on|off`, `-su=on|off` as a deprecated alias that prints a deprecation warning through the logger (so `--silent`/`--quiet` are honored). `--help` lists both.

**Unsupported-option check** — only a *truthy* value requests a feature. A falsy value is the 4.x default ("off") and is now a no-op instead of throwing, so consumers passing explicit defaults (`strictUnits: false`, `compress: false`, `sourceMap: false`) work; truthy requests still reject (the existing must-reject test passes `true` and is unchanged in spirit).

**Tests** — dropped `strictUnits` from the must-reject list (it was pinning a mis-classification, not a requirement); added a positive test that `unitMode: "strict"` / `strictUnits: true` reject `1px + 3em` and `{}` / `loose` / `strictUnits: false` render `4px`.

Verified: `alpha-support.mjs` and `lessc-alpha.mjs` green; CLI checked for every spelling (`on`/bare reject with `eval/invalid-unit-arithmetic`, `off` renders, warning printed).