### PR TITLE
chore: bump jess pins to 2.0.0-alpha.20

### DIFF
--- a/packages/less/package.json
+++ b/packages/less/package.json
@@ -141,15 +141,15 @@
 	"rawcurrent": "https://raw.github.com/less/less.js/v",
 	"sourcearchive": "https://github.com/less/less.js/archive/v",
 	"dependencies": {
-		"@jesscss/compiler": "2.0.0-alpha.19",
-		"@jesscss/core": "2.0.0-alpha.19",
-		"@jesscss/plugin-less": "2.0.0-alpha.19",
-		"@jesscss/plugin-less-compat": "2.0.0-alpha.19",
-		"@jesscss/plugin-node-modules": "2.0.0-alpha.19",
+		"@jesscss/compiler": "2.0.0-alpha.20",
+		"@jesscss/core": "2.0.0-alpha.20",
+		"@jesscss/plugin-less": "2.0.0-alpha.20",
+		"@jesscss/plugin-less-compat": "2.0.0-alpha.20",
+		"@jesscss/plugin-node-modules": "2.0.0-alpha.20",
 		"parse-node-version": "^1.0.1"
 	},
 	"peerDependencies": {
-		"@jesscss/plugin-js": "2.0.0-alpha.19"
+		"@jesscss/plugin-js": "2.0.0-alpha.20"
 	},
 	"peerDependenciesMeta": {
 		"@jesscss/plugin-js": {

--- a/packages/test-data/tests-config/3rd-party/bootstrap4.css
+++ b/packages/test-data/tests-config/3rd-party/bootstrap4.css
@@ -1315,7 +1315,8 @@ pre code {
   margin-bottom: 1rem;
   background-color: transparent;
 }
-.table :is(th, td) {
+.table th,
+.table td {
   padding: 0.75rem;
   vertical-align: top;
   border-top: 1px solid #dee2e6;
@@ -1330,19 +1331,25 @@ pre code {
 .table .table {
   background-color: #fff;
 }
-.table-sm :is(th, td) {
+.table-sm th,
+.table-sm td {
   padding: 0.3rem;
 }
 .table-bordered {
   border: 1px solid #dee2e6;
 }
-.table-bordered :is(th, td) {
+.table-bordered th,
+.table-bordered td {
   border: 1px solid #dee2e6;
 }
-.table-bordered thead :is(th, td) {
+.table-bordered thead th,
+.table-bordered thead td {
   border-bottom-width: 2px;
 }
-.table-borderless :is(th, td, thead th, tbody + tbody) {
+.table-borderless th,
+.table-borderless td,
+.table-borderless thead th,
+.table-borderless tbody + tbody {
   border: 0;
 }
 .table-striped tbody tr:nth-of-type(odd) {
@@ -1473,7 +1480,9 @@ pre code {
   color: #fff;
   background-color: #212529;
 }
-.table-dark :is(th, td, thead th) {
+.table-dark th,
+.table-dark td,
+.table-dark thead th {
   border-color: #32383e;
 }
 .table-dark.table-bordered {
@@ -1879,7 +1888,8 @@ select.form-control-lg:not([size]):not([multiple]) {
   .form-inline .form-control-plaintext {
     display: inline-block;
   }
-  .form-inline :is(.input-group, .custom-select) {
+  .form-inline .input-group,
+  .form-inline .custom-select {
     width: auto;
   }
   .form-inline .form-check {
@@ -2696,7 +2706,10 @@ fieldset:disabled a.btn {
 :is(.btn-group > .btn, .btn-group-vertical > .btn).active {
   z-index: 1;
 }
-:is(.btn-group, .btn-group-vertical) :is(.btn + .btn, .btn + .btn-group, .btn-group + .btn, .btn-group + .btn-group) {
+:is(.btn-group, .btn-group-vertical) .btn + .btn,
+:is(.btn-group, .btn-group-vertical) .btn + .btn-group,
+:is(.btn-group, .btn-group-vertical) .btn-group + .btn,
+:is(.btn-group, .btn-group-vertical) .btn-group + .btn-group {
   margin-left: -1px;
 }
 .btn-toolbar {
@@ -2745,7 +2758,8 @@ fieldset:disabled a.btn {
   align-items: flex-start;
   justify-content: center;
 }
-.btn-group-vertical :is(.btn, .btn-group) {
+.btn-group-vertical .btn,
+.btn-group-vertical .btn-group {
   width: 100%;
 }
 .btn-group-vertical > .btn + .btn,
@@ -2769,7 +2783,8 @@ fieldset:disabled a.btn {
 .btn-group-toggle > .btn-group > .btn {
   margin-bottom: 0;
 }
-.btn-group-toggle > .btn :is(input[type="radio"], input[type="checkbox"]) {
+.btn-group-toggle > .btn input[type="radio"],
+.btn-group-toggle > .btn input[type="checkbox"] {
   position: absolute;
   clip: rect(0, 0, 0, 0);
   pointer-events: none;
@@ -2826,7 +2841,10 @@ fieldset:disabled a.btn {
   position: relative;
   z-index: 2;
 }
-:is(.input-group-prepend, .input-group-append) :is(.btn + .btn, .btn + .input-group-text, .input-group-text + .input-group-text, .input-group-text + .btn) {
+:is(.input-group-prepend, .input-group-append) .btn + .btn,
+:is(.input-group-prepend, .input-group-append) .btn + .input-group-text,
+:is(.input-group-prepend, .input-group-append) .input-group-text + .input-group-text,
+:is(.input-group-prepend, .input-group-append) .input-group-text + .btn {
   margin-left: -1px;
 }
 .input-group-prepend {
@@ -2850,7 +2868,8 @@ fieldset:disabled a.btn {
   border: 1px solid #ced4da;
   border-radius: 0.25rem;
 }
-.input-group-text :is(input[type="radio"], input[type="checkbox"]) {
+.input-group-text input[type="radio"],
+.input-group-text input[type="checkbox"] {
   margin-top: 0;
 }
 .input-group > .input-group-prepend > .btn,
@@ -3199,7 +3218,8 @@ fieldset:disabled a.btn {
   background-color: transparent;
   border-color: transparent;
 }
-.nav-tabs :is(.nav-link.active, .nav-item.show .nav-link) {
+.nav-tabs .nav-link.active,
+.nav-tabs .nav-item.show .nav-link {
   color: #495057;
   background-color: #fff;
   border-color: #dee2e6 #dee2e6 #fff;
@@ -3212,7 +3232,8 @@ fieldset:disabled a.btn {
 .nav-pills .nav-link {
   border-radius: 0.25rem;
 }
-.nav-pills :is(.nav-link.active, .show > .nav-link) {
+.nav-pills .nav-link.active,
+.nav-pills .show > .nav-link {
   color: #fff;
   background-color: #007bff;
 }
@@ -3491,7 +3512,10 @@ fieldset:disabled a.btn {
 .navbar-light .navbar-nav .nav-link.disabled {
   color: rgba(0, 0, 0, 0.3);
 }
-.navbar-light .navbar-nav :is(.show > .nav-link, .active > .nav-link, .nav-link.show, .nav-link.active) {
+.navbar-light .navbar-nav .show > .nav-link,
+.navbar-light .navbar-nav .active > .nav-link,
+.navbar-light .navbar-nav .nav-link.show,
+.navbar-light .navbar-nav .nav-link.active {
   color: rgba(0, 0, 0, 0.9);
 }
 .navbar-light .navbar-toggler {
@@ -3528,7 +3552,10 @@ fieldset:disabled a.btn {
 .navbar-dark .navbar-nav .nav-link.disabled {
   color: rgba(255, 255, 255, 0.25);
 }
-.navbar-dark .navbar-nav :is(.show > .nav-link, .active > .nav-link, .nav-link.show, .nav-link.active) {
+.navbar-dark .navbar-nav .show > .nav-link,
+.navbar-dark .navbar-nav .active > .nav-link,
+.navbar-dark .navbar-nav .nav-link.show,
+.navbar-dark .navbar-nav .nav-link.active {
   color: #fff;
 }
 .navbar-dark .navbar-toggler {
@@ -3688,37 +3715,46 @@ fieldset:disabled a.btn {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
-  .card-group > .card:first-child :is(.card-img-top, .card-header) {
+  .card-group > .card:first-child .card-img-top,
+  .card-group > .card:first-child .card-header {
     border-top-right-radius: 0;
   }
-  .card-group > .card:first-child :is(.card-img-bottom, .card-footer) {
+  .card-group > .card:first-child .card-img-bottom,
+  .card-group > .card:first-child .card-footer {
     border-bottom-right-radius: 0;
   }
   .card-group > .card:last-child {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
-  .card-group > .card:last-child :is(.card-img-top, .card-header) {
+  .card-group > .card:last-child .card-img-top,
+  .card-group > .card:last-child .card-header {
     border-top-left-radius: 0;
   }
-  .card-group > .card:last-child :is(.card-img-bottom, .card-footer) {
+  .card-group > .card:last-child .card-img-bottom,
+  .card-group > .card:last-child .card-footer {
     border-bottom-left-radius: 0;
   }
   .card-group > .card:only-child {
     border-radius: 0.25rem;
   }
-  .card-group > .card:only-child :is(.card-img-top, .card-header) {
+  .card-group > .card:only-child .card-img-top,
+  .card-group > .card:only-child .card-header {
     border-top-left-radius: 0.25rem;
     border-top-right-radius: 0.25rem;
   }
-  .card-group > .card:only-child :is(.card-img-bottom, .card-footer) {
+  .card-group > .card:only-child .card-img-bottom,
+  .card-group > .card:only-child .card-footer {
     border-bottom-right-radius: 0.25rem;
     border-bottom-left-radius: 0.25rem;
   }
   .card-group > .card:not(:first-child):not(:last-child):not(:only-child) {
     border-radius: 0;
   }
-  .card-group > .card:not(:first-child):not(:last-child):not(:only-child) :is(.card-img-top, .card-img-bottom, .card-header, .card-footer) {
+  .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-img-top,
+  .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
+  .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-header,
+  .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-footer {
     border-radius: 0;
   }
 }
@@ -4781,13 +4817,20 @@ button.close {
   transition-duration: 0.6s;
   transition-property: opacity;
 }
-.carousel-fade :is(.carousel-item.active, .carousel-item-next.carousel-item-left, .carousel-item-prev.carousel-item-right) {
+.carousel-fade .carousel-item.active,
+.carousel-fade .carousel-item-next.carousel-item-left,
+.carousel-fade .carousel-item-prev.carousel-item-right {
   opacity: 1;
 }
-.carousel-fade :is(.active.carousel-item-left, .active.carousel-item-right) {
+.carousel-fade .active.carousel-item-left,
+.carousel-fade .active.carousel-item-right {
   opacity: 0;
 }
-.carousel-fade :is(.carousel-item-next, .carousel-item-prev, .carousel-item.active, .active.carousel-item-left, .active.carousel-item-prev) {
+.carousel-fade .carousel-item-next,
+.carousel-fade .carousel-item-prev,
+.carousel-fade .carousel-item.active,
+.carousel-fade .active.carousel-item-left,
+.carousel-fade .active.carousel-item-prev {
   transform: translateX(0);
 }
 @supports (transform-style: preserve-3d) {
@@ -5245,7 +5288,11 @@ button.close {
   display: block;
   content: "";
 }
-.embed-responsive :is(.embed-responsive-item, iframe, embed, object, video) {
+.embed-responsive .embed-responsive-item,
+.embed-responsive iframe,
+.embed-responsive embed,
+.embed-responsive object,
+.embed-responsive video {
   position: absolute;
   top: 0;
   bottom: 0;
@@ -7411,16 +7458,21 @@ a.text-dark:focus {
   .table {
     border-collapse: collapse !important;
   }
-  .table :is(td, th) {
+  .table td,
+  .table th {
     background-color: #fff !important;
   }
-  .table-bordered :is(th, td) {
+  .table-bordered th,
+  .table-bordered td {
     border: 1px solid #dee2e6 !important;
   }
   .table-dark {
     color: inherit;
   }
-  .table-dark :is(th, td, thead th, tbody + tbody) {
+  .table-dark th,
+  .table-dark td,
+  .table-dark thead th,
+  .table-dark tbody + tbody {
     border-color: #dee2e6;
   }
   .table .thead-dark th {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,20 +30,20 @@ importers:
   packages/less:
     dependencies:
       '@jesscss/compiler':
-        specifier: 2.0.0-alpha.19
-        version: 2.0.0-alpha.19(typescript@5.9.3)
+        specifier: 2.0.0-alpha.20
+        version: 2.0.0-alpha.20(typescript@5.9.3)
       '@jesscss/core':
-        specifier: 2.0.0-alpha.19
-        version: 2.0.0-alpha.19
+        specifier: 2.0.0-alpha.20
+        version: 2.0.0-alpha.20
       '@jesscss/plugin-less':
-        specifier: 2.0.0-alpha.19
-        version: 2.0.0-alpha.19(typescript@5.9.3)
+        specifier: 2.0.0-alpha.20
+        version: 2.0.0-alpha.20(typescript@5.9.3)
       '@jesscss/plugin-less-compat':
-        specifier: 2.0.0-alpha.19
-        version: 2.0.0-alpha.19
+        specifier: 2.0.0-alpha.20
+        version: 2.0.0-alpha.20
       '@jesscss/plugin-node-modules':
-        specifier: 2.0.0-alpha.19
-        version: 2.0.0-alpha.19
+        specifier: 2.0.0-alpha.20
+        version: 2.0.0-alpha.20
       parse-node-version:
         specifier: ^1.0.1
         version: 1.0.1
@@ -416,58 +416,58 @@ packages:
     resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
     engines: {node: '>=8'}
 
-  '@jesscss/awaitable-pipe@2.0.0-alpha.19':
-    resolution: {integrity: sha512-3kqM99UKWhtwYVhC7I/Q6LjZaSM+AV/8L8vB3zueugSKHntbPtNZwHGdUm7mmzMT45mymRfzcyDGdVmNu0txYA==}
+  '@jesscss/awaitable-pipe@2.0.0-alpha.20':
+    resolution: {integrity: sha512-pqCppTIFH4GhJPRTdG2uUjSbrkDHGyN/luYP21bmDK/n0F1KJKcwCNZt1KUXSCRiktY8fv2xdz+bwtpEeCrjaw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@jesscss/compiler@2.0.0-alpha.19':
-    resolution: {integrity: sha512-i/yAjMaKheaysdm/DPCut49SG8DsbmF9RfX9v1+h8QPPwN6jE8VdjeV5cicI0QCqgt93r4gJIlmV7f8ORe6h7A==}
+  '@jesscss/compiler@2.0.0-alpha.20':
+    resolution: {integrity: sha512-k4M0vaJziEVxcCQTehl9cLsoU/oxWsuazqsMAEgC8y9EH6VsKFFf7wRNjz95F1z6HZYg3x4HDPiZDTNpFMQ07w==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@jesscss/core@2.0.0-alpha.19':
-    resolution: {integrity: sha512-e8nVAiOb+w5rF5kiwjJ5iQgHOvhYIgkc2JylqqocIO8ajHb5mbTJQ6SRhYKk0zvAzmRsA4ms9YqcJBLAM1Ihng==}
+  '@jesscss/core@2.0.0-alpha.20':
+    resolution: {integrity: sha512-G+uXDOiXwGGrfyWi9w1/PlAyNvjKQr8RIA4H4Uuelf1bJsDytxiPf53WkzpsEfwS8cn9udlmY4R8u3/gL89CeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@jesscss/css-parser@2.0.0-alpha.19':
-    resolution: {integrity: sha512-NSpfQ/whaJ5R12fBIQq1xyYzSpozN8S/lIy4jJlXotUWUFdppVosvPUkTd3LH8xvQsbtlHTpwJsxmvBfJc8NlQ==}
+  '@jesscss/css-parser@2.0.0-alpha.20':
+    resolution: {integrity: sha512-JNT6WrOILEuz5/1SRpwaQnGiXhZZcfDTQ2ML1C6kBOD3yMYstD8LT9UlmMjQCvxITPaEUSjEJHCvL6mB20tcaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      '@jesscss/core': 2.0.0-alpha.19
+      '@jesscss/core': 2.0.0-alpha.20
     peerDependenciesMeta:
       '@jesscss/core':
         optional: true
 
-  '@jesscss/fns@2.0.0-alpha.19':
-    resolution: {integrity: sha512-uTgTJmcfOvp9D3BwwXpxVrZtkEUFUsTJo2SS4/Qoxd+11N1G48SKIiT12Xhyc/0SDTXqmahAjPeogr7NSxqAfw==}
+  '@jesscss/fns@2.0.0-alpha.20':
+    resolution: {integrity: sha512-PLtAfmhPEUNvNKLMjZ1wDEX3lXP9OBcFgIpy4F2D1KrzXKn0x9p4KfmbwNYdPC3q3H70asQtSXmgJsm/U1tU8A==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@jesscss/less-parser@2.0.0-alpha.19':
-    resolution: {integrity: sha512-HgftASXrAfmtBOdJ/jX61aVb8APi04D0NDe7YUOpg+kMyohB6quiQ7qudxwdL2XCOXZOE4Mqw8u2d9h6GPYNXw==}
+  '@jesscss/less-parser@2.0.0-alpha.20':
+    resolution: {integrity: sha512-05ZAOIiKVzNFvLM/lnPqg85lQeixZjAmffsx6YyiOhPlgVZdHMpTHbqN06gz++S63nEMj3ieOXomxPSD9r9FZQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      '@jesscss/core': 2.0.0-alpha.19
+      '@jesscss/core': 2.0.0-alpha.20
     peerDependenciesMeta:
       '@jesscss/core':
         optional: true
 
-  '@jesscss/parser-shared@2.0.0-alpha.19':
-    resolution: {integrity: sha512-bjKlyyNuKAi4EoZcxWs2l8qOQzz0xgeJkE+W5N9NWzckhwUkISEGXgrdntJez+RMkqoDEoXhBUDJ/hL4KsgqDA==}
+  '@jesscss/parser-shared@2.0.0-alpha.20':
+    resolution: {integrity: sha512-CjA8F+M6CEIQ5vNQNqI3puUrXSf7Py9Ik2PELvcbhmwj9YEvhWp22MHvZinmXgD4UpHPo69uIPHtDQC+sovzhg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@jesscss/plugin-less-compat@2.0.0-alpha.19':
-    resolution: {integrity: sha512-s5jlrKt/PdMJutHcr99AzOCw4bSL6HVhQjtQIAkGqbbMAC/p/DCwDgxMATpdHOlfFjmGu6gK0J494+9oLVvVVQ==}
+  '@jesscss/plugin-less-compat@2.0.0-alpha.20':
+    resolution: {integrity: sha512-5oQP8Z1nJP3ye8ZC0igXkmyrgmt8oqwBFa5ZHltIcsmbGa7oWZ2vNcLQ76L3yUN7p/YwTPUkTg6eoR38UtOIGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@jesscss/plugin-less@2.0.0-alpha.19':
-    resolution: {integrity: sha512-y5Dq627yp/qd0heCEraPWhGOrNMivetxZ3Fx/zAvAdYectxd/1h17oQPpsfUXQL/Zys1QRlMFk15hpW6A3RYHw==}
+  '@jesscss/plugin-less@2.0.0-alpha.20':
+    resolution: {integrity: sha512-JJdtvpFp+vh5pg0g1mFzxhbsWDpB7cvPYwejWSuzbWbKEWgSzXbc6IpfVs78KZE1RYgQJACe0HZUA+nn0vO1iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@jesscss/plugin-node-modules@2.0.0-alpha.19':
-    resolution: {integrity: sha512-T6UOiQtNIm6b/d8NsGkcRu1sCLUjniUqseUHSOjc+Ei4yFiuZcuFUhrgoLG+ULpKtBVL6camjiBw5w3DKNs5fw==}
+  '@jesscss/plugin-node-modules@2.0.0-alpha.20':
+    resolution: {integrity: sha512-QeM0vblomAJVqKV7pr/a7sl/oOI86kasB+y7sj8hPd+ndkkyDrajyx+NmJEycRMhHEbEaONX2Y2vAy8utfJI4w==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@jesscss/style-resolver@2.0.0-alpha.19':
-    resolution: {integrity: sha512-cCtTGY8SX03jOl9cGD1s1RK4F/HfPlZexAh/oGmDPyheCuGTe9M3FGDirn7QA1UV3sSbJKy19sVvvcDE4dKTIA==}
+  '@jesscss/style-resolver@2.0.0-alpha.20':
+    resolution: {integrity: sha512-Kk6PM8AFq6xRHDch7tJ7awObfvIvhkHawbtrLt5nwMBqyxyXUX7BY1IQaSGEb5CrUetxF1S8oMU5UNI0RLBBGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   '@jest/diff-sequences@30.0.1':
@@ -3062,8 +3062,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  styles-config@2.0.0-alpha.19:
-    resolution: {integrity: sha512-CkeCxLexn7opnFMFRhkoochMan0bOqWAiHb9h7VO41Zlao4pOp34rsdO4PKnFhNotfQGeqr2yiHGogXfmdZv0A==}
+  styles-config@2.0.0-alpha.20:
+    resolution: {integrity: sha512-k8wuc0u+0VzL8umgvFqJ752F0GKgze3jr39cWt3Bq7jOMAZmCW9IHdSNYkfRKe8P7P26A7uzpu1TNPWZyJWIMg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   superstruct@1.0.3:
@@ -3577,20 +3577,20 @@ snapshots:
 
   '@istanbuljs/schema@0.1.6': {}
 
-  '@jesscss/awaitable-pipe@2.0.0-alpha.19': {}
+  '@jesscss/awaitable-pipe@2.0.0-alpha.20': {}
 
-  '@jesscss/compiler@2.0.0-alpha.19(typescript@5.9.3)':
+  '@jesscss/compiler@2.0.0-alpha.20(typescript@5.9.3)':
     dependencies:
-      '@jesscss/core': 2.0.0-alpha.19
+      '@jesscss/core': 2.0.0-alpha.20
       linecraft: 0.2.8
       lodash-es: 4.18.1
-      styles-config: 2.0.0-alpha.19(typescript@5.9.3)
+      styles-config: 2.0.0-alpha.20(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
-  '@jesscss/core@2.0.0-alpha.19':
+  '@jesscss/core@2.0.0-alpha.20':
     dependencies:
-      '@jesscss/awaitable-pipe': 2.0.0-alpha.19
+      '@jesscss/awaitable-pipe': 2.0.0-alpha.20
       '@jridgewell/gen-mapping': 0.3.13
       '@ungap/set-methods': 0.1.1
       big.js: 7.0.1
@@ -3601,57 +3601,57 @@ snapshots:
       data-structure-typed: 2.0.5
       lodash-es: 4.18.1
 
-  '@jesscss/css-parser@2.0.0-alpha.19(@jesscss/core@2.0.0-alpha.19)':
+  '@jesscss/css-parser@2.0.0-alpha.20(@jesscss/core@2.0.0-alpha.20)':
     dependencies:
-      '@jesscss/parser-shared': 2.0.0-alpha.19
+      '@jesscss/parser-shared': 2.0.0-alpha.20
       parseman: 0.50.5
     optionalDependencies:
-      '@jesscss/core': 2.0.0-alpha.19
+      '@jesscss/core': 2.0.0-alpha.20
 
-  '@jesscss/fns@2.0.0-alpha.19':
+  '@jesscss/fns@2.0.0-alpha.20':
     dependencies:
-      '@jesscss/awaitable-pipe': 2.0.0-alpha.19
-      '@jesscss/core': 2.0.0-alpha.19
+      '@jesscss/awaitable-pipe': 2.0.0-alpha.20
+      '@jesscss/core': 2.0.0-alpha.20
       big.js: 7.0.1
       color-name: 2.0.2
       lodash-es: 4.18.1
       superstruct: 1.0.3
 
-  '@jesscss/less-parser@2.0.0-alpha.19(@jesscss/core@2.0.0-alpha.19)':
+  '@jesscss/less-parser@2.0.0-alpha.20(@jesscss/core@2.0.0-alpha.20)':
     dependencies:
-      '@jesscss/css-parser': 2.0.0-alpha.19(@jesscss/core@2.0.0-alpha.19)
+      '@jesscss/css-parser': 2.0.0-alpha.20(@jesscss/core@2.0.0-alpha.20)
       known-css-properties: 0.37.0
       parseman: 0.50.5
     optionalDependencies:
-      '@jesscss/core': 2.0.0-alpha.19
+      '@jesscss/core': 2.0.0-alpha.20
 
-  '@jesscss/parser-shared@2.0.0-alpha.19':
+  '@jesscss/parser-shared@2.0.0-alpha.20':
     dependencies:
       parseman: 0.50.5
 
-  '@jesscss/plugin-less-compat@2.0.0-alpha.19':
+  '@jesscss/plugin-less-compat@2.0.0-alpha.20':
     dependencies:
-      '@jesscss/awaitable-pipe': 2.0.0-alpha.19
-      '@jesscss/core': 2.0.0-alpha.19
-      '@jesscss/less-parser': 2.0.0-alpha.19(@jesscss/core@2.0.0-alpha.19)
-      '@jesscss/plugin-node-modules': 2.0.0-alpha.19
+      '@jesscss/awaitable-pipe': 2.0.0-alpha.20
+      '@jesscss/core': 2.0.0-alpha.20
+      '@jesscss/less-parser': 2.0.0-alpha.20(@jesscss/core@2.0.0-alpha.20)
+      '@jesscss/plugin-node-modules': 2.0.0-alpha.20
 
-  '@jesscss/plugin-less@2.0.0-alpha.19(typescript@5.9.3)':
+  '@jesscss/plugin-less@2.0.0-alpha.20(typescript@5.9.3)':
     dependencies:
-      '@jesscss/core': 2.0.0-alpha.19
-      '@jesscss/fns': 2.0.0-alpha.19
-      '@jesscss/less-parser': 2.0.0-alpha.19(@jesscss/core@2.0.0-alpha.19)
-      '@jesscss/plugin-less-compat': 2.0.0-alpha.19
-      '@jesscss/style-resolver': 2.0.0-alpha.19
-      styles-config: 2.0.0-alpha.19(typescript@5.9.3)
+      '@jesscss/core': 2.0.0-alpha.20
+      '@jesscss/fns': 2.0.0-alpha.20
+      '@jesscss/less-parser': 2.0.0-alpha.20(@jesscss/core@2.0.0-alpha.20)
+      '@jesscss/plugin-less-compat': 2.0.0-alpha.20
+      '@jesscss/style-resolver': 2.0.0-alpha.20
+      styles-config: 2.0.0-alpha.20(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
-  '@jesscss/plugin-node-modules@2.0.0-alpha.19':
+  '@jesscss/plugin-node-modules@2.0.0-alpha.20':
     dependencies:
-      '@jesscss/core': 2.0.0-alpha.19
+      '@jesscss/core': 2.0.0-alpha.20
 
-  '@jesscss/style-resolver@2.0.0-alpha.19': {}
+  '@jesscss/style-resolver@2.0.0-alpha.20': {}
 
   '@jest/diff-sequences@30.0.1': {}
 
@@ -6361,9 +6361,9 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  styles-config@2.0.0-alpha.19(typescript@5.9.3):
+  styles-config@2.0.0-alpha.20(typescript@5.9.3):
     dependencies:
-      '@jesscss/core': 2.0.0-alpha.19
+      '@jesscss/core': 2.0.0-alpha.20
       cosmiconfig: 9.0.2(typescript@5.9.3)
       picomatch: 4.0.5
     transitivePeerDependencies:


### PR DESCRIPTION
Bumps the Jess runtime pins to `2.0.0-alpha.20` and reconciles the bootstrap4 golden.

### What changed in Jess alpha.20

`collapseNesting` is now an enum — `false | 'native' | 'compact'` (`true` is a deprecated alias for `'native'`):

- **`'native'` (the default flatten):** the CSS Nesting desugaring — the parent is wrapped in `:is()` and child selector lists are **distributed**, so each branch keeps its own specificity, matching the browser and Less 4.x.
- **`'compact'` (opt-in):** additionally folds same-combinator descendant runs into a single `:is()` (group-max specificity).

Previously the child selector list was always folded into `:is()`, which silently raised specificity as a side effect of a formatting flag (e.g. `.table-borderless :is(th, td, thead th, tbody + tbody)` scored every branch at the group max). That fold is now opt-in via `'compact'`; the default distributes.

### Golden

`bootstrap4.css` is regenerated to the distributed form — e.g. `.table-borderless :is(th, td, thead th, tbody + tbody)` becomes four rows, each keeping its own specificity. The parent-list `:is(...)` prefixes are unchanged.

### Verification

- `packages/less` alpha suite: 91 fixtures rendered, expected failures only, 0 unexpected.
- Packed-consumer proof: `require('less')` renders against the published Jess `2.0.0-alpha.20`.
- publish-dry-run: 10/10.