### PR TITLE
fix: leave relative-color slash operations for the browser

### DIFF
--- a/packages/less/lib/less/functions/color.js
+++ b/packages/less/lib/less/functions/color.js
@@ -56,8 +56,29 @@ function scaled(n, size) {
         return number(n);
     }
 }
+/**
+ * CSS Color Level 5 relative color: `rgb(from ... r g b / 0.9)`.
+ * Returning nothing leaves the call for the browser. Argument eval still
+ * has to succeed first; see Operation.eval() for Keyword `/` under math=always.
+ */
+function isRelativeColorFrom(node) {
+    if (!node) {
+        return false;
+    }
+    if (node.value === 'from') {
+        return true;
+    }
+    if (node instanceof Expression && node.value && node.value[0] &&
+        node.value[0].value === 'from') {
+        return true;
+    }
+    return false;
+}
 colorFunctions = {
     rgb: function (r, g, b) {
+        if (isRelativeColorFrom(r)) {
+            return;
+        }
         let a = 1
         /**
          * Comma-less syntax
@@ -101,6 +122,9 @@ colorFunctions = {
         catch (e) {}
     },
     hsl: function (h, s, l) {
+        if (isRelativeColorFrom(h)) {
+            return;
+        }
         let a = 1
         if (h instanceof Expression) {
             const val = h.value

--- a/packages/less/lib/less/tree/operation.js
+++ b/packages/less/lib/less/tree/operation.js
@@ -7,20 +7,33 @@ import * as Constants from '../constants.js';
 const MATH = Constants.Math;
 
 /**
- * Keywords (relative-color channels such as `r`/`g`/`b`) and CSS functions
- * such as var() only resolve in the browser. An operation holding one cannot
- * be computed here, so eval() leaves it intact.
+ * CSS functions such as var() and relative-color channel keywords
+ * (`r`/`g`/`b`, `alpha`, `none`, ...) only resolve in the browser.
+ * An operation holding one cannot be computed here, so eval() leaves
+ * it intact. Ordinary keywords (`auto`, `inherit`) are not colorOperands,
+ * so they never become Operation nodes; they are unchanged.
  *
  * Nested operations have to be searched too: a pass-through inner op is
- * itself uncomputable, same as a Call. #4480 covers Call only; a hex origin
- * such as `rgb(from #112233 r g b / 0.9)` has no Call at all.
+ * itself uncomputable, same as a Call. A hex origin such as
+ * `rgb(from #112233 r g b / 0.9)` has no Call at all.
  *
  * @param {Node} node
  * @returns {boolean}
  */
+const RELATIVE_COLOR_CHANNELS = new Set([
+    'r', 'g', 'b',
+    'h', 's', 'l',
+    'w', 'c',
+    'a', 'x', 'y', 'z',
+    'alpha', 'none'
+]);
+
 function isBrowserOperand(node) {
-    if (node.type === 'Call' || node.type === 'Keyword') {
+    if (node.type === 'Call') {
         return true;
+    }
+    if (node.type === 'Keyword') {
+        return RELATIVE_COLOR_CHANNELS.has(String(node.value).toLowerCase());
     }
     return node instanceof Operation && node.operands.some(isBrowserOperand);
 }

--- a/packages/less/lib/less/tree/operation.js
+++ b/packages/less/lib/less/tree/operation.js
@@ -6,6 +6,25 @@ import Dimension from './dimension.js';
 import * as Constants from '../constants.js';
 const MATH = Constants.Math;
 
+/**
+ * Keywords (relative-color channels such as `r`/`g`/`b`) and CSS functions
+ * such as var() only resolve in the browser. An operation holding one cannot
+ * be computed here, so eval() leaves it intact.
+ *
+ * Nested operations have to be searched too: a pass-through inner op is
+ * itself uncomputable, same as a Call. #4480 covers Call only; a hex origin
+ * such as `rgb(from #112233 r g b / 0.9)` has no Call at all.
+ *
+ * @param {Node} node
+ * @returns {boolean}
+ */
+function isBrowserOperand(node) {
+    if (node.type === 'Call' || node.type === 'Keyword') {
+        return true;
+    }
+    return node instanceof Operation && node.operands.some(isBrowserOperand);
+}
+
 class Operation extends Node {
     get type() { return 'Operation'; }
 
@@ -46,6 +65,9 @@ class Operation extends Node {
                     (a instanceof Operation || b instanceof Operation)
                     && /** @type {Operation} */ (a).op === '/' && context.math === MATH.PARENS_DIVISION
                 ) {
+                    return new Operation(this.op, [a, b], this.isSpaced);
+                }
+                if (isBrowserOperand(a) || isBrowserOperand(b)) {
                     return new Operation(this.op, [a, b], this.isSpaced);
                 }
                 throw { type: 'Operation',

--- a/packages/test-data/tests-config/math-always/relative-color-alpha.css
+++ b/packages/test-data/tests-config/math-always/relative-color-alpha.css
@@ -1,21 +1,28 @@
 .relative-rgb-var-alpha {
-  color: rgb(from var(--dt_color-base-pry) r g b / 0.9);
+  color: rgb(from var(--surface) r g b / 0.9);
 }
 .relative-rgb-hex-alpha {
   color: rgb(from #112233 r g b / 0.9);
 }
 .relative-rgb-no-alpha {
-  color: rgb(from var(--dt_color-base-pry) r g b);
+  color: rgb(from var(--surface) r g b);
 }
 .relative-hsl-var-alpha {
-  color: hsl(from var(--dt_color-base-pry) h s l / 0.9);
+  color: hsl(from var(--surface) h s l / 0.9);
 }
 .relative-oklch-var-alpha {
-  color: oklch(from var(--dt_color-base-pry) l c h / 0.9);
+  color: oklch(from var(--surface) l c h / 0.9);
 }
 .relative-rgb-light-dark {
-  color: light-dark(rgb(from var(--dt_color-base-pry) r g b / 0.9), rgb(from var(--dt_color-base-pry) r g b / 0.9));
+  color: light-dark(rgb(from var(--surface) r g b / 0.9), rgb(from var(--surface) r g b / 0.9));
 }
 .classic-rgb-still-evaluates {
   color: #112233;
+}
+.keyword-not-a-channel {
+  a: auto - 1px;
+  b: hidden / 2;
+}
+.channel-letter-outside-color {
+  c: b / 0.9;
 }

--- a/packages/test-data/tests-config/math-always/relative-color-alpha.css
+++ b/packages/test-data/tests-config/math-always/relative-color-alpha.css
@@ -1,0 +1,21 @@
+.relative-rgb-var-alpha {
+  color: rgb(from var(--dt_color-base-pry) r g b / 0.9);
+}
+.relative-rgb-hex-alpha {
+  color: rgb(from #112233 r g b / 0.9);
+}
+.relative-rgb-no-alpha {
+  color: rgb(from var(--dt_color-base-pry) r g b);
+}
+.relative-hsl-var-alpha {
+  color: hsl(from var(--dt_color-base-pry) h s l / 0.9);
+}
+.relative-oklch-var-alpha {
+  color: oklch(from var(--dt_color-base-pry) l c h / 0.9);
+}
+.relative-rgb-light-dark {
+  color: light-dark(rgb(from var(--dt_color-base-pry) r g b / 0.9), rgb(from var(--dt_color-base-pry) r g b / 0.9));
+}
+.classic-rgb-still-evaluates {
+  color: #112233;
+}

--- a/packages/test-data/tests-config/math-always/relative-color-alpha.less
+++ b/packages/test-data/tests-config/math-always/relative-color-alpha.less
@@ -2,26 +2,33 @@
 // The slash parses as a Less Operation on the channel keyword (`b / 0.9`).
 // Compile-time math cannot resolve that, so the call is left for the browser.
 .relative-rgb-var-alpha {
-    color: rgb(from var(--dt_color-base-pry) r g b / 0.9);
+    color: rgb(from var(--surface) r g b / 0.9);
 }
 .relative-rgb-hex-alpha {
     color: rgb(from #112233 r g b / 0.9);
 }
 .relative-rgb-no-alpha {
-    color: rgb(from var(--dt_color-base-pry) r g b);
+    color: rgb(from var(--surface) r g b);
 }
 .relative-hsl-var-alpha {
-    color: hsl(from var(--dt_color-base-pry) h s l / 0.9);
+    color: hsl(from var(--surface) h s l / 0.9);
 }
 .relative-oklch-var-alpha {
-    color: oklch(from var(--dt_color-base-pry) l c h / 0.9);
+    color: oklch(from var(--surface) l c h / 0.9);
 }
 .relative-rgb-light-dark {
     color: light-dark(
-        rgb(from var(--dt_color-base-pry) r g b / 0.9),
-        rgb(from var(--dt_color-base-pry) r g b / 0.9)
+        rgb(from var(--surface) r g b / 0.9),
+        rgb(from var(--surface) r g b / 0.9)
     );
 }
 .classic-rgb-still-evaluates {
     color: rgb(17, 34, 51);
+}
+.keyword-not-a-channel {
+  a: auto - 1px;
+  b: hidden / 2;
+}
+.channel-letter-outside-color {
+  c: b / 0.9;
 }

--- a/packages/test-data/tests-config/math-always/relative-color-alpha.less
+++ b/packages/test-data/tests-config/math-always/relative-color-alpha.less
@@ -1,0 +1,27 @@
+// Relative color with an alpha slash under --math=always (issue #4528).
+// The slash parses as a Less Operation on the channel keyword (`b / 0.9`).
+// Compile-time math cannot resolve that, so the call is left for the browser.
+.relative-rgb-var-alpha {
+    color: rgb(from var(--dt_color-base-pry) r g b / 0.9);
+}
+.relative-rgb-hex-alpha {
+    color: rgb(from #112233 r g b / 0.9);
+}
+.relative-rgb-no-alpha {
+    color: rgb(from var(--dt_color-base-pry) r g b);
+}
+.relative-hsl-var-alpha {
+    color: hsl(from var(--dt_color-base-pry) h s l / 0.9);
+}
+.relative-oklch-var-alpha {
+    color: oklch(from var(--dt_color-base-pry) l c h / 0.9);
+}
+.relative-rgb-light-dark {
+    color: light-dark(
+        rgb(from var(--dt_color-base-pry) r g b / 0.9),
+        rgb(from var(--dt_color-base-pry) r g b / 0.9)
+    );
+}
+.classic-rgb-still-evaluates {
+    color: rgb(17, 34, 51);
+}

--- a/packages/test-data/tests-unit/color-functions/modern.css
+++ b/packages/test-data/tests-unit/color-functions/modern.css
@@ -40,3 +40,15 @@
 .color-rgb-add-left-operand {
   background: rgb(from blue calc(r + 100) g b);
 }
+.color-rgb-from-hex-alpha {
+  color: rgb(from #112233 r g b / 0.9);
+}
+.color-rgb-from-var-alpha {
+  color: rgb(from var(--dt_color-base-pry) r g b / 0.9);
+}
+.color-hsl-from-var-alpha {
+  color: hsl(from var(--dt_color-base-pry) h s l / 0.9);
+}
+.color-oklch-from-var-alpha {
+  color: oklch(from var(--dt_color-base-pry) l c h / 0.9);
+}

--- a/packages/test-data/tests-unit/color-functions/modern.css
+++ b/packages/test-data/tests-unit/color-functions/modern.css
@@ -44,11 +44,11 @@
   color: rgb(from #112233 r g b / 0.9);
 }
 .color-rgb-from-var-alpha {
-  color: rgb(from var(--dt_color-base-pry) r g b / 0.9);
+  color: rgb(from var(--surface) r g b / 0.9);
 }
 .color-hsl-from-var-alpha {
-  color: hsl(from var(--dt_color-base-pry) h s l / 0.9);
+  color: hsl(from var(--surface) h s l / 0.9);
 }
 .color-oklch-from-var-alpha {
-  color: oklch(from var(--dt_color-base-pry) l c h / 0.9);
+  color: oklch(from var(--surface) l c h / 0.9);
 }

--- a/packages/test-data/tests-unit/color-functions/modern.less
+++ b/packages/test-data/tests-unit/color-functions/modern.less
@@ -54,3 +54,21 @@
 .color-rgb-add-left-operand {
   background: rgb(from blue calc(r + 100) g b);
 }
+
+// Relative color with an alpha slash. The slash is a Less Operation on
+// the channel keyword; it must still pass through (issue #4528).
+.color-rgb-from-hex-alpha {
+  color: rgb(from #112233 r g b / 0.9);
+}
+
+.color-rgb-from-var-alpha {
+  color: rgb(from var(--dt_color-base-pry) r g b / 0.9);
+}
+
+.color-hsl-from-var-alpha {
+  color: hsl(from var(--dt_color-base-pry) h s l / 0.9);
+}
+
+.color-oklch-from-var-alpha {
+  color: oklch(from var(--dt_color-base-pry) l c h / 0.9);
+}

--- a/packages/test-data/tests-unit/color-functions/modern.less
+++ b/packages/test-data/tests-unit/color-functions/modern.less
@@ -62,13 +62,13 @@
 }
 
 .color-rgb-from-var-alpha {
-  color: rgb(from var(--dt_color-base-pry) r g b / 0.9);
+  color: rgb(from var(--surface) r g b / 0.9);
 }
 
 .color-hsl-from-var-alpha {
-  color: hsl(from var(--dt_color-base-pry) h s l / 0.9);
+  color: hsl(from var(--surface) h s l / 0.9);
 }
 
 .color-oklch-from-var-alpha {
-  color: oklch(from var(--dt_color-base-pry) l c h / 0.9);
+  color: oklch(from var(--surface) l c h / 0.9);
 }


### PR DESCRIPTION
**What**:

`rgb(from var(--x) r g b / 0.9)` throws `Operation on an invalid type` when `--math=always`. The slash is a Less `Operation` on the channel keyword `b`. `functionCaller` evaluates arguments first, so `rgb()` never sees `from`.

This leaves the operation in the tree when an operand is a Keyword (channel names) or a Call (`var()`). `rgb()` and `hsl()` also return nothing when the first argument is `from`, so the call is printed as CSS.

A hex origin has no `var()`, so this is not the same as #4480. Classic `rgb(17, 34, 51)` still compiles to a hex.

**Why**:

Relative color with an alpha slash is valid CSS Color Level 5. Default `parens-division` already leaves `/` alone. Builds that still use `math: 'always'` (including less-loader) die on this.

Fixes #4528

**Checklist**:

- [ ] Documentation N/A
- [x] Added/updated unit tests
- [x] Code complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for CSS Color Level 5 relative color syntax, including `rgb(from ...)`, `hsl(from ...)`, and `oklch(from ...)`.
  - Relative colors and alpha values are preserved for browser-side evaluation, including CSS variables and `light-dark()`.
  - Classic color functions continue to be evaluated during compilation when applicable.

- **Tests**
  - Added coverage for relative color channels, hexadecimal sources, custom properties, alpha-channel output, and unrelated keyword handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->