### PR TITLE
feat(less5): keep incompatible-unit math as calc(); deprecate strictUnits for unitMode

### DIFF
--- a/packages/less/bin/lessc
+++ b/packages/less/bin/lessc
@@ -214,7 +214,7 @@ async function run() {
   });
 
   if (deprecatedStrictUnits) {
-    less.logger.warn('lessc: --strict-units is deprecated; use --unit-mode=strict (or =loose, the default)');
+    less.logger.warn('lessc: --strict-units is deprecated; use --unit-mode=strict (the default is preserve; --unit-mode=loose restores Less 4.x guessing)');
   }
 
   try {

--- a/packages/less/bin/lessc
+++ b/packages/less/bin/lessc
@@ -17,7 +17,6 @@ let output = null;
 let silent = false;
 let quiet = false;
 let verbose = false;
-let deprecatedStrictUnits = false;
 
 const unsupportedOptions = new Map([
   ['--source-map', 'source maps are not supported'],
@@ -142,12 +141,11 @@ function parseArgs() {
       continue;
     }
     // Deprecated 4.x spellings (--strict-units, --strict-units=on|off, -su=on|off)
-    // alias --unit-mode=strict; the warning is emitted once the logger listener
-    // is attached so --silent/--quiet are honored. `off` is the default (loose).
+    // set the deprecated `strictUnits` boolean; `createLessOptions` maps it to
+    // `unitMode` and warns during compile, after the logger listener is attached.
     const strictUnitsMatch = arg.match(/^(?:--strict-units|-su)(?:=(on|off))?$/);
     if (strictUnitsMatch) {
-      if (strictUnitsMatch[1] !== 'off') options.strictUnits = true;
-      deprecatedStrictUnits = true;
+      options.strictUnits = strictUnitsMatch[1] !== 'off';
       continue;
     }
     const unitModeMatch = arg.match(/^--unit-mode=(.+)$/);
@@ -212,10 +210,6 @@ async function run() {
       if (!silent) console.error(renderLogMessage(msg));
     },
   });
-
-  if (deprecatedStrictUnits) {
-    less.logger.warn('lessc: --strict-units is deprecated; use --unit-mode=strict (the default is preserve; --unit-mode=loose restores Less 4.x guessing)');
-  }
 
   try {
     let result;

--- a/packages/less/lib/lessc-helper.js
+++ b/packages/less/lib/lessc-helper.js
@@ -38,7 +38,7 @@ const lesscHelper = {
     console.log('  -v, --version                Prints version number and exit.');
     console.log('  --verbose                    Be verbose.');
     console.log('  --collapse-nesting           Flatten nested rules after preserving source-order cascade.');
-    console.log('  --unit-mode=MODE             Unit handling in math: loose (default), strict, or preserve.');
+    console.log('  --unit-mode=MODE             Unit handling in math: preserve (default), strict, or loose (Less 4.x guessing).');
     console.log('  --strict-units               Deprecated alias for --unit-mode=strict.');
     console.log('');
     console.log('This release intentionally supports a smaller CLI surface.');

--- a/packages/less/lib/lessc-helper.js
+++ b/packages/less/lib/lessc-helper.js
@@ -39,7 +39,7 @@ const lesscHelper = {
     console.log('  --verbose                    Be verbose.');
     console.log('  --collapse-nesting           Flatten nested rules after preserving source-order cascade.');
     console.log('  --unit-mode=MODE             Unit handling in math: preserve (default), strict, or loose (Less 4.x guessing).');
-    console.log('  --strict-units               Deprecated alias for --unit-mode=strict.');
+    console.log('  --strict-units[=on|off]      Deprecated: on is --unit-mode=strict, off is the default (preserve).');
     console.log('');
     console.log('This release intentionally supports a smaller CLI surface.');
     console.log('Source maps, browser compilation, legacy plugin flags, lint-only mode, and');

--- a/packages/less/lib/options.js
+++ b/packages/less/lib/options.js
@@ -5,6 +5,7 @@
 
 import lessPlugin from '@jesscss/plugin-less';
 import { lessCompatPlugin } from '@jesscss/plugin-less-compat';
+import { logger } from './logger.js';
 
 const unsupportedAlphaOptions = new Map([
   ['sourceMap', 'source maps are not supported'],
@@ -83,11 +84,19 @@ export function createLessOptions(options) {
     'parens-division';
 
   // `unitMode` is the option ('loose' | 'preserve' | 'strict'); `strictUnits`
-  // is its deprecated boolean alias: true → 'strict', false/undefined defers
-  // to `unitMode`. Left unset so the compiler default ('loose') applies.
+  // is its deprecated boolean alias: true → 'strict'; false means "not strict",
+  // i.e. the default ('preserve') — never the Less 4.x 'loose' fold, which only
+  // an explicit `unitMode: 'loose'` selects. Any use warns so the mapping is
+  // never discovered by staring at output. Left unset so the compiler default applies.
   const unitMode = opts.unitMode !== undefined ? opts.unitMode
     : opts.strictUnits === true ? 'strict'
     : undefined;
+  if (opts.strictUnits !== undefined && opts.unitMode === undefined) {
+    logger.warn(
+      `strictUnits is deprecated; use unitMode. strictUnits: ${String(opts.strictUnits)} now means `
+      + `unitMode: '${unitMode ?? 'preserve'}'${opts.strictUnits ? '' : " (Less 4.x unit folding is unitMode: 'loose')"}`
+    );
+  }
 
   const plugins = [lessPlugin()];
   if (!skipLessCompat) {

--- a/packages/less/test/alpha-fixtures.mjs
+++ b/packages/less/test/alpha-fixtures.mjs
@@ -114,6 +114,7 @@ const skippedFixtures = new Map([
 const selectedSkippedCount = [...skippedFixtures.keys()].filter(fixtureMatches).length;
 
 const expectedFailureFixtures = new Map([
+    ['tests-unit/variables/variable-advanced.less', 'V18 unit-mode ruling (preserve = strict without the error): fixture graduated to calc() for incompatible-unit math ahead of the published @jesscss/compiler; remove when the pinned Jess renders it'],
     ['tests-unit/import/import-reference.less', 'reference import filtering leaves extra at-rules'],
     ['tests-unit/import/import.less', '@plugin executes; remaining gap is @import media-query handling and @media query merging'],
     ['tests-unit/urls/urls.less', 'renders but CSS @import placement and multiline function formatting differ from Less'],

--- a/packages/less/test/alpha-support.mjs
+++ b/packages/less/test/alpha-support.mjs
@@ -189,11 +189,28 @@ async function assertUnitModeSupported() {
             `${JSON.stringify(options)} must reject incompatible units`
         );
     }
-    // Loose is the default; the deprecated `strictUnits: false` is a no-op, not an error.
-    for (const options of [{}, { unitMode: 'loose' }, { strictUnits: false }]) {
-        const result = await less.render(source, options);
-        assert.match(result.css, /width: 4px/, `${JSON.stringify(options)} must render loosely`);
+    // `unitMode: 'loose'` is the only way to select the Less 4.x fold.
+    const loose = await less.render(source, { unitMode: 'loose' });
+    assert.match(loose.css, /width: 4px/, 'unitMode: loose must fold');
+    // The deprecated `strictUnits: false` means "not strict" — the default — and
+    // warns; it never selects the fold. (Asserted as identity with the default so
+    // the check holds across the pinned Jess's default-mode behavior.)
+    const warnings = [];
+    const listener = { warn(msg) { warnings.push(String(msg)); } };
+    less.logger.addListener(listener);
+    try {
+        const [dflt, off] = await Promise.all([
+            less.render(source, {}),
+            less.render(source, { strictUnits: false })
+        ]);
+        assert.equal(off.css, dflt.css, 'strictUnits: false must render exactly as the default');
+    } finally {
+        less.logger.removeListener(listener);
     }
+    assert.ok(
+        warnings.some(w => /strictUnits is deprecated.*unitMode: 'preserve'/.test(w)),
+        `strictUnits: false must warn with the mapping; got ${JSON.stringify(warnings)}`
+    );
 }
 
 await assertSupportedCompileSurface();

--- a/packages/test-data/tests-unit/variables/variable-advanced.css
+++ b/packages/test-data/tests-unit/variables/variable-advanced.css
@@ -10,20 +10,20 @@
   conversion-imperial: 3in;
   custom-unit: 420octocats;
   custom-unit-cancelling: 18dogs;
-  mix-units: 2px;
+  mix-units: calc(1px + 1em);
   invalid-units: calc(1px * 1px);
 }
 .units-extended .fallback {
-  div-px-1: 10px;
-  div-px-2: 1px;
-  sub-px-1: 12.6px;
-  sub-cm-1: 9.666625cm;
+  div-px-1: calc(14px / 1.4em);
+  div-px-2: calc(14px / 1.4em / 10cm);
+  sub-px-1: calc(14px - 1.4em);
+  sub-cm-1: calc(10cm - (14px - 1.4em));
   mul-px-1: calc(14px * 1.4em);
   mul-em-1: calc(1.4em * 14px);
   mul-em-2: calc(1.4em * 14px * 10cm);
   mul-cm-1: calc(10cm * 1.4em * 14px);
-  add-px-1: 15.4px;
-  add-px-2: 393.3527559px;
+  add-px-1: calc(14px + 1.4em);
+  add-px-2: calc((14px + 1.4em) + 10cm);
   mul-px-2: calc(14px * 10cm);
   mul-px-3: calc(14px * 10cm);
 }


### PR DESCRIPTION
## What this changes for Less 5 alpha

### Incompatible-unit math now stays as `calc()` (fixture update)

Less 4.x guesses a unit when you add, subtract, multiply or divide values whose units cannot be converted into each other: `1px + 1em` became `2px`, `14px / 1.4em` became `10px`. Those results are not real CSS values, and browsers can compute the right thing if the expression is handed to them as `calc()`.

Less 5's default unit mode (`preserve`) now emits the expression as authored inside `calc()` and logs a warning, instead of guessing. The strict mode (`--unit-mode=strict`) still errors on the same inputs; the 4.x guessing is still available as `--unit-mode=loose`.

`packages/test-data/tests-unit/variables/variable-advanced.css` is updated accordingly. Seven declarations change:

| source | Less 4.x | Less 5 |
|---|---|---|
| `(1px + 1em)` | `2px` | `calc(1px + 1em)` |
| `(14px / 1.4em)` | `10px` | `calc(14px / 1.4em)` |
| `(14px / 1.4em / 10cm)` | `1px` | `calc(14px / 1.4em / 10cm)` |
| `(14px - 1.4em)` | `12.6px` | `calc(14px - 1.4em)` |
| `(10cm - (14px - 1.4em))` | `9.666625cm` | `calc(10cm - (14px - 1.4em))` |
| `(14px + 1.4em)` | `15.4px` | `calc(14px + 1.4em)` |
| `((14px + 1.4em) + 10cm)` | `393.3527559px` | `calc((14px + 1.4em) + 10cm)` |

Math whose units do resolve is unchanged, e.g. `unit((@onePixel * 4em / 2cm))` in the same fixture.

The compiler this repo currently pins (`@jesscss/compiler` 2.0.0-alpha.15) still produces the old values, so the fixture is listed in `test/alpha-fixtures.mjs` as an expected failure. The test harness reports "passed unexpectedly" once a compiler release with the new behavior is pinned, which is the signal to remove the entry.

### `strictUnits` is deprecated in favor of `unitMode`, and says so

`unitMode` (`preserve` by default, `strict`, or `loose`) is the option. The Less 4.x boolean `strictUnits` and the CLI flags `--strict-units`, `--strict-units=on|off` and `-su=on|off` keep working as a deprecated alias:

- `strictUnits: true` / `=on` selects `unitMode: 'strict'`.
- `strictUnits: false` / `=off` means "not strict", which is the default `preserve`. It does not select the 4.x guessing; only an explicit `unitMode: 'loose'` does.

Any use of `strictUnits` logs a deprecation warning during compile that states the mapping, through the normal Less logger, so it reaches both API listeners and `lessc` output (`--quiet` suppresses it). The previous `lessc`-only warning at flag-parse time is removed in favor of that single site.

`lessc --help` and the warning previously described `loose` as the default; the default is `preserve`.

### Tests

`test/alpha-support.mjs` asserts that `unitMode: 'strict'` and `strictUnits: true` reject `1px + 3em`, that `unitMode: 'loose'` folds it to `4px`, that `strictUnits: false` renders byte-identically to passing no option and emits the deprecation warning.
