### PR TITLE
ci(release): grouped, linked changelog in the auto-created release PR body

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -199,8 +199,10 @@ jobs:
 
           # Compose the PR body: a short preamble plus a grouped, linked
           # changelog of everything new since the previous release tag.
+          # No fallback: a generation failure aborts the step (set -e) rather
+          # than replacing an existing PR's changelog with an empty one.
           PREAMBLE=$(node scripts/release-metadata.js body)
-          CHANGELOG=$(node scripts/release-changelog.js || echo "")
+          CHANGELOG=$(node scripts/release-changelog.js)
           BODY=$(printf '%s\n\n%s\n' "${PREAMBLE}" "${CHANGELOG}")
 
           # Open a PR if one doesn't already exist for this version.

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -197,13 +197,17 @@ jobs:
           # second run will fail-fast here and the release branch stays coherent.
           git push origin "${RELEASE_BRANCH}" --force-with-lease
 
+          # Compose the PR body: a short preamble plus a grouped, linked
+          # changelog of everything new since the previous release tag.
+          PREAMBLE=$(node scripts/release-metadata.js body)
+          CHANGELOG=$(node scripts/release-changelog.js || echo "")
+          BODY=$(printf '%s\n\n%s\n' "${PREAMBLE}" "${CHANGELOG}")
+
           # Open a PR if one doesn't already exist for this version.
           EXISTING=$(gh pr list --head "${RELEASE_BRANCH}" --base "${RELEASE_BASE}" \
             --json number --jq '.[0].number' 2>/dev/null || echo "")
 
           if [ -z "${EXISTING}" ]; then
-            BODY=$(node scripts/release-metadata.js body)
-
             gh pr create \
               --title "${TITLE}" \
               --body "${BODY}" \
@@ -211,7 +215,9 @@ jobs:
               --head "${RELEASE_BRANCH}"
             echo "✅ Created release PR for v${NEXT_VERSION}"
           else
-            echo "✅ Release PR #${EXISTING} already exists; branch updated to include latest ${RELEASE_BASE} commits"
+            # Refresh the body so the changelog reflects the latest commits.
+            gh pr edit "${EXISTING}" --body "${BODY}"
+            echo "✅ Release PR #${EXISTING} already exists; branch and changelog updated"
           fi
 
   sync-release-pr-title:

--- a/scripts/release-changelog.js
+++ b/scripts/release-changelog.js
@@ -88,9 +88,17 @@ function linkify(text, url) {
   return text.replace(ISSUE_REF, (_, n) => linkIssue(n, url));
 }
 
+// Less variable names like `@block1` or `@1` in subjects would otherwise render
+// as GitHub @-mentions. Emit the `@` as an HTML entity so it stays literal text.
+function escapeMentions(text) {
+  return text.replace(/@(?=[\w-])/g, '&#64;');
+}
+
 function renderCommit(commit, url) {
   const scope = commit.scope ? `**${commit.scope}:** ` : '';
-  let line = `- \`${commit.sha}\` ${scope}${linkify(commit.description, url)}`;
+  // Linkify #refs first, then escape @mentions — the &#64; entity contains a
+  // "#64" that linkify would otherwise mistake for an issue reference.
+  let line = `- \`${commit.sha}\` ${scope}${escapeMentions(linkify(commit.description, url))}`;
 
   // Surface "Closes/Fixes #N" from the body when it isn't already in the subject.
   const inSubject = issuesFrom(commit.subject);
@@ -126,7 +134,49 @@ function git(args) {
   return execFileSync('git', args, { encoding: 'utf8' });
 }
 
-function lastTag() {
+const TAG = /^v?(\d+)\.(\d+)\.(\d+)(?:-alpha\.(\d+))?$/;
+
+function parseTag(tag) {
+  const m = TAG.exec(tag.trim());
+  if (!m) return null;
+  // A stable X.Y.Z sorts above its own -alpha.N; Infinity puts it last-wins.
+  return {
+    tag: tag.trim(),
+    nums: [+m[1], +m[2], +m[3], m[4] === undefined ? Infinity : +m[4]],
+    isAlpha: m[4] !== undefined,
+  };
+}
+
+function compareNums(a, b) {
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return a[i] - b[i];
+  }
+  return 0;
+}
+
+// Pick the newest tag that belongs to the release lane we're publishing, so an
+// alpha PR ranges from the previous alpha (never a stable tag merged into alpha,
+// and vice versa). Tags must already be filtered to HEAD's ancestors.
+function pickPreviousTag(tags, base) {
+  const wantAlpha = base === 'alpha';
+  const candidates = tags
+    .map(parseTag)
+    .filter(Boolean)
+    .filter(t => (base === 'alpha' || base === 'master') ? t.isAlpha === wantAlpha : true)
+    .sort((a, b) => compareNums(b.nums, a.nums));
+  return candidates.length ? candidates[0].tag : '';
+}
+
+function previousReleaseTag(base) {
+  let reachable;
+  try {
+    reachable = git(['tag', '--merged', 'HEAD']).split('\n');
+  } catch {
+    return '';
+  }
+  const picked = pickPreviousTag(reachable, base);
+  if (picked) return picked;
+  // No lane-matching tag (e.g. the first alpha ever): fall back to nearest tag.
   try {
     return git(['describe', '--tags', '--abbrev=0']).trim();
   } catch {
@@ -143,7 +193,7 @@ function readCommits(since, until) {
 }
 
 function generate(argv) {
-  const since = argv[0] || lastTag();
+  const since = argv[0] || previousReleaseTag(process.env.RELEASE_BASE);
   const until = argv[1] || 'HEAD';
   const commits = readCommits(since, until);
   return buildChangelog(commits, { repo: process.env.GITHUB_REPOSITORY, since });
@@ -174,6 +224,18 @@ function selftest() {
   assert.ok(out.includes('### Other Changes'));
   // Empty range yields a friendly note, not an empty body.
   assert.ok(buildChangelog([], { since: 'v1' }).includes('_No changes found'));
+
+  // Lane-aware tag selection: alpha ignores a newer stable tag merged in.
+  const tags = ['v4.9.0', 'v5.0.0-alpha.2', 'v5.0.0-alpha.10', 'v4.9.1'];
+  assert.strictEqual(pickPreviousTag(tags, 'alpha'), 'v5.0.0-alpha.10');
+  assert.strictEqual(pickPreviousTag(tags, 'master'), 'v4.9.1');
+
+  // `@`-prefixed Less variables must not become GitHub mentions.
+  const mention = renderCommit(
+    classify(parseLog(['e5', 'fix(functions): rename @1 to @block1', ''].join('\x00'))[0]),
+    'https://github.com/less/less.js',
+  );
+  assert.ok(!/@block1/.test(mention) && mention.includes('&#64;block1'));
   console.log('release-changelog selftest passed');
 }
 
@@ -193,5 +255,6 @@ module.exports = {
   issuesFrom,
   linkify,
   parseLog,
+  pickPreviousTag,
   renderCommit,
 };

--- a/scripts/release-changelog.js
+++ b/scripts/release-changelog.js
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+'use strict';
+
+// Build a grouped, linked changelog for the auto-created release PR body.
+//
+// Reads `git log <since>..<until>`, groups commits by conventional-commit type
+// (feat/fix/…), and links every `#NNN` and `Closes/Fixes #NNN` reference to the
+// repository's issues. Dependency-light on purpose: git + string parsing only.
+//
+// Usage:
+//   node scripts/release-changelog.js [<sinceRef>] [<untilRef>]
+//   node scripts/release-changelog.js --selftest
+//
+// <sinceRef> defaults to the most recent tag reachable from HEAD; <untilRef>
+// defaults to HEAD. GITHUB_REPOSITORY (owner/repo) picks the link target and
+// falls back to less/less.js.
+
+const { execFileSync } = require('child_process');
+
+// Conventional-commit type → heading, in the order they should appear.
+const GROUPS = [
+  ['feat', 'Features'],
+  ['fix', 'Bug Fixes'],
+  ['perf', 'Performance'],
+  ['refactor', 'Refactoring'],
+  ['revert', 'Reverts'],
+  ['docs', 'Documentation'],
+  ['test', 'Tests'],
+  ['build', 'Build System'],
+  ['ci', 'Continuous Integration'],
+  ['style', 'Styles'],
+  ['chore', 'Chores'],
+  ['other', 'Other Changes'],
+];
+
+const GROUP_HEADINGS = new Map(GROUPS);
+const CONVENTIONAL = /^(\w+)(?:\(([^)]+)\))?(!)?:\s*(.+)$/;
+const CLOSES = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+const ISSUE_REF = /#(\d+)/g;
+// Release commits are the PR's own bump commit — never changelog material.
+const RELEASE_SUBJECT = /^chore: (?:alpha )?release v/;
+
+function repoUrl(repo) {
+  return `https://github.com/${repo || 'less/less.js'}`;
+}
+
+// Split `git log` output (records separated by \x1e, fields by \x00).
+function parseLog(raw) {
+  return raw
+    .split('\x1e')
+    .map(record => record.trim())
+    .filter(Boolean)
+    .map(record => {
+      const [sha, subject, body = ''] = record.split('\x00');
+      return { sha: (sha || '').trim(), subject: (subject || '').trim(), body: body.trim() };
+    })
+    .filter(commit => commit.sha && commit.subject);
+}
+
+function classify(commit) {
+  const match = commit.subject.match(CONVENTIONAL);
+  const type = match && GROUP_HEADINGS.has(match[1].toLowerCase())
+    ? match[1].toLowerCase()
+    : 'other';
+  const scope = match ? match[2] : null;
+  const description = match ? match[4] : commit.subject;
+  return { ...commit, type, scope, description };
+}
+
+function issuesFrom(text) {
+  return new Set((text.match(ISSUE_REF) || []).map(ref => ref.slice(1)));
+}
+
+function closesFrom(text) {
+  const refs = new Set();
+  let m;
+  CLOSES.lastIndex = 0;
+  while ((m = CLOSES.exec(text)) !== null) refs.add(m[1]);
+  return refs;
+}
+
+function linkIssue(number, url) {
+  return `[#${number}](${url}/issues/${number})`;
+}
+
+function linkify(text, url) {
+  return text.replace(ISSUE_REF, (_, n) => linkIssue(n, url));
+}
+
+function renderCommit(commit, url) {
+  const scope = commit.scope ? `**${commit.scope}:** ` : '';
+  let line = `- \`${commit.sha}\` ${scope}${linkify(commit.description, url)}`;
+
+  // Surface "Closes/Fixes #N" from the body when it isn't already in the subject.
+  const inSubject = issuesFrom(commit.subject);
+  const closes = [...closesFrom(commit.body)].filter(n => !inSubject.has(n));
+  if (closes.length) {
+    line += ` (closes ${closes.map(n => linkIssue(n, url)).join(', ')})`;
+  }
+  return line;
+}
+
+function buildChangelog(commits, { repo, since } = {}) {
+  const url = repoUrl(repo);
+  const kept = commits
+    .filter(c => !RELEASE_SUBJECT.test(c.subject))
+    .map(classify);
+
+  const heading = since ? `## Changes since ${since}` : '## Changes';
+  if (kept.length === 0) {
+    return `${heading}\n\n_No changes found in this range._`;
+  }
+
+  const sections = [];
+  for (const [type, title] of GROUPS) {
+    const group = kept.filter(c => c.type === type);
+    if (group.length === 0) continue;
+    sections.push(`### ${title}\n\n${group.map(c => renderCommit(c, url)).join('\n')}`);
+  }
+
+  return `${heading}\n\n${sections.join('\n\n')}`;
+}
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' });
+}
+
+function lastTag() {
+  try {
+    return git(['describe', '--tags', '--abbrev=0']).trim();
+  } catch {
+    return '';
+  }
+}
+
+function readCommits(since, until) {
+  const range = since ? `${since}..${until}` : until;
+  const args = ['log', '--no-merges', '--format=%h%x00%s%x00%b%x1e'];
+  if (!since) args.push('--max-count=100');
+  args.push(range);
+  return parseLog(git(args));
+}
+
+function generate(argv) {
+  const since = argv[0] || lastTag();
+  const until = argv[1] || 'HEAD';
+  const commits = readCommits(since, until);
+  return buildChangelog(commits, { repo: process.env.GITHUB_REPOSITORY, since });
+}
+
+function selftest() {
+  const assert = require('assert');
+  const commits = parseLog(
+    [
+      ['a1', 'feat(parser): add thing (#10)', 'Closes #11'].join('\x00'),
+      ['b2', 'fix: crash on empty', 'Fixes #12'].join('\x00'),
+      ['c3', 'chore: release v5.0.0-alpha.5', ''].join('\x00'),
+      ['d4', 'random subject without type', ''].join('\x00'),
+    ].join('\x1e'),
+  );
+  assert.strictEqual(commits.length, 4);
+
+  const out = buildChangelog(commits, { repo: 'less/less.js', since: 'v5.0.0-alpha.4' });
+  assert.ok(out.includes('## Changes since v5.0.0-alpha.4'));
+  assert.ok(out.includes('### Features'));
+  assert.ok(out.includes('**parser:**'));
+  // Subject reference is linked; body "Closes #11" is appended.
+  assert.ok(out.includes('[#10](https://github.com/less/less.js/issues/10)'));
+  assert.ok(out.includes('(closes [#11](https://github.com/less/less.js/issues/11))'));
+  // fix group present, release commit dropped, untyped commit falls to Other.
+  assert.ok(out.includes('### Bug Fixes'));
+  assert.ok(!out.includes('chore: release'));
+  assert.ok(out.includes('### Other Changes'));
+  // Empty range yields a friendly note, not an empty body.
+  assert.ok(buildChangelog([], { since: 'v1' }).includes('_No changes found'));
+  console.log('release-changelog selftest passed');
+}
+
+if (require.main === module) {
+  const argv = process.argv.slice(2);
+  if (argv[0] === '--selftest') {
+    selftest();
+  } else {
+    process.stdout.write(generate(argv) + '\n');
+  }
+}
+
+module.exports = {
+  buildChangelog,
+  classify,
+  closesFrom,
+  issuesFrom,
+  linkify,
+  parseLog,
+  renderCommit,
+};

--- a/scripts/test-release-automation.js
+++ b/scripts/test-release-automation.js
@@ -565,6 +565,35 @@ test('release body does not repeat the version', () => {
   assert.ok(releaseMetadata.releaseBody().includes('PR title'));
 });
 
+test('changelog groups commits by conventional type and links references', () => {
+  const changelog = require('./release-changelog');
+  const commits = changelog.parseLog([
+    ['a1', 'feat(parser): add thing (#10)', 'Closes #11'].join('\x00'),
+    ['b2', 'fix: crash on empty input', 'Fixes #12'].join('\x00'),
+    ['c3', 'chore: release v5.0.0-alpha.5', ''].join('\x00'),
+    ['d4', 'random subject without a type', ''].join('\x00'),
+  ].join('\x1e'));
+
+  const out = changelog.buildChangelog(commits, { repo: 'less/less.js', since: 'v5.0.0-alpha.4' });
+
+  assert.ok(out.includes('## Changes since v5.0.0-alpha.4'));
+  // Grouped under readable headings, feat before fix.
+  assert.ok(out.indexOf('### Features') < out.indexOf('### Bug Fixes'));
+  assert.ok(out.includes('**parser:**'));
+  // Inline `#NNN` and body "Closes #NNN" both linked to the repo's issues.
+  assert.ok(out.includes('[#10](https://github.com/less/less.js/issues/10)'));
+  assert.ok(out.includes('(closes [#11](https://github.com/less/less.js/issues/11))'));
+  assert.ok(out.includes('(closes [#12](https://github.com/less/less.js/issues/12))'));
+  // The release bump commit is never listed; untyped commits fall to "Other".
+  assert.ok(!out.includes('chore: release'));
+  assert.ok(out.includes('### Other Changes'));
+});
+
+test('changelog reports an empty range without producing an empty body', () => {
+  const changelog = require('./release-changelog');
+  assert.ok(changelog.buildChangelog([], { since: 'v1.0.0' }).includes('_No changes found'));
+});
+
 test('npm latest check rejects a master title version that is already published', () => {
   assert.throws(
     () => releaseMetadata.validateAgainstNpm('master', '4.9.0', '4.9.0'),

--- a/scripts/test-release-automation.js
+++ b/scripts/test-release-automation.js
@@ -594,6 +594,24 @@ test('changelog reports an empty range without producing an empty body', () => {
   assert.ok(changelog.buildChangelog([], { since: 'v1.0.0' }).includes('_No changes found'));
 });
 
+test('changelog picks the previous tag from the active release lane', () => {
+  const changelog = require('./release-changelog');
+  const tags = ['v4.9.0', 'v4.9.1', 'v5.0.0-alpha.2', 'v5.0.0-alpha.10'];
+  // A stable tag merged into alpha must not become the alpha "since" range.
+  assert.strictEqual(changelog.pickPreviousTag(tags, 'alpha'), 'v5.0.0-alpha.10');
+  assert.strictEqual(changelog.pickPreviousTag(tags, 'master'), 'v4.9.1');
+});
+
+test('changelog does not turn @-prefixed Less variables into GitHub mentions', () => {
+  const changelog = require('./release-changelog');
+  const commit = changelog.classify(
+    changelog.parseLog(['e5', 'fix(functions): rename @1 to @block1', ''].join('\x00'))[0],
+  );
+  const line = changelog.renderCommit(commit, 'https://github.com/less/less.js');
+  assert.ok(!line.includes('@block1'));
+  assert.ok(line.includes('&#64;block1'));
+});
+
 test('npm latest check rejects a master title version that is already published', () => {
   assert.throws(
     () => releaseMetadata.validateAgainstNpm('master', '4.9.0', '4.9.0'),


### PR DESCRIPTION
## What this does

The `Create Release PR` workflow auto-opens a `chore: release vX.Y.Z-alpha.N` PR whenever code lands on `alpha` (or `master`). Until now its body was a single generic line. This makes that body carry a real changelog of everything new since the previous release.

The body now shows, grouped by conventional-commit type (feat / fix / perf / refactor / docs / test / build / ci / chore / other):

- each commit's short SHA and subject, and
- the issues/PRs it references — inline `#NNN` and `Closes/Fixes #NNN` from the commit body are both linked to the repo's issues.

## How

- New **`scripts/release-changelog.js`** reads `git log <last tag>..HEAD`, classifies each commit, drops the release bump commit itself, and renders grouped Markdown with linked references. Dependency-light on purpose — `git` + string parsing, no semantic-release.
- **`create-release-pr.yml`** composes the body as the existing preamble + this changelog. It sets the body on PR creation and refreshes it with `gh pr edit` on subsequent pushes, so the changelog stays current as commits land on the release branch.
- Range is the previous **lane-matching** release tag reachable from HEAD (alpha PR → newest reachable `X.Y.Z-alpha.N`; master → newest non-prerelease), so a stable tag merged into `alpha` never skews the "since last alpha" range. Links use `GITHUB_REPOSITORY`.
- `@`-prefixed Less variable names in subjects (e.g. `@block1`) are emitted as the `&#64;` entity so they render as literal text, not GitHub @-mentions.
- If changelog generation fails, the workflow step aborts (`set -e`) rather than replacing an existing PR body with an empty changelog.

## Sample output

Generated locally with `node scripts/release-changelog.js v5.0.0-alpha.1 v5.0.0-alpha.3`:

---

## Changes since v5.0.0-alpha.1

### Features

- `870f1f2d` **less5:** experimental dev browser bundle (dist/less-browser-dev.js)

### Bug Fixes

- `bb0b7de7` **less5:** strictUnits: false means the default (preserve); every use warns
- `7ed6ec4e` **less5:** support unitMode; strictUnits is a deprecated alias, not unsupported
- `c1e45e5d` **less5:** browser bundle exposes window.less with 4.x-compatible render
- `f18cc429` **release:** drop redundant post-tag-push origin/master fetch
- `b84b6dfe` **release:** drop behind-master gate blocking alpha publishes

### Tests

- `16b2f1c7` **units:** no-strict expects calc() under Less 5; add explicit unitMode loose fixture
- `d6ac8c60` **v5:** graduate mixins-guards to §4.1 string ground and §4.2 trichotomy
- `68987c90` **v5:** graduate unit-algebra fixtures to §4.7 preserved spelling

### Chores

- `1519dca3` **less5:** pin Jess 2.0.0-alpha.16; incompatible-unit math renders as calc()
- `93a26158` **less5:** V18 preserve follow-ups — fixture, expected-failure, default wording
- `e25737e0` **less5:** rename browser-v5 -> browser-dev
- `6929c47b` **alpha:** bump Jess stack to 2.0.0-alpha.15, drop parseman pin

### Other Changes

- `bd2d25d2` test-data(units): no-strict golden is loose, not preserve
- `04a15d6c` test-data(functions): rename invalid &#64;1 detached-ruleset var to &#64;block1
- `e7626e8c` test-data(url-args): graduate to v5 — preserve authored newline+indent in multi-line src value
- `7d07c112` Less 5 alpha.1: Jess-powered compiler preview ([#19](https://github.com/less/less.js/issues/19))

---

Reference-linking (from the last real range, `v5.0.0-alpha.3..v5.0.0-alpha.4`):

> - `2244d804` bump jess pins to 2.0.0-alpha.17 ([#4523](https://github.com/less/less.js/issues/4523))

## Testing

`node scripts/test-release-automation.js` — 62 passed, 0 failed, including cases for grouping/linking, the empty-range fallback, lane-aware tag selection, and @-mention escaping. The script also has a `--selftest` for a quick standalone check.
