### PR TITLE
test(test-data): port lookup-interpolation, mixin-as-value & rootpath-escape-interpolation fixtures to alpha

### DIFF
--- a/packages/less/test/alpha-fixtures.mjs
+++ b/packages/less/test/alpha-fixtures.mjs
@@ -98,6 +98,7 @@ const skippedFixtures = new Map([
     ['tests-config/rewrite-urls-local/rewrite-urls-local.less', 'URL rewriting is not alpha-supported'],
     ['tests-config/root-registry/file.less', 'no expected CSS in upstream fixture'],
     ['tests-config/root-registry/root.less', 'no expected CSS in upstream fixture'],
+    ['tests-config/rootpath-escape-interpolation/rootpath-escape-interpolation.less', 'URL rootpath rewriting is not alpha-supported'],
     ['tests-config/rootpath-rewrite-urls-all/rootpath-rewrite-urls-all.less', 'URL rootpath rewriting is not alpha-supported'],
     ['tests-config/rootpath-rewrite-urls-local/rootpath-rewrite-urls-local.less', 'URL rootpath rewriting is not alpha-supported'],
     ['tests-config/strict-imports/imported.less', 'helper imported by strict-imports fixture; no expected CSS'],

--- a/packages/test-data/tests-config/rootpath-escape-interpolation/rootpath-escape-interpolation.css
+++ b/packages/test-data/tests-config/rootpath-escape-interpolation/rootpath-escape-interpolation.css
@@ -1,0 +1,8 @@
+#rootpath-escape-interpolation {
+  plain-unquoted: url(http://example.com/a\(b\)\ c/relative/path);
+  interp-unquoted: url(http://example.com/a\(b\)\ c/images/path);
+  lookup-unquoted: url(http://example.com/a\(b\)\ c/images/path);
+  plain-quoted: url("http://example.com/a(b) c/relative/path");
+  interp-quoted: url("http://example.com/a(b) c/images/path");
+  lookup-quoted: url("http://example.com/a(b) c/images/path");
+}

--- a/packages/test-data/tests-config/rootpath-escape-interpolation/rootpath-escape-interpolation.less
+++ b/packages/test-data/tests-config/rootpath-escape-interpolation/rootpath-escape-interpolation.less
@@ -1,0 +1,24 @@
+// A rewritten rootpath is escaped only for *unquoted* url() values, so the node
+// produced for an interpolated unquoted body must not read as quoted. Giving it a
+// real quote character suppressed the escaping and emitted the parentheses and
+// space raw, producing a malformed url().
+//
+// The rootpath here deliberately contains `(`, `)` and a space — the characters
+// `escapePath` handles — so quoted and unquoted forms cannot look alike.
+
+@dir: images;
+@paths: {
+  dir: images;
+};
+
+#rootpath-escape-interpolation {
+  // unquoted: rootpath must be escaped
+  plain-unquoted: url(relative/path);
+  interp-unquoted: url(@{dir}/path);
+  lookup-unquoted: url(@{paths[dir]}/path);
+
+  // quoted: rootpath must not be escaped
+  plain-quoted: url("relative/path");
+  interp-quoted: url("@{dir}/path");
+  lookup-quoted: url("@{paths[dir]}/path");
+}

--- a/packages/test-data/tests-config/rootpath-escape-interpolation/styles.config.cjs
+++ b/packages/test-data/tests-config/rootpath-escape-interpolation/styles.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  language: {
+    less: {
+      "rootpath": "http://example.com/a(b) c/",
+      "rewriteUrls": "all"
+    }
+  }
+};

--- a/packages/test-data/tests-error/eval/mixin-as-value.less
+++ b/packages/test-data/tests-error/eval/mixin-as-value.less
@@ -1,0 +1,6 @@
+#rgbify(@color) {
+  @rgb: red(@color), green(@color), blue(@color);
+}
+.x {
+  color: #rgbify(#fff);
+}

--- a/packages/test-data/tests-error/eval/mixin-as-value.txt
+++ b/packages/test-data/tests-error/eval/mixin-as-value.txt
@@ -1,0 +1,4 @@
+SyntaxError: Rulesets cannot be evaluated on a property. in {path}mixin-as-value.less on line 5, column 3:
+4 .x {
+5   color: #rgbify(#fff);
+6 }

--- a/packages/test-data/tests-unit/lookup-interpolation/lookup-interpolation.css
+++ b/packages/test-data/tests-unit/lookup-interpolation/lookup-interpolation.css
@@ -1,0 +1,60 @@
+.quoted {
+  single: "card";
+  chained: "inner";
+  quoted-value: "deep";
+  indirect-key: "indirect-hit";
+  empty-key: "tail";
+  chained-empty-key: "nested-tail";
+  surrounded: "a-card-b";
+  twice: "card/blue";
+}
+.url {
+  quoted: url("/assets/img/hero.png");
+  unquoted: url(/assets/img/plain.png);
+  unquoted-plain: url(/plain/no-lookup.png);
+  untouched: url(/static/literal.png);
+  untouched-quoted: url("/static/literal.png");
+  data-uri: url(data:image/svg+xml;base64,AAAA);
+}
+.property-interpolation {
+  color: red;
+  from-property: "red";
+  surrounded: "a-red-b";
+  bare: red;
+}
+.card {
+  a: b;
+}
+.inner {
+  c: d;
+}
+.property {
+  card: from-lookup;
+  inner: from-chained-lookup;
+}
+@keyframes card {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@media (min-width: 768px) {
+  .responsive {
+    e: f;
+  }
+}
+.custom-property {
+  --from-lookup: /assets/img;
+  --from-chained: inner;
+}
+.recursive {
+  g: "card";
+}
+.plain {
+  h: "name";
+}
+.name {
+  i: j;
+}

--- a/packages/test-data/tests-unit/lookup-interpolation/lookup-interpolation.less
+++ b/packages/test-data/tests-unit/lookup-interpolation/lookup-interpolation.less
@@ -1,0 +1,127 @@
+// `[...]` lookups inside `@{...}` interpolation, backported from Less 5.x.
+//
+// Before the backport the parser accepted only `@{name}`, so every form below
+// either failed to parse or — in string and url positions — silently emitted the
+// interpolation verbatim into the output. The url/quoted cases in particular are
+// regression coverage for that silent pass-through: a wrong-output bug that
+// produced no error and no warning.
+//
+// The bare `@map[key]` spelling is covered by at-rule-variable-deprecated.less,
+// where it is deprecated in structural positions.
+
+@sizes: {
+  tablet: 768px;
+  name: card;
+  @name: indirect-hit;
+  last-entry: tail;
+};
+
+@theme: {
+  color: blue;
+  @nested: {
+    name: inner;
+    label: "deep";
+    last-entry: nested-tail;
+  }
+};
+
+@paths: {
+  img: "/assets/img";
+};
+
+@which: name;
+
+// --- quoted strings ---
+.quoted {
+  single: "@{sizes[name]}";
+  chained: "@{theme[@nested][name]}";
+  quoted-value: "@{theme[@nested][label]}";
+  indirect-key: "@{sizes[@@which]}";
+  empty-key: "@{sizes[]}";
+  chained-empty-key: "@{theme[@nested][]}";
+  surrounded: "a-@{sizes[name]}-b";
+  twice: "@{sizes[name]}/@{theme[color]}";
+}
+
+// --- url() — the silent pass-through regression ---
+// An unquoted url() body was raw text in an Anonymous node, so neither the plain
+// nor the lookup interpolation resolved there while the quoted form did. Both
+// spellings are covered so the two cannot diverge again.
+@plain-path: "/plain";
+
+.url {
+  quoted: url("@{paths[img]}/hero.png");
+  unquoted: url(@{paths[img]}/plain.png);
+  unquoted-plain: url(@{plain-path}/no-lookup.png);
+  untouched: url(/static/literal.png);
+  untouched-quoted: url("/static/literal.png");
+  data-uri: url(data:image/svg+xml;base64,AAAA);
+}
+
+// --- ${...} property interpolation ---
+// Properties have no lookup grammar: `$name[key]` is a property reference followed
+// by literal `[key]`, and `prop: { … }` is a parse error in every scope, so nothing
+// can hold a ruleset to look into. `${...}` therefore stays narrow while `@{...}`
+// carries lookups, and the plain form must keep working unchanged.
+.property-interpolation {
+  color: red;
+  from-property: "${color}";
+  surrounded: "a-${color}-b";
+  bare: $color;
+}
+
+// --- selector interpolation ---
+.@{sizes[name]} {
+  a: b;
+}
+
+.@{theme[@nested][name]} {
+  c: d;
+}
+
+// --- property name interpolation ---
+.property {
+  @{sizes[name]}: from-lookup;
+  @{theme[@nested][name]}: from-chained-lookup;
+}
+
+// --- at-rule name and prelude ---
+@keyframes @{sizes[name]} {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@queries: {
+  tablet: ~"(min-width: 768px)";
+};
+
+@media @{queries[tablet]} {
+  .responsive {
+    e: f;
+  }
+}
+
+// --- custom property values ---
+.custom-property {
+  --from-lookup: @{paths[img]};
+  --from-chained: @{theme[@nested][name]};
+}
+
+// --- interpolation still resolves to a fixpoint ---
+// The inner `@{...}` arrives from a variable's value at eval time, so it is not
+// present in the source text of the outer reference.
+@inner: card;
+@outer: ~"@{inner}";
+
+.recursive {
+  g: "@{outer}";
+}
+
+// --- plain interpolation is unaffected by the lookup support ---
+.plain {
+  h: "@{which}";
+}
+
+.@{which} {
+  i: j;
+}


### PR DESCRIPTION
## What this does

Three fixtures exist under `packages/test-data` on `master` but were missing from `alpha`. Since `@less/test-data` is a shared corpus consumed across branches (and by downstream compatibility suites), this ports them onto `alpha` so the corpus stays aligned:

| Fixture | Covers |
|---|---|
| `tests-unit/lookup-interpolation` | `[...]` lookups inside `@{…}` interpolation — selectors, `url()`, at-rule name/prelude, property names, custom-property values, and the quoted/url silent-pass-through regressions |
| `tests-error/eval/mixin-as-value` | using a mixin call as a value is an error |
| `tests-config/rootpath-escape-interpolation` | `rootpath` combined with escaped-string interpolation |

## Alpha fixture gate

`lookup-interpolation` and `mixin-as-value` render / error as expected under the alpha fixture gate — the full `pnpm --dir packages/less run test:alpha` run stays green:

```
Less alpha fixtures passed: 89 rendered, 20 expected render failures, 81 friendly errors,
15 expected missing errors, 0 warnings, 2 expected missing warnings, 45 skipped.
```

`rootpath-escape-interpolation` exercises the `rootpath` option, which the alpha build does not support yet (`validateAlphaOptions` rejects it). It is added to the `alpha-fixtures.mjs` skip map next to the existing `rootpath-rewrite-urls-*` entries, with the same reason, so the fixture ships in the corpus without gating the alpha build. When rootpath support lands, removing that one skip line turns it into an active gate.

## Notes

- The sibling `extend/extend-clearfix.less` and `media-nested-type` / `property-interpolation-lookup` fixtures from the same master range are intentionally **not** included here: `extend-clearfix.less` is an `@import` helper with no expected CSS, and the other two do not yet pass the alpha engine — they are tracked separately.
